### PR TITLE
Adds readOnly prop to QPlainTextEdit

### DIFF
--- a/docs/api/QPlainTextEdit.md
+++ b/docs/api/QPlainTextEdit.md
@@ -42,6 +42,10 @@ Sets the given text to the plainTextEdit.
 
 Returns the text of the text edit as plain text.
 
+#### [`plainTextEdit.setReadOnly(isReadOnly)`](https://doc.qt.io/qt-5/qplaintextedit.html#readOnly-prop)
+
+Sets the plainTextEdit to be read only.
+
 #### [`plainTextEdit.clear()`](https://doc.qt.io/qt-5/qplaintextedit.html#clear)
 
 Deletes all the text in the text edit.

--- a/src/cpp/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
+++ b/src/cpp/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
@@ -13,6 +13,7 @@ Napi::Object QPlainTextEditWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, CLASSNAME, {
     InstanceMethod("setPlainText",&QPlainTextEditWrap::setPlainText),
     InstanceMethod("toPlainText",&QPlainTextEditWrap::toPlainText),
+    InstanceMethod("setReadOnly", &QPlainTextEditWrap::setReadOnly),
     InstanceMethod("clear", &QPlainTextEditWrap::clear),
     QWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QPlainTextEditWrap)
     QABSTRACTSCROLLAREA_WRAPPED_METHODS_EXPORT_DEFINE(QPlainTextEditWrap)
@@ -52,6 +53,15 @@ Napi::Value QPlainTextEditWrap::setPlainText(const Napi::CallbackInfo& info){
   Napi::HandleScope scope(env);
   Napi::String plainText = info[0].As<Napi::String>();
   this->instance->setPlainText(plainText.Utf8Value().c_str());
+  return env.Null();
+}
+
+Napi::Value QPlainTextEditWrap::setReadOnly(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  Napi::Boolean isReadOnly = info[0].As<Napi::Boolean>();
+  this->instance->setReadOnly(isReadOnly.Value());
   return env.Null();
 }
 

--- a/src/cpp/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.h
+++ b/src/cpp/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.h
@@ -20,6 +20,7 @@ class QPlainTextEditWrap : public  Napi::ObjectWrap<QPlainTextEditWrap>{
   QABSTRACTSCROLLAREA_WRAPPED_METHODS_DECLARATION
   Napi::Value setPlainText(const Napi::CallbackInfo& info);
   Napi::Value toPlainText(const Napi::CallbackInfo &info);
+  Napi::Value setReadOnly(const Napi::CallbackInfo &info);
   Napi::Value clear(const Napi::CallbackInfo &info);
 };
 

--- a/src/lib/QtWidgets/QPlainTextEdit/index.ts
+++ b/src/lib/QtWidgets/QPlainTextEdit/index.ts
@@ -24,6 +24,7 @@ export class QPlainTextEdit extends QAbstractScrollArea {
     // bind member functions
     this.setPlainText.bind(this);
     this.toPlainText.bind(this);
+    this.setReadOnly.bind(this);
     this.clear.bind(this);
   }
   setPlainText(text: string | number) {
@@ -31,6 +32,9 @@ export class QPlainTextEdit extends QAbstractScrollArea {
   }
   toPlainText() {
     return this.native.toPlainText();
+  }
+  setReadOnly(isReadOnly: boolean) {
+    this.native.setReadOnly(isReadOnly);
   }
   clear() {
     this.native.clear();


### PR DESCRIPTION
Allows a plainTextEdit to be set as read only.