### PR TITLE
Added support for spinBox widget with docs

### DIFF
--- a/config/application.gypi
+++ b/config/application.gypi
@@ -21,6 +21,7 @@
         "../src/cpp/QtWidgets/QLayout/qlayout_wrap.cpp",
         "../src/cpp/QtWidgets/QMainWindow/qmainwindow_wrap.cpp",
         "../src/cpp/QtWidgets/QPushButton/qpushbutton_wrap.cpp",
+        "../src/cpp/QtWidgets/QSpinBox/qspinbox_wrap.cpp",
         "../src/cpp/QtWidgets/QCheckBox/qcheckbox_wrap.cpp",
         "../src/cpp/QtWidgets/QProgressBar/qprogressbar_wrap.cpp",
         "../src/cpp/QtWidgets/QRadioButton/qradiobutton_wrap.cpp",

--- a/config/moc.gypi
+++ b/config/moc.gypi
@@ -9,6 +9,7 @@
         "../src/cpp/autogen/nmainwindow_moc.cpp",
         "../src/cpp/autogen/nprogressbar_moc.cpp",
         "../src/cpp/autogen/npushbutton_moc.cpp",
+        "../src/cpp/autogen/nspinbox_moc.cpp",
         "../src/cpp/autogen/nradiobutton_moc.cpp",
         "../src/cpp/autogen/nplaintextedit_moc.cpp"
     ]

--- a/config/moc.json
+++ b/config/moc.json
@@ -8,6 +8,7 @@
     "src/cpp/QtWidgets/QMainWindow/nmainwindow.h",
     "src/cpp/QtWidgets/QProgressBar/nprogressbar.h",
     "src/cpp/QtWidgets/QPushButton/npushbutton.h",
+    "src/cpp/QtWidgets/QSpinBox/nspinbox.h",
     "src/cpp/QtWidgets/QRadioButton/nradiobutton.h",
     "src/cpp/QtWidgets/QPlainTextEdit/nplaintextedit.h"
   ]

--- a/docs/api/QSpinBox.md
+++ b/docs/api/QSpinBox.md
@@ -1,0 +1,80 @@
+## Class: QSpinBox
+
+> Create and control spin box widgets.
+
+**This class is a JS wrapper around Qt's [QSpinBox class](https://doc.qt.io/qt-5/qspinbox.html)**
+
+A `QSpinBox` provides ability to add and manipulate native spin box widgets.
+
+**QSpinBox inherits from [NodeWidget](api/NodeWidget.md)**
+
+### Example
+
+```javascript
+const { QSpinBox } = require("@nodegui/nodegui");
+
+const spinBox = new QSpinBox();
+```
+
+### `new QSpinBox(parent?)`
+
+- `parent` NodeWidget (_optional_). Any widget inheriting from NodeWidget can be passed as a parent. This will make this widget, the child of the parent widget.
+
+### Static Methods
+
+QSpinBox can access all the static methods defined in [NodeWidget](api/NodeWidget.md)
+
+### Instance Properties
+
+QSpinBox can access all the instance properties defined in [NodeWidget](api/NodeWidget.md)
+
+### Instance Methods
+
+QSpinBox can access all the instance methods defined in [NodeWidget](api/NodeWidget.md). Additionally it also has the following instance methods:
+
+#### `spinBox.setValue(val)`
+
+Sets the current value of the spinBox. It calls the native method [QSpinBox: setValue](https://doc.qt.io/qt-5/qspinbox.html#value-prop).
+
+- `val` number - Set the value as current value
+
+#### `spinBox.setRange(minimum, maximum)`
+
+Sets the min/max value of the spinBox. It calls the native method [QSpinBox: setRange](https://doc.qt.io/qt-5/qspinbox.html#setRange).
+
+- `max` number - Set the value as max value of the progress bar.
+
+#### `spinBox.setPrefix(prefix)`
+
+Sets the prefix of the spinBox. It calls the native method [QSpinBox: setPrefix](https://doc.qt.io/qt-5/qspinbox.html#prefix-prop).
+
+- `prefix` string - Specifies prefix content shows before the spinBox value. [Prefix is an enum from Qt](api/QtEnums.md)
+
+#### `spinBox.setSuffix(suffix)`
+
+Sets the suffix of the spinBox. It calls the native method [QSpinBox: setSuffix](https://doc.qt.io/qt-5/qspinbox.html#suffix-prop).
+
+- `suffix` string - Specifies suffix content shows after the spinBox value. [Suffix is an enum from Qt](api/QtEnums.md)
+
+#### `spinBox.setSingleStep(val)`
+
+Sets the single step value of the spinBox. It calls the native method [QSpinBox: setSingleStep](https://doc.qt.io/qt-5/qspinbox.html#singleStep-prop).
+
+- `val` number - Specifies amount value changes with each step. [Suffix is an enum from Qt](api/QtEnums.md)
+
+
+#### `spinBox.cleanText()`
+
+Returns the text content (String) of the spinBox excluding any prefix, suffix, or leading or trailing whitespace. It calls the native method [QSpinBox: value](https://doc.qt.io/qt-5/qspinbox.html#minimum-prop).
+
+#### `spinBox.minimum()`
+
+Returns the minimum value (Number) of the spinBox. It calls the native method [QSpinBox: value](https://doc.qt.io/qt-5/qspinbox.html#minimum-prop).
+
+#### `spinBox.maximum()`
+
+Returns the maximum value (Number) of the spinBox. It calls the native method [QSpinBox: value](https://doc.qt.io/qt-5/qspinbox.html#maximum-prop).
+
+#### `spinBox.value()`
+
+Returns the current value (Number) of the spinBox. It calls the native method [QSpinBox: value](https://doc.qt.io/qt-5/qspinbox.html#value-prop).

--- a/src/cpp/QtWidgets/QSpinBox/nspinbox.h
+++ b/src/cpp/QtWidgets/QSpinBox/nspinbox.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QSpinBox>
+#include "src/cpp/core/NodeWidget/nodewidget.h"
+#include "napi.h"
+
+class NSpinBox: public QSpinBox, public NodeWidget
+{
+    NODEWIDGET_IMPLEMENTATIONS(QSpinBox)
+public:
+    using QSpinBox::QSpinBox; //inherit all constructors of QSpinBox
+
+    void connectWidgetSignalsToEventEmitter() {
+        // Qt Connects: Implement all signal connects here
+        QObject::connect(this, QOverload<int>::of(&QSpinBox::valueChanged), [=](int val) { 
+            Napi::Env env = this->emitOnNode.Env();
+            Napi::HandleScope scope(env);
+            this->emitOnNode.Call({  Napi::String::New(env, "valueChanged") });
+        });
+    }
+};
+
+

--- a/src/cpp/QtWidgets/QSpinBox/qspinbox_wrap.cpp
+++ b/src/cpp/QtWidgets/QSpinBox/qspinbox_wrap.cpp
@@ -1,0 +1,128 @@
+#include "QSpinBox_wrap.h"
+#include "src/cpp/QtWidgets/QWidget/qwidget_wrap.h"
+#include "src/cpp/QtGui/QIcon/qicon_wrap.h"
+#include "src/cpp/Extras/Utils/nutils.h"
+
+Napi::FunctionReference QSpinBoxWrap::constructor;
+
+Napi::Object QSpinBoxWrap::init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  char CLASSNAME[] = "QSpinBox";
+  Napi::Function func = DefineClass(env, CLASSNAME, {    
+  InstanceMethod("setPrefix", &QSpinBoxWrap::setPrefix),
+  InstanceMethod("setSingleStep", &QSpinBoxWrap::setSingleStep),
+  InstanceMethod("setSuffix", &QSpinBoxWrap::setSuffix),
+  InstanceMethod("setRange", &QSpinBoxWrap::setRange),
+  InstanceMethod("setValue", &QSpinBoxWrap::setValue),
+  InstanceMethod("cleanText", &QSpinBoxWrap::cleanText),
+  InstanceMethod("maximum", &QSpinBoxWrap::maximum),
+  InstanceMethod("minimum", &QSpinBoxWrap::minimum),
+  InstanceMethod("value", &QSpinBoxWrap::value),
+
+    QWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QSpinBoxWrap)
+  });
+  constructor = Napi::Persistent(func);
+  exports.Set(CLASSNAME, func);
+  return exports;
+}
+
+NSpinBox* QSpinBoxWrap::getInternalInstance() {
+  return this->instance;
+}
+
+QSpinBoxWrap::QSpinBoxWrap(const Napi::CallbackInfo& info): Napi::ObjectWrap<QSpinBoxWrap>(info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  
+  if(info.Length() == 1) {
+      Napi::Object parentObject = info[0].As<Napi::Object>();
+      QWidgetWrap* parentWidgetWrap = Napi::ObjectWrap<QWidgetWrap>::Unwrap(parentObject);
+      this->instance = new NSpinBox(parentWidgetWrap->getInternalInstance()); //this sets the parent to current widget
+  } else if (info.Length() == 0){
+    this->instance = new NSpinBox();
+  } else {
+    Napi::TypeError::New(env, "Wrong number of arguments").ThrowAsJavaScriptException();
+  }
+  // Adds measure function on yoga node so that widget size is calculated based on its text also.
+  YGNodeSetMeasureFunc(this->instance->getFlexNode(), &extrautils::measureQtWidget);
+}
+
+QSpinBoxWrap::~QSpinBoxWrap() {
+  delete this->instance;
+}
+
+Napi::Value QSpinBoxWrap::setPrefix(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::String napiPrefix = info[0].As<Napi::String>();
+  std::string prefix = napiPrefix.Utf8Value();
+  this->instance->setPrefix(prefix.c_str());
+  return env.Null();
+}
+
+Napi::Value QSpinBoxWrap::setSingleStep(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Number val = info[0].As<Napi::Number>();
+  this->instance->setSingleStep(val.Int32Value()); 
+  return env.Null();
+}
+
+Napi::Value QSpinBoxWrap::setSuffix(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::String napiSuffix = info[0].As<Napi::String>();
+  std::string suffix = napiSuffix.Utf8Value();
+  this->instance->setSuffix(suffix.c_str());
+  return env.Null();
+}
+
+Napi::Value QSpinBoxWrap::setRange(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Number minimum = info[0].As<Napi::Number>();
+  Napi::Number maximum = info[1].As<Napi::Number>();
+  this->instance->setRange(minimum.Int32Value(), maximum.Int32Value()); 
+  return env.Null();
+}
+
+Napi::Value QSpinBoxWrap::setValue(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Number val = info[0].As<Napi::Number>();
+  this->instance->setValue(val.Int32Value()); 
+  return env.Null();
+}
+
+Napi::Value QSpinBoxWrap::cleanText(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  QString cleanText = this->instance->cleanText();
+  return Napi::String::New(env, cleanText.toStdString().c_str());
+}
+
+Napi::Value QSpinBoxWrap::maximum(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  int maximum = this->instance->maximum();
+  return Napi::Number::New(env, maximum);
+}
+
+Napi::Value QSpinBoxWrap::minimum(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  int minimum = this->instance->minimum();
+  return Napi::Number::New(env, minimum);
+}
+
+Napi::Value QSpinBoxWrap::value(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  int value = this->instance->value();
+  return Napi::Number::New(env, value);
+}

--- a/src/cpp/QtWidgets/QSpinBox/qspinbox_wrap.h
+++ b/src/cpp/QtWidgets/QSpinBox/qspinbox_wrap.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <napi.h>
+#include "nspinbox.h"
+#include "src/cpp/QtWidgets/QWidget/qwidget_macro.h"
+
+#include "src/cpp/Extras/Utils/nutils.h"
+
+class QSpinBoxWrap : public  Napi::ObjectWrap<QSpinBoxWrap> {
+ private:
+  NSpinBox* instance;
+ public:
+  static Napi::Object init(Napi::Env env, Napi::Object exports);
+  QSpinBoxWrap(const Napi::CallbackInfo &info);
+  ~QSpinBoxWrap();
+  NSpinBox *getInternalInstance();
+  //class constructor
+  static Napi::FunctionReference constructor;
+  //wrapped methods
+  Napi::Value setPrefix(const Napi::CallbackInfo &info);
+  Napi::Value setSingleStep(const Napi::CallbackInfo &info);
+  Napi::Value setSuffix(const Napi::CallbackInfo &info);
+  Napi::Value setRange(const Napi::CallbackInfo &info);
+  Napi::Value setValue(const Napi::CallbackInfo &info);
+  Napi::Value cleanText(const Napi::CallbackInfo &info);
+  Napi::Value maximum(const Napi::CallbackInfo &info);
+  Napi::Value minimum(const Napi::CallbackInfo &info);
+  Napi::Value value(const Napi::CallbackInfo &info);
+
+  QWIDGET_WRAPPED_METHODS_DECLARATION
+};

--- a/src/cpp/autogen/nspinbox_moc.cpp
+++ b/src/cpp/autogen/nspinbox_moc.cpp
@@ -1,0 +1,337 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'nspinbox.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.13.0)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include <memory>
+#include "../QtWidgets/QSpinBox/nspinbox.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'nspinbox.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.13.0. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+struct qt_meta_stringdata_NSpinBox_t {
+    QByteArrayData data[47];
+    char stringdata0[545];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_NSpinBox_t, stringdata0) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_NSpinBox_t qt_meta_stringdata_NSpinBox = {
+    {
+QT_MOC_LITERAL(0, 0, 8), // "NSpinBox"
+QT_MOC_LITERAL(1, 9, 8), // "yDisplay"
+QT_MOC_LITERAL(2, 18, 11), // "yAlignItems"
+QT_MOC_LITERAL(3, 30, 13), // "yAlignContent"
+QT_MOC_LITERAL(4, 44, 10), // "yAlignSelf"
+QT_MOC_LITERAL(5, 55, 15), // "yJustifyContent"
+QT_MOC_LITERAL(6, 71, 10), // "yDirection"
+QT_MOC_LITERAL(7, 82, 14), // "yFlexDirection"
+QT_MOC_LITERAL(8, 97, 9), // "yOverflow"
+QT_MOC_LITERAL(9, 107, 9), // "yPosition"
+QT_MOC_LITERAL(10, 117, 9), // "yFlexWrap"
+QT_MOC_LITERAL(11, 127, 5), // "yFlex"
+QT_MOC_LITERAL(12, 133, 9), // "yFlexGrow"
+QT_MOC_LITERAL(13, 143, 11), // "yFlexShrink"
+QT_MOC_LITERAL(14, 155, 12), // "yAspectRatio"
+QT_MOC_LITERAL(15, 168, 4), // "yTop"
+QT_MOC_LITERAL(16, 173, 6), // "yRight"
+QT_MOC_LITERAL(17, 180, 7), // "yBottom"
+QT_MOC_LITERAL(18, 188, 5), // "yLeft"
+QT_MOC_LITERAL(19, 194, 10), // "yFlexBasis"
+QT_MOC_LITERAL(20, 205, 9), // "yMinWidth"
+QT_MOC_LITERAL(21, 215, 10), // "yMinHeight"
+QT_MOC_LITERAL(22, 226, 6), // "yWidth"
+QT_MOC_LITERAL(23, 233, 7), // "yHeight"
+QT_MOC_LITERAL(24, 241, 9), // "yMaxWidth"
+QT_MOC_LITERAL(25, 251, 10), // "yMaxHeight"
+QT_MOC_LITERAL(26, 262, 11), // "yPaddingTop"
+QT_MOC_LITERAL(27, 274, 13), // "yPaddingRight"
+QT_MOC_LITERAL(28, 288, 14), // "yPaddingBottom"
+QT_MOC_LITERAL(29, 303, 12), // "yPaddingLeft"
+QT_MOC_LITERAL(30, 316, 18), // "yPaddingHorizontal"
+QT_MOC_LITERAL(31, 335, 16), // "yPaddingVertical"
+QT_MOC_LITERAL(32, 352, 8), // "yPadding"
+QT_MOC_LITERAL(33, 361, 10), // "yMarginTop"
+QT_MOC_LITERAL(34, 372, 12), // "yMarginRight"
+QT_MOC_LITERAL(35, 385, 13), // "yMarginBottom"
+QT_MOC_LITERAL(36, 399, 11), // "yMarginLeft"
+QT_MOC_LITERAL(37, 411, 17), // "yMarginHorizontal"
+QT_MOC_LITERAL(38, 429, 15), // "yMarginVertical"
+QT_MOC_LITERAL(39, 445, 7), // "yMargin"
+QT_MOC_LITERAL(40, 453, 10), // "yBorderTop"
+QT_MOC_LITERAL(41, 464, 12), // "yBorderRight"
+QT_MOC_LITERAL(42, 477, 13), // "yBorderBottom"
+QT_MOC_LITERAL(43, 491, 11), // "yBorderLeft"
+QT_MOC_LITERAL(44, 503, 17), // "yBorderHorizontal"
+QT_MOC_LITERAL(45, 521, 15), // "yBorderVertical"
+QT_MOC_LITERAL(46, 537, 7) // "yBorder"
+
+    },
+    "NSpinBox\0yDisplay\0yAlignItems\0"
+    "yAlignContent\0yAlignSelf\0yJustifyContent\0"
+    "yDirection\0yFlexDirection\0yOverflow\0"
+    "yPosition\0yFlexWrap\0yFlex\0yFlexGrow\0"
+    "yFlexShrink\0yAspectRatio\0yTop\0yRight\0"
+    "yBottom\0yLeft\0yFlexBasis\0yMinWidth\0"
+    "yMinHeight\0yWidth\0yHeight\0yMaxWidth\0"
+    "yMaxHeight\0yPaddingTop\0yPaddingRight\0"
+    "yPaddingBottom\0yPaddingLeft\0"
+    "yPaddingHorizontal\0yPaddingVertical\0"
+    "yPadding\0yMarginTop\0yMarginRight\0"
+    "yMarginBottom\0yMarginLeft\0yMarginHorizontal\0"
+    "yMarginVertical\0yMargin\0yBorderTop\0"
+    "yBorderRight\0yBorderBottom\0yBorderLeft\0"
+    "yBorderHorizontal\0yBorderVertical\0"
+    "yBorder"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_NSpinBox[] = {
+
+ // content:
+       8,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       0,    0, // methods
+      46,   14, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // properties: name, type, flags
+       1, QMetaType::QString, 0x00095103,
+       2, QMetaType::QString, 0x00095103,
+       3, QMetaType::QString, 0x00095103,
+       4, QMetaType::QString, 0x00095103,
+       5, QMetaType::QString, 0x00095103,
+       6, QMetaType::QString, 0x00095103,
+       7, QMetaType::QString, 0x00095103,
+       8, QMetaType::QString, 0x00095103,
+       9, QMetaType::QString, 0x00095103,
+      10, QMetaType::QString, 0x00095103,
+      11, QMetaType::Float, 0x00095103,
+      12, QMetaType::Float, 0x00095103,
+      13, QMetaType::Float, 0x00095103,
+      14, QMetaType::Float, 0x00095103,
+      15, QMetaType::QString, 0x00095003,
+      16, QMetaType::QString, 0x00095003,
+      17, QMetaType::QString, 0x00095003,
+      18, QMetaType::QString, 0x00095003,
+      19, QMetaType::QString, 0x00095103,
+      20, QMetaType::QString, 0x00095103,
+      21, QMetaType::QString, 0x00095103,
+      22, QMetaType::QString, 0x00095103,
+      23, QMetaType::QString, 0x00095103,
+      24, QMetaType::QString, 0x00095103,
+      25, QMetaType::QString, 0x00095103,
+      26, QMetaType::QString, 0x00095103,
+      27, QMetaType::QString, 0x00095103,
+      28, QMetaType::QString, 0x00095103,
+      29, QMetaType::QString, 0x00095103,
+      30, QMetaType::QString, 0x00095103,
+      31, QMetaType::QString, 0x00095103,
+      32, QMetaType::QString, 0x00095103,
+      33, QMetaType::QString, 0x00095103,
+      34, QMetaType::QString, 0x00095103,
+      35, QMetaType::QString, 0x00095103,
+      36, QMetaType::QString, 0x00095103,
+      37, QMetaType::QString, 0x00095103,
+      38, QMetaType::QString, 0x00095103,
+      39, QMetaType::QString, 0x00095003,
+      40, QMetaType::Float, 0x00095103,
+      41, QMetaType::Float, 0x00095103,
+      42, QMetaType::Float, 0x00095103,
+      43, QMetaType::Float, 0x00095103,
+      44, QMetaType::Float, 0x00095103,
+      45, QMetaType::Float, 0x00095103,
+      46, QMetaType::Float, 0x00095103,
+
+       0        // eod
+};
+
+void NSpinBox::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+
+#ifndef QT_NO_PROPERTIES
+    if (_c == QMetaObject::ReadProperty) {
+        auto *_t = static_cast<NSpinBox *>(_o);
+        Q_UNUSED(_t)
+        void *_v = _a[0];
+        switch (_id) {
+        case 0: *reinterpret_cast< QString*>(_v) = _t->_yDisplay; break;
+        case 1: *reinterpret_cast< QString*>(_v) = _t->_yAlignItems; break;
+        case 2: *reinterpret_cast< QString*>(_v) = _t->_yAlignContent; break;
+        case 3: *reinterpret_cast< QString*>(_v) = _t->_yAlignSelf; break;
+        case 4: *reinterpret_cast< QString*>(_v) = _t->_yJustifyContent; break;
+        case 5: *reinterpret_cast< QString*>(_v) = _t->_yDirection; break;
+        case 6: *reinterpret_cast< QString*>(_v) = _t->_yFlexDirection; break;
+        case 7: *reinterpret_cast< QString*>(_v) = _t->_yOverflow; break;
+        case 8: *reinterpret_cast< QString*>(_v) = _t->_yPosition; break;
+        case 9: *reinterpret_cast< QString*>(_v) = _t->_yFlexWrap; break;
+        case 10: *reinterpret_cast< float*>(_v) = _t->_yFlex; break;
+        case 11: *reinterpret_cast< float*>(_v) = _t->_yFlexGrow; break;
+        case 12: *reinterpret_cast< float*>(_v) = _t->_yFlexShrink; break;
+        case 13: *reinterpret_cast< float*>(_v) = _t->_yAspectRatio; break;
+        case 14: *reinterpret_cast< QString*>(_v) = _t->_yTop; break;
+        case 15: *reinterpret_cast< QString*>(_v) = _t->_yRight; break;
+        case 16: *reinterpret_cast< QString*>(_v) = _t->_yBottom; break;
+        case 17: *reinterpret_cast< QString*>(_v) = _t->_yLeft; break;
+        case 18: *reinterpret_cast< QString*>(_v) = _t->_yFlexBasis; break;
+        case 19: *reinterpret_cast< QString*>(_v) = _t->_yMinWidth; break;
+        case 20: *reinterpret_cast< QString*>(_v) = _t->_yMinHeight; break;
+        case 21: *reinterpret_cast< QString*>(_v) = _t->_yWidth; break;
+        case 22: *reinterpret_cast< QString*>(_v) = _t->_yHeight; break;
+        case 23: *reinterpret_cast< QString*>(_v) = _t->_yMaxWidth; break;
+        case 24: *reinterpret_cast< QString*>(_v) = _t->_yMaxHeight; break;
+        case 25: *reinterpret_cast< QString*>(_v) = _t->_yPaddingTop; break;
+        case 26: *reinterpret_cast< QString*>(_v) = _t->_yPaddingRight; break;
+        case 27: *reinterpret_cast< QString*>(_v) = _t->_yPaddingBottom; break;
+        case 28: *reinterpret_cast< QString*>(_v) = _t->_yPaddingLeft; break;
+        case 29: *reinterpret_cast< QString*>(_v) = _t->_yPaddingHorizontal; break;
+        case 30: *reinterpret_cast< QString*>(_v) = _t->_yPaddingVertical; break;
+        case 31: *reinterpret_cast< QString*>(_v) = _t->_yPadding; break;
+        case 32: *reinterpret_cast< QString*>(_v) = _t->_yMarginTop; break;
+        case 33: *reinterpret_cast< QString*>(_v) = _t->_yMarginRight; break;
+        case 34: *reinterpret_cast< QString*>(_v) = _t->_yMarginBottom; break;
+        case 35: *reinterpret_cast< QString*>(_v) = _t->_yMarginLeft; break;
+        case 36: *reinterpret_cast< QString*>(_v) = _t->_yMarginHorizontal; break;
+        case 37: *reinterpret_cast< QString*>(_v) = _t->_yMarginVertical; break;
+        case 38: *reinterpret_cast< QString*>(_v) = _t->_yMargin; break;
+        case 39: *reinterpret_cast< float*>(_v) = _t->_yBorderTop; break;
+        case 40: *reinterpret_cast< float*>(_v) = _t->_yBorderRight; break;
+        case 41: *reinterpret_cast< float*>(_v) = _t->_yBorderBottom; break;
+        case 42: *reinterpret_cast< float*>(_v) = _t->_yBorderLeft; break;
+        case 43: *reinterpret_cast< float*>(_v) = _t->_yBorderHorizontal; break;
+        case 44: *reinterpret_cast< float*>(_v) = _t->_yBorderVertical; break;
+        case 45: *reinterpret_cast< float*>(_v) = _t->_yBorder; break;
+        default: break;
+        }
+    } else if (_c == QMetaObject::WriteProperty) {
+        auto *_t = static_cast<NSpinBox *>(_o);
+        Q_UNUSED(_t)
+        void *_v = _a[0];
+        switch (_id) {
+        case 0: _t->setYDisplay(*reinterpret_cast< QString*>(_v)); break;
+        case 1: _t->setYAlignItems(*reinterpret_cast< QString*>(_v)); break;
+        case 2: _t->setYAlignContent(*reinterpret_cast< QString*>(_v)); break;
+        case 3: _t->setYAlignSelf(*reinterpret_cast< QString*>(_v)); break;
+        case 4: _t->setYJustifyContent(*reinterpret_cast< QString*>(_v)); break;
+        case 5: _t->setYDirection(*reinterpret_cast< QString*>(_v)); break;
+        case 6: _t->setYFlexDirection(*reinterpret_cast< QString*>(_v)); break;
+        case 7: _t->setYOverflow(*reinterpret_cast< QString*>(_v)); break;
+        case 8: _t->setYPosition(*reinterpret_cast< QString*>(_v)); break;
+        case 9: _t->setYFlexWrap(*reinterpret_cast< QString*>(_v)); break;
+        case 10: _t->setYFlex(*reinterpret_cast< float*>(_v)); break;
+        case 11: _t->setYFlexGrow(*reinterpret_cast< float*>(_v)); break;
+        case 12: _t->setYFlexShrink(*reinterpret_cast< float*>(_v)); break;
+        case 13: _t->setYAspectRatio(*reinterpret_cast< float*>(_v)); break;
+        case 14: _t->setYNodeTop(*reinterpret_cast< QString*>(_v)); break;
+        case 15: _t->setYNodeRight(*reinterpret_cast< QString*>(_v)); break;
+        case 16: _t->setYNodeBottom(*reinterpret_cast< QString*>(_v)); break;
+        case 17: _t->setYNodeLeft(*reinterpret_cast< QString*>(_v)); break;
+        case 18: _t->setYFlexBasis(*reinterpret_cast< QString*>(_v)); break;
+        case 19: _t->setYMinWidth(*reinterpret_cast< QString*>(_v)); break;
+        case 20: _t->setYMinHeight(*reinterpret_cast< QString*>(_v)); break;
+        case 21: _t->setYWidth(*reinterpret_cast< QString*>(_v)); break;
+        case 22: _t->setYHeight(*reinterpret_cast< QString*>(_v)); break;
+        case 23: _t->setYMaxWidth(*reinterpret_cast< QString*>(_v)); break;
+        case 24: _t->setYMaxHeight(*reinterpret_cast< QString*>(_v)); break;
+        case 25: _t->setYPaddingTop(*reinterpret_cast< QString*>(_v)); break;
+        case 26: _t->setYPaddingRight(*reinterpret_cast< QString*>(_v)); break;
+        case 27: _t->setYPaddingBottom(*reinterpret_cast< QString*>(_v)); break;
+        case 28: _t->setYPaddingLeft(*reinterpret_cast< QString*>(_v)); break;
+        case 29: _t->setYPaddingHorizontal(*reinterpret_cast< QString*>(_v)); break;
+        case 30: _t->setYPaddingVertical(*reinterpret_cast< QString*>(_v)); break;
+        case 31: _t->setYPadding(*reinterpret_cast< QString*>(_v)); break;
+        case 32: _t->setYMarginTop(*reinterpret_cast< QString*>(_v)); break;
+        case 33: _t->setYMarginRight(*reinterpret_cast< QString*>(_v)); break;
+        case 34: _t->setYMarginBottom(*reinterpret_cast< QString*>(_v)); break;
+        case 35: _t->setYMarginLeft(*reinterpret_cast< QString*>(_v)); break;
+        case 36: _t->setYMarginHorizontal(*reinterpret_cast< QString*>(_v)); break;
+        case 37: _t->setYMarginVertical(*reinterpret_cast< QString*>(_v)); break;
+        case 38: _t->setYMarginAll(*reinterpret_cast< QString*>(_v)); break;
+        case 39: _t->setYBorderTop(*reinterpret_cast< float*>(_v)); break;
+        case 40: _t->setYBorderRight(*reinterpret_cast< float*>(_v)); break;
+        case 41: _t->setYBorderBottom(*reinterpret_cast< float*>(_v)); break;
+        case 42: _t->setYBorderLeft(*reinterpret_cast< float*>(_v)); break;
+        case 43: _t->setYBorderHorizontal(*reinterpret_cast< float*>(_v)); break;
+        case 44: _t->setYBorderVertical(*reinterpret_cast< float*>(_v)); break;
+        case 45: _t->setYBorder(*reinterpret_cast< float*>(_v)); break;
+        default: break;
+        }
+    } else if (_c == QMetaObject::ResetProperty) {
+    }
+#endif // QT_NO_PROPERTIES
+    Q_UNUSED(_o);
+    Q_UNUSED(_id);
+    Q_UNUSED(_c);
+    Q_UNUSED(_a);
+}
+
+QT_INIT_METAOBJECT const QMetaObject NSpinBox::staticMetaObject = { {
+    &QSpinBox::staticMetaObject,
+    qt_meta_stringdata_NSpinBox.data,
+    qt_meta_data_NSpinBox,
+    qt_static_metacall,
+    nullptr,
+    nullptr
+} };
+
+
+const QMetaObject *NSpinBox::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *NSpinBox::qt_metacast(const char *_clname)
+{
+    if (!_clname) return nullptr;
+    if (!strcmp(_clname, qt_meta_stringdata_NSpinBox.stringdata0))
+        return static_cast<void*>(this);
+    if (!strcmp(_clname, "NodeWidget"))
+        return static_cast< NodeWidget*>(this);
+    return QSpinBox::qt_metacast(_clname);
+}
+
+int NSpinBox::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QSpinBox::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    
+#ifndef QT_NO_PROPERTIES
+   if (_c == QMetaObject::ReadProperty || _c == QMetaObject::WriteProperty
+            || _c == QMetaObject::ResetProperty || _c == QMetaObject::RegisterPropertyMetaType) {
+        qt_static_metacall(this, _c, _id, _a);
+        _id -= 46;
+    } else if (_c == QMetaObject::QueryPropertyDesignable) {
+        _id -= 46;
+    } else if (_c == QMetaObject::QueryPropertyScriptable) {
+        _id -= 46;
+    } else if (_c == QMetaObject::QueryPropertyStored) {
+        _id -= 46;
+    } else if (_c == QMetaObject::QueryPropertyEditable) {
+        _id -= 46;
+    } else if (_c == QMetaObject::QueryPropertyUser) {
+        _id -= 46;
+    }
+#endif // QT_NO_PROPERTIES
+    return _id;
+}
+QT_WARNING_POP
+QT_END_MOC_NAMESPACE

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -7,6 +7,7 @@
 #include "src/cpp/QtWidgets/QLabel/qlabel_wrap.h"
 #include "src/cpp/QtWidgets/QMainWindow/qmainwindow_wrap.h"
 #include "src/cpp/QtWidgets/QPushButton/qpushbutton_wrap.h"
+#include "src/cpp/QtWidgets/QSpinBox/qspinbox_wrap.h"
 #include "src/cpp/QtWidgets/QCheckBox/qcheckbox_wrap.h"
 #include "src/cpp/QtWidgets/QProgressBar/qprogressbar_wrap.h"
 #include "src/cpp/QtWidgets/QRadioButton/qradiobutton_wrap.h"
@@ -30,6 +31,7 @@ Napi::Object Main(Napi::Env env, Napi::Object exports) {
     FlexLayoutWrap::init(env, exports);
     QMainWindowWrap::init(env, exports);
     QPushButtonWrap::init(env, exports);
+    QSpinBoxWrap::init(env, exports);
     QCheckBoxWrap::init(env, exports);
     QProgressBarWrap::init(env, exports);
     QRadioButtonWrap::init(env, exports);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { QLineEdit, QLineEditEvents } from "./lib/QtWidgets/QLineEdit";
 export { QMainWindow, QMainWindowEvents } from "./lib/QtWidgets/QMainWindow";
 export { QProgressBar, QProgressBarEvents } from "./lib/QtWidgets/QProgressBar";
 export { QPushButton, QPushButtonEvents } from "./lib/QtWidgets/QPushButton";
+export { QSpinBox , QSpinBoxEvents } from "./lib/QtWidgets/QSpinBox";
 export { QRadioButton, QRadioButtonEvents } from "./lib/QtWidgets/QRadioButton";
 export {
   QPlainTextEdit,

--- a/src/lib/QtWidgets/QSpinBox/index.ts
+++ b/src/lib/QtWidgets/QSpinBox/index.ts
@@ -1,0 +1,63 @@
+import addon from "../../core/addon";
+import { NodeWidget } from "../../QtGui/QWidget";
+import { BaseWidgetEvents } from "../../core/EventWidget";
+import { NativeElement } from "../../core/Component";
+import { QIcon } from "../../QtGui/QIcon";
+
+export const QSpinBoxEvents = Object.freeze({
+  ...BaseWidgetEvents,
+  valueChanged: "valueChanged"
+});
+
+export class QSpinBox extends NodeWidget {
+  native: NativeElement;
+  constructor(parent?: NodeWidget) {
+    let native;
+    if (parent) {
+      native = new addon.QSpinBox(parent.native);
+    } else {
+      native = new addon.QSpinBox();
+    }
+    super(native);
+    this.parent = parent;
+    this.native = native;
+    // bind member functions
+    this.setPrefix.bind(this);
+    this.setSingleStep.bind(this);
+    this.setSuffix.bind(this);
+    this.setRange.bind(this);
+    this.setValue.bind(this);
+    this.cleanText.bind(this);
+    this.maximum.bind(this);
+    this.minimum.bind(this);
+    this.value.bind(this);
+  }
+
+  setPrefix(prefix: string) {
+    this.native.setPrefix(`${prefix}`);
+  }
+  setSingleStep(val: number) {
+    this.native.setSingleStep(val);
+  }
+  setSuffix(suffix: string) {
+    this.native.setSuffix(`${suffix}`);
+  }
+  setRange(minimum: number, maximum: number) {
+    this.native.setRange(minimum, maximum);
+  }
+  setValue(val: number) {
+    this.native.setValue(val);
+  }
+  cleanText(): string {
+    return this.native.cleanText();
+  }
+  maximum(): number {
+    return this.native.maximum();
+  }
+  minimum(): number {
+    return this.native.minimum();
+  }
+  value(): number {
+    return this.native.value();
+  }
+}


### PR DESCRIPTION
@master-atul I have maintained original parameters names from QT codebase but they proved to be really inconsistent switching names like **posX**->**x**, **value**->**val** and so on.

So maybe its a valid point of discussion for future development if we want to still maintain compatibility with original "naming scheme" or unify them on our end.