### PR TITLE
fixes the crash on keyevent

### DIFF
--- a/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
@@ -6,7 +6,7 @@
 
 class QKeyEventWrap : public  Napi::ObjectWrap<QKeyEventWrap>{
  private:
-  std::unique_ptr<QKeyEvent> instance;
+  QKeyEvent* instance;
   
  public:
   static Napi::Object init(Napi::Env env, Napi::Object exports);

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -19,7 +19,7 @@ Napi::Object QKeyEventWrap::init(Napi::Env env, Napi::Object exports) {
 }
 
 QKeyEvent* QKeyEventWrap::getInternalInstance() {
-  return this->instance.get();
+  return this->instance;
 }
 
 QKeyEventWrap::QKeyEventWrap(const Napi::CallbackInfo& info): Napi::ObjectWrap<QKeyEventWrap>(info) {
@@ -27,7 +27,7 @@ QKeyEventWrap::QKeyEventWrap(const Napi::CallbackInfo& info): Napi::ObjectWrap<Q
     Napi::HandleScope scope(env);
     if(info.Length() == 1) {
       Napi::External<QKeyEvent> eventObject = info[0].As<Napi::External<QKeyEvent>>();
-      this->instance  = std::unique_ptr<QKeyEvent>(eventObject.Data());
+      this->instance  = static_cast<QKeyEvent*>(eventObject.Data());
     } else {
       Napi::TypeError::New(env, "Wrong number of arguments").ThrowAsJavaScriptException();
     }


### PR DESCRIPTION
resolves https://github.com/nodegui/nodegui/issues/137

The application crash occurs because both C++(smart pointers) and qt (event loop) try to clear the same memory. This fixes the issue. 