### PR TITLE
Added QCheckBoxEvents.toggled

### DIFF
--- a/src/cpp/QtWidgets/QCheckBox/ncheckbox.h
+++ b/src/cpp/QtWidgets/QCheckBox/ncheckbox.h
@@ -2,12 +2,21 @@
 
 #include <QCheckBox>
 #include "src/cpp/core/NodeWidget/nodewidget.h"
+#include "napi.h"
 
 class NCheckBox: public QCheckBox, public NodeWidget
 {
     NODEWIDGET_IMPLEMENTATIONS(QCheckBox)
 public:
     using QCheckBox::QCheckBox; //inherit all constructors of QCheckBox
+
+    void connectWidgetSignalsToEventEmitter() {
+        QObject::connect(this, &QCheckBox::toggled, [=](bool checked) { 
+            Napi::Env env = this->emitOnNode.Env();
+            Napi::HandleScope scope(env);
+            this->emitOnNode.Call({  Napi::String::New(env, "toggled"), Napi::Value::From(env, checked) });
+        });
+    }
 };
 
 

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -19,6 +19,7 @@ import {
   QApplication,
   QClipboardMode
 } from "./index";
+import { QCheckBoxEvents } from './lib/QtWidgets/QCheckBox';
 
 const path = require("path");
 
@@ -33,6 +34,9 @@ const checkbox = new QCheckBox();
 checkbox.setText("Check me out?");
 checkbox.setObjectName("check");
 checkbox.setChecked(true);
+checkbox.addEventListener(QCheckBoxEvents.toggled, () => {
+  console.log('checkbox was toggled!');
+})
 
 const dial = new QDial();
 checkbox.setObjectName("dial");

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -17,9 +17,9 @@ import {
   WindowState,
   QTextOptionWrapMode,
   QApplication,
-  QClipboardMode
+  QClipboardMode,
+  QCheckBoxEvents
 } from "./index";
-import { QCheckBoxEvents } from './lib/QtWidgets/QCheckBox';
 
 const path = require("path");
 

--- a/src/lib/QtWidgets/QCheckBox/index.ts
+++ b/src/lib/QtWidgets/QCheckBox/index.ts
@@ -4,7 +4,8 @@ import { BaseWidgetEvents } from "../../core/EventWidget";
 import { NativeElement } from "../../core/Component";
 
 export const QCheckBoxEvents = Object.freeze({
-  ...BaseWidgetEvents
+  ...BaseWidgetEvents,
+  toggled: "toggled"
 });
 export class QCheckBox extends NodeWidget {
   native: NativeElement;


### PR DESCRIPTION
## Description
Added support for a new event handler on `QCheckBox` that fires whenever the checkbox is toggled. This event intercepts the `toggled` signal (see [here](https://doc.qt.io/archives/qt-4.8/qabstractbutton.html)).

## Example
```ts
const checkbox = new QCheckBox();
checkbox.addEventListener(QCheckBoxEvents.toggled, () => {
  console.log('checkbox was toggled!');
})
```

## Changes
1. Added the `toggled` event into the `QCheckBoxEvents` enum (in `lib/QtWidgets/QCheckBox`)
2. Added `connectWidgetSignalToEventEmitter` to `NCheckBox`, and added an interceptor for `QCheckBox::toggled` (in `cpp/QtWidgets/QCheckBox`)
3. Added `toggled` event handler to the checkbox in the demo application (`src/demo.ts`)