### PR TITLE
Added QIcon isMask and setIsMask

### DIFF
--- a/src/cpp/include/nodegui/QtGui/QIcon/qicon_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QIcon/qicon_wrap.h
@@ -18,4 +18,6 @@ public:
     QIcon *getInternalInstance();
     // Wrapped methods
     Napi::Value pixmap(const Napi::CallbackInfo& info);
+    Napi::Value isMask(const Napi::CallbackInfo& info);
+    Napi::Value setIsMask(const Napi::CallbackInfo& info);
 };

--- a/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
+++ b/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
@@ -11,6 +11,8 @@ Napi::Object QIconWrap::init(Napi::Env env, Napi::Object exports)
     char CLASSNAME[] = "QIcon";
     Napi::Function func = DefineClass(env, CLASSNAME, {
         InstanceMethod("pixmap", &QIconWrap::pixmap),
+        InstanceMethod("isMask", &QIconWrap::isMask),
+        InstanceMethod("setIsMask", &QIconWrap::setIsMask),
         COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE
     });
     constructor = Napi::Persistent(func);
@@ -73,4 +75,30 @@ Napi::Value QIconWrap::pixmap(const Napi::CallbackInfo& info)
     QPixmap* pixmap = new QPixmap(this->instance->pixmap(width, height, mode, state));
     auto instance = QPixmapWrap::constructor.New({ Napi::External<QPixmap>::New(env, pixmap) });
     return instance;
+}
+
+Napi::Value QIconWrap::isMask(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+
+    return Napi::Boolean::New(env, this->instance->isMask());
+}
+
+Napi::Value QIconWrap::setIsMask(const Napi::CallbackInfo& info)
+{
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+
+    if (info.Length() == 1)
+    {
+        Napi::Boolean isMask = info[0].As<Napi::Boolean>();
+        this->instance->setIsMask(isMask.Value());
+    }
+    else
+    {
+        Napi::TypeError::New(env, "Wrong number of arguments").ThrowAsJavaScriptException();
+    }
+
+    return env.Null();
 }

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -21,6 +21,7 @@ shortcut.addEventListener(QShortcutEvents.activated, () => {
 const trayIcon = new QIcon(
   path.resolve(__dirname, "../extras/assets/nodegui_white.png")
 );
+trayIcon.setIsMask(true);
 
 const tray = new QSystemTrayIcon();
 tray.setIcon(trayIcon);

--- a/src/lib/QtGui/QIcon/index.ts
+++ b/src/lib/QtGui/QIcon/index.ts
@@ -41,4 +41,12 @@ export class QIcon extends Component {
     }
     return new QPixmap(nativePixmap);
   };
+
+  isMask(): boolean {
+    return this.native.isMask();
+  }
+
+  setIsMask(isMask: boolean) {
+    this.native.setIsMask(isMask);
+  }
 }

--- a/website/docs/api/QIcon.md
+++ b/website/docs/api/QIcon.md
@@ -44,3 +44,13 @@ Returns a pixmap with the requested size, mode, and state, generating one if nec
 - `height`: number
 - `mode?`: QIconMode
 - `state?`: QIconState
+
+### `icon.isMask()`
+
+Returns true if this icon has been marked as a mask image. It calls the native method [QIcon: isMask](https://doc.qt.io/qt-5/qicon.html#isMask).
+
+### `icon.setIsMask(isMask)`
+
+Indicate that this icon is a mask image, and hence can potentially be modified based on where it's displayed. It calls the native method [QIcon: setIsMask](https://doc.qt.io/qt-5/qicon.html#setIsMask).
+
+- `isMask`: boolean


### PR DESCRIPTION
Enables support to use one image for both light and dark mode:
![image](https://user-images.githubusercontent.com/8790386/67626251-5db9ae00-f851-11e9-85a5-105f58f22a25.png)
![image](https://user-images.githubusercontent.com/8790386/67626256-61e5cb80-f851-11e9-8443-f5a40a3dc497.png)
