### PR TITLE
Add qvariant object translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "license": "MIT",
     "private": false,
     "scripts": {
-        "dev": "npm run build && qode dist/demo.js",
+        "dev": "npm run build && qode --inspect dist/demo.js",
         "postinstall": "npm run build:addon",
         "build": "tsc && npm run build:addon",
         "build:addon": "cross-env CMAKE_BUILD_PARALLEL_LEVEL=8 cmake-js build",

--- a/src/cpp/include/nodegui/Extras/Utils/nutils.h
+++ b/src/cpp/include/nodegui/Extras/Utils/nutils.h
@@ -10,8 +10,12 @@
 namespace extrautils {
 YGSize measureQtWidget(YGNodeRef node, float width, YGMeasureMode widthMode,
                        float height, YGMeasureMode heightMode);
+
 QVariant* convertToQVariant(Napi::Env& env, Napi::Value& value);
+
 bool isNapiValueInt(Napi::Env& env, Napi::Value& num);
+
+std::string getNapiObjectClassName(Napi::Object& object);
 
 template <typename T>
 void safeDelete(QPointer<T> component) {

--- a/src/cpp/include/nodegui/QtCore/QObject/qobject_macro.h
+++ b/src/cpp/include/nodegui/QtCore/QObject/qobject_macro.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Extras/Utils/nutils.h"
-#include "core/Component/component_macro.h"
 #include "core/Events/eventwidget_macro.h"
 /*
 
@@ -53,7 +52,6 @@
 #define QOBJECT_WRAPPED_METHODS_EXPORT_DEFINE(ComponentWrapName)          \
                                                                           \
   EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(ComponentWrapName)            \
-  COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE                                 \
                                                                           \
   InstanceMethod("inherits", &ComponentWrapName::inherits),               \
       InstanceMethod("setProperty", &ComponentWrapName::setProperty),     \

--- a/src/cpp/include/nodegui/QtGui/QApplication/qapplication_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QApplication/qapplication_wrap.h
@@ -4,6 +4,9 @@
 
 #include <QApplication>
 #include <QPointer>
+
+#include "core/Component/component_macro.h"
+
 class QApplicationWrap : public Napi::ObjectWrap<QApplicationWrap> {
  private:
   QPointer<QApplication> instance;
@@ -24,6 +27,8 @@ class QApplicationWrap : public Napi::ObjectWrap<QApplicationWrap> {
   Napi::Value exit(const Napi::CallbackInfo& info);
   Napi::Value setQuitOnLastWindowClosed(const Napi::CallbackInfo& info);
   Napi::Value quitOnLastWindowClosed(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };
 
 namespace StaticQApplicationWrapMethods {

--- a/src/cpp/include/nodegui/QtGui/QClipboard/qclipboard_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QClipboard/qclipboard_wrap.h
@@ -19,4 +19,6 @@ class QClipboardWrap : public Napi::ObjectWrap<QClipboardWrap> {
   Napi::Value clear(const Napi::CallbackInfo& info);
   Napi::Value setText(const Napi::CallbackInfo& info);
   Napi::Value text(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtGui/QCursor/qcursor_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QCursor/qcursor_wrap.h
@@ -20,4 +20,6 @@ class QCursorWrap : public Napi::ObjectWrap<QCursorWrap> {
   // Wrapped methods
   Napi::Value pos(const Napi::CallbackInfo& info);
   Napi::Value setPos(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
@@ -5,6 +5,8 @@
 
 #include <QKeyEvent>
 
+#include "core/Component/component_macro.h"
+
 class QKeyEventWrap : public Napi::ObjectWrap<QKeyEventWrap> {
  private:
   QKeyEvent* instance;
@@ -18,5 +20,6 @@ class QKeyEventWrap : public Napi::ObjectWrap<QKeyEventWrap> {
   static Napi::FunctionReference constructor;
   // wrapped methods
   Napi::Value text(const Napi::CallbackInfo& info);
-  // Napi::Value setFlexNode(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtGui/QIcon/qicon_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QIcon/qicon_wrap.h
@@ -21,4 +21,6 @@ class QIconWrap : public Napi::ObjectWrap<QIconWrap> {
   Napi::Value pixmap(const Napi::CallbackInfo& info);
   Napi::Value isMask(const Napi::CallbackInfo& info);
   Napi::Value setIsMask(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtGui/QKeySequence/qkeysequence_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QKeySequence/qkeysequence_wrap.h
@@ -19,4 +19,6 @@ class QKeySequenceWrap : public Napi::ObjectWrap<QKeySequenceWrap> {
   QKeySequence *getInternalInstance();
   // Wrapped methods
   Napi::Value count(const Napi::CallbackInfo &info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtGui/QPixmap/qpixmap_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QPixmap/qpixmap_wrap.h
@@ -21,4 +21,6 @@ class QPixmapWrap : public Napi::ObjectWrap<QPixmapWrap> {
   Napi::Value load(const Napi::CallbackInfo& info);
   Napi::Value save(const Napi::CallbackInfo& info);
   Napi::Value scaled(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtWidgets/QLayout/qlayout_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QLayout/qlayout_macro.h
@@ -2,7 +2,7 @@
 
 #include <QSize>
 
-#include "core/Component/component_macro.h"
+#include "QtCore/QObject/qobject_macro.h"
 /*
 
     This macro adds common QLayout exported methods
@@ -12,6 +12,7 @@
 
 #ifndef QLAYOUT_WRAPPED_METHODS_DECLARATION
 #define QLAYOUT_WRAPPED_METHODS_DECLARATION                \
+  COMPONENT_WRAPPED_METHODS_DECLARATION                    \
                                                            \
   Napi::Value activate(const Napi::CallbackInfo& info) {   \
     Napi::Env env = info.Env();                            \

--- a/src/cpp/include/nodegui/core/Component/component_macro.h
+++ b/src/cpp/include/nodegui/core/Component/component_macro.h
@@ -1,7 +1,14 @@
 
+#pragma once
+
 #ifndef COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE
 #define COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE \
                                                 \
   InstanceValue("type", Napi::String::New(env, "native")),
+#endif
 
-#endif  // COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE
+#ifndef COMPONENT_WRAPPED_METHODS_DECLARATION
+#define COMPONENT_WRAPPED_METHODS_DECLARATION \
+ public:                                      \
+  void* rawData = nullptr;
+#endif

--- a/src/cpp/include/nodegui/core/Component/component_wrap.h
+++ b/src/cpp/include/nodegui/core/Component/component_wrap.h
@@ -1,0 +1,16 @@
+/*
+  This wrapper can be used to get the value of the actual instance inside a
+  wrapper for any component exported
+  as long as the component wrapper has this macro
+  COMPONENT_WRAPPED_METHODS_DECLARATION and components this->rawData has been
+  assigned in the constructor
+*/
+#pragma once
+
+#include <napi.h>
+
+#include "component_macro.h"
+
+class ComponentWrap : public Napi::ObjectWrap<ComponentWrap> {
+  COMPONENT_WRAPPED_METHODS_DECLARATION
+};

--- a/src/cpp/include/nodegui/core/Events/eventwidget_macro.h
+++ b/src/cpp/include/nodegui/core/Events/eventwidget_macro.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 
+#include "core/Component/component_macro.h"
 #include "eventwidget.h"
 
 /*
@@ -13,7 +14,7 @@
 
 #ifndef EVENTWIDGET_WRAPPED_METHODS_DECLARATION
 #define EVENTWIDGET_WRAPPED_METHODS_DECLARATION                      \
-                                                                     \
+  COMPONENT_WRAPPED_METHODS_DECLARATION                              \
   Napi::Value initNodeEventEmitter(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                                      \
     this->instance->emitOnNode =                                     \
@@ -39,7 +40,7 @@
 
 #ifndef EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE
 #define EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(WidgetWrapName) \
-                                                                  \
+  COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE                         \
   InstanceMethod("initNodeEventEmitter",                          \
                  &WidgetWrapName::initNodeEventEmitter),          \
       InstanceMethod("subscribeToQtEvent",                        \

--- a/src/cpp/lib/Extras/Utils/nutils.cpp
+++ b/src/cpp/lib/Extras/Utils/nutils.cpp
@@ -1,8 +1,10 @@
-#include "Extras/Utils/nutils.h"
-
 #include <QDebug>
+#include <QMetaType>
 #include <QWidget>
 #include <string>
+
+#include "Extras/Utils/nutils.h"
+#include "core/Component/component_wrap.h"
 
 YGSize extrautils::measureQtWidget(YGNodeRef node, float width,
                                    YGMeasureMode widthMode, float height,
@@ -37,6 +39,14 @@ bool extrautils::isNapiValueInt(Napi::Env& env, Napi::Value& num) {
       .Value();
 }
 
+std::string extrautils::getNapiObjectClassName(Napi::Object& object) {
+  return object.Get("constructor")
+      .As<Napi::Object>()
+      .Get("name")
+      .As<Napi::String>()
+      .Utf8Value();
+}
+
 QVariant* extrautils::convertToQVariant(Napi::Env& env, Napi::Value& value) {
   // Warning: Make sure you delete the QVariant fron this function upon use.
   if (value.IsBoolean()) {
@@ -62,8 +72,12 @@ QVariant* extrautils::convertToQVariant(Napi::Env& env, Napi::Value& value) {
     // TODO: fix this
     return new QVariant();
   } else if (value.IsObject()) {
-    // TODO: fix this
-    return new QVariant();
+    Napi::Object object = value.As<Napi::Object>();
+    std::string className = getNapiObjectClassName(object);
+    int typeId = QMetaType::type(className.c_str());
+    ComponentWrap* componentWrap =
+        Napi::ObjectWrap<ComponentWrap>::Unwrap(object);
+    return new QVariant(typeId, componentWrap->rawData);
   } else if (value.IsFunction()) {
     return new QVariant();
   } else if (value.IsPromise()) {

--- a/src/cpp/lib/Extras/Utils/nutils.cpp
+++ b/src/cpp/lib/Extras/Utils/nutils.cpp
@@ -1,9 +1,10 @@
+#include "Extras/Utils/nutils.h"
+
 #include <QDebug>
 #include <QMetaType>
 #include <QWidget>
 #include <string>
 
-#include "Extras/Utils/nutils.h"
 #include "core/Component/component_wrap.h"
 
 YGSize extrautils::measureQtWidget(YGNodeRef node, float width,

--- a/src/cpp/lib/QtCore/QObject/qobject_wrap.cpp
+++ b/src/cpp/lib/QtCore/QObject/qobject_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtCore/QObject/qobject_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 
 Napi::FunctionReference QObjectWrap::constructor;
 

--- a/src/cpp/lib/QtCore/QObject/qobject_wrap.cpp
+++ b/src/cpp/lib/QtCore/QObject/qobject_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtCore/QObject/qobject_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtCore/QObject/qobject_wrap.h"
 
 Napi::FunctionReference QObjectWrap::constructor;
 
@@ -37,4 +36,5 @@ QObjectWrap::QObjectWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }

--- a/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp
+++ b/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp
@@ -1,8 +1,6 @@
-#include "QtGui/QApplication/qapplication_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QApplication/qapplication_wrap.h"
 #include "QtGui/QClipboard/qclipboard_wrap.h"
-#include "core/Component/component_macro.h"
 
 Napi::FunctionReference QApplicationWrap::constructor;
 int QApplicationWrap::argc = 0;
@@ -42,6 +40,7 @@ QApplicationWrap::QApplicationWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 QApplicationWrap::~QApplicationWrap() {
   if (this->_wasManuallyCreated) {

--- a/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp
+++ b/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtGui/QApplication/qapplication_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "QtGui/QClipboard/qclipboard_wrap.h"
 
 Napi::FunctionReference QApplicationWrap::constructor;

--- a/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp
+++ b/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtGui/QClipboard/qclipboard_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "deps/spdlog/spdlog.h"
 
 Napi::FunctionReference QClipboardWrap::constructor;

--- a/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp
+++ b/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtGui/QClipboard/qclipboard_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QClipboard/qclipboard_wrap.h"
 #include "deps/spdlog/spdlog.h"
 
 Napi::FunctionReference QClipboardWrap::constructor;
@@ -29,6 +28,7 @@ QClipboardWrap::QClipboardWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Incorrect initialization of QClipboardWrap")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QClipboard* QClipboardWrap::getInternalInstance() { return this->instance; }

--- a/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp
+++ b/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtGui/QCursor/qcursor_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 

--- a/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp
+++ b/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtGui/QCursor/qcursor_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QCursor/qcursor_wrap.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 
@@ -33,6 +32,7 @@ QCursorWrap::QCursorWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QCursorWrap::~QCursorWrap() { this->instance.reset(); }

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -1,10 +1,7 @@
-#include "QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h"
-
 #include <QString>
 
 #include "Extras/Utils/nutils.h"
-#include "core/Component/component_macro.h"
-#include "deps/spdlog/spdlog.h"
+#include "QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h"
 
 Napi::FunctionReference QKeyEventWrap::constructor;
 
@@ -34,6 +31,7 @@ QKeyEventWrap::QKeyEventWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QKeyEventWrap::~QKeyEventWrap() {

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -1,7 +1,8 @@
+#include "QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h"
+
 #include <QString>
 
 #include "Extras/Utils/nutils.h"
-#include "QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h"
 
 Napi::FunctionReference QKeyEventWrap::constructor;
 

--- a/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
+++ b/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtGui/QIcon/qicon_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QIcon/qicon_wrap.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 
@@ -34,6 +33,7 @@ QIconWrap::QIconWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QIconWrap::~QIconWrap() { this->instance.reset(); }

--- a/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
+++ b/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtGui/QIcon/qicon_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 

--- a/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp
+++ b/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 

--- a/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp
+++ b/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtGui/QKeySequence/qkeysequence_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QKeySequence/qkeysequence_wrap.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 
@@ -32,6 +31,7 @@ QKeySequenceWrap::QKeySequenceWrap(const Napi::CallbackInfo &info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QKeySequenceWrap::~QKeySequenceWrap() { this->instance.reset(); }

--- a/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "deps/spdlog/spdlog.h"
 
 Napi::FunctionReference QPixmapWrap::constructor;

--- a/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtGui/QPixmap/qpixmap_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "deps/spdlog/spdlog.h"
 
 Napi::FunctionReference QPixmapWrap::constructor;
@@ -38,6 +37,7 @@ QPixmapWrap::QPixmapWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QPixmapWrap::~QPixmapWrap() { this->instance.reset(); }

--- a/src/cpp/lib/QtWidgets/QAction/qaction_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QAction/qaction_wrap.cpp
@@ -1,9 +1,8 @@
-#include "QtWidgets/QAction/qaction_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
+#include "QtWidgets/QAction/qaction_wrap.h"
 #include "QtWidgets/QMenu/qmenu_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
@@ -26,8 +25,7 @@ Napi::Object QActionWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("setChecked", &QActionWrap::setChecked),
        InstanceMethod("isSeparator", &QActionWrap::isSeparator),
        InstanceMethod("setSeparator", &QActionWrap::setSeparator),
-       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE
-           EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QActionWrap)});
+       EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QActionWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -51,6 +49,7 @@ QActionWrap::QActionWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QActionWrap::~QActionWrap() { extrautils::safeDelete(this->instance); }

--- a/src/cpp/lib/QtWidgets/QAction/qaction_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QAction/qaction_wrap.cpp
@@ -1,8 +1,9 @@
+#include "QtWidgets/QAction/qaction_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
-#include "QtWidgets/QAction/qaction_wrap.h"
 #include "QtWidgets/QMenu/qmenu_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 

--- a/src/cpp/lib/QtWidgets/QCheckBox/qcheckbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QCheckBox/qcheckbox_wrap.cpp
@@ -1,7 +1,8 @@
+#include "QtWidgets/QCheckBox/qcheckbox_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QCheckBox/qcheckbox_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QCheckBoxWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QCheckBox/qcheckbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QCheckBox/qcheckbox_wrap.cpp
@@ -1,8 +1,7 @@
-#include "QtWidgets/QCheckBox/qcheckbox_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QCheckBox/qcheckbox_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QCheckBoxWrap::constructor;
@@ -39,6 +38,7 @@ QCheckBoxWrap::QCheckBoxWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QDial/qdial_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDial/qdial_wrap.cpp
@@ -1,9 +1,8 @@
 
-#include "QtWidgets/QDial/qdial_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QDial/qdial_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QDialWrap::constructor;
@@ -43,6 +42,7 @@ QDialWrap::QDialWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its own size.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QDial/qdial_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDial/qdial_wrap.cpp
@@ -1,8 +1,9 @@
 
+#include "QtWidgets/QDial/qdial_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QDial/qdial_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QDialWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QGridLayout/qgridlayout_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QGridLayout/qgridlayout_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtWidgets/QGridLayout/qgridlayout_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QGridLayoutWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QGridLayout/qgridlayout_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QGridLayout/qgridlayout_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtWidgets/QGridLayout/qgridlayout_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QGridLayout/qgridlayout_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QGridLayoutWrap::constructor;
@@ -37,6 +36,7 @@ QGridLayoutWrap::QGridLayoutWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 Napi::Value QGridLayoutWrap::addWidget(const Napi::CallbackInfo& info) {

--- a/src/cpp/lib/QtWidgets/QLabel/qlabel_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLabel/qlabel_wrap.cpp
@@ -1,8 +1,9 @@
+#include "QtWidgets/QLabel/qlabel_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
-#include "QtWidgets/QLabel/qlabel_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 Napi::FunctionReference QLabelWrap::constructor;
 

--- a/src/cpp/lib/QtWidgets/QLabel/qlabel_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLabel/qlabel_wrap.cpp
@@ -1,9 +1,8 @@
-#include "QtWidgets/QLabel/qlabel_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
+#include "QtWidgets/QLabel/qlabel_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 Napi::FunctionReference QLabelWrap::constructor;
 
@@ -45,6 +44,7 @@ QLabelWrap::QLabelWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
@@ -1,8 +1,9 @@
 
+#include "QtWidgets/QLineEdit/qlineedit_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QLineEdit/qlineedit_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QLineEditWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
@@ -1,9 +1,8 @@
 
-#include "QtWidgets/QLineEdit/qlineedit_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QLineEdit/qlineedit_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QLineEditWrap::constructor;
@@ -42,6 +41,7 @@ QLineEditWrap::QLineEditWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QMainWindow/qmainwindow_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMainWindow/qmainwindow_wrap.cpp
@@ -1,8 +1,9 @@
+#include "QtWidgets/QMainWindow/qmainwindow_wrap.h"
+
 #include <QApplication>
 #include <QDesktopWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QMainWindow/qmainwindow_wrap.h"
 #include "QtWidgets/QMenuBar/qmenubar_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 

--- a/src/cpp/lib/QtWidgets/QMainWindow/qmainwindow_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMainWindow/qmainwindow_wrap.cpp
@@ -1,9 +1,8 @@
-#include "QtWidgets/QMainWindow/qmainwindow_wrap.h"
-
 #include <QApplication>
 #include <QDesktopWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QMainWindow/qmainwindow_wrap.h"
 #include "QtWidgets/QMenuBar/qmenubar_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
@@ -46,6 +45,7 @@ QMainWindowWrap::QMainWindowWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 Napi::Value QMainWindowWrap::setCentralWidget(const Napi::CallbackInfo& info) {

--- a/src/cpp/lib/QtWidgets/QMenu/qmenu_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMenu/qmenu_wrap.cpp
@@ -1,10 +1,11 @@
+#include "QtWidgets/QMenu/qmenu_wrap.h"
+
 #include <nodegui/Extras/Utils/nutils.h>
 #include <nodegui/QtWidgets/QWidget/qwidget_wrap.h>
 
 #include <QWidget>
 
 #include "QtWidgets/QAction/qaction_wrap.h"
-#include "QtWidgets/QMenu/qmenu_wrap.h"
 
 Napi::FunctionReference QMenuWrap::constructor;
 

--- a/src/cpp/lib/QtWidgets/QMenu/qmenu_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMenu/qmenu_wrap.cpp
@@ -1,11 +1,10 @@
-#include "QtWidgets/QMenu/qmenu_wrap.h"
-
 #include <nodegui/Extras/Utils/nutils.h>
 #include <nodegui/QtWidgets/QWidget/qwidget_wrap.h>
 
 #include <QWidget>
 
 #include "QtWidgets/QAction/qaction_wrap.h"
+#include "QtWidgets/QMenu/qmenu_wrap.h"
 
 Napi::FunctionReference QMenuWrap::constructor;
 
@@ -40,6 +39,7 @@ QMenuWrap::QMenuWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QMenuBar/qmenubar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMenuBar/qmenubar_wrap.cpp
@@ -1,10 +1,11 @@
+#include "QtWidgets/QMenuBar/qmenubar_wrap.h"
+
 #include <nodegui/Extras/Utils/nutils.h>
 #include <nodegui/QtWidgets/QWidget/qwidget_wrap.h>
 
 #include <QWidget>
 
 #include "QtWidgets/QMenu/qmenu_wrap.h"
-#include "QtWidgets/QMenuBar/qmenubar_wrap.h"
 
 Napi::FunctionReference QMenuBarWrap::constructor;
 

--- a/src/cpp/lib/QtWidgets/QMenuBar/qmenubar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMenuBar/qmenubar_wrap.cpp
@@ -1,11 +1,10 @@
-#include "QtWidgets/QMenuBar/qmenubar_wrap.h"
-
 #include <nodegui/Extras/Utils/nutils.h>
 #include <nodegui/QtWidgets/QWidget/qwidget_wrap.h>
 
 #include <QWidget>
 
 #include "QtWidgets/QMenu/qmenu_wrap.h"
+#include "QtWidgets/QMenuBar/qmenubar_wrap.h"
 
 Napi::FunctionReference QMenuBarWrap::constructor;
 
@@ -45,6 +44,7 @@ QMenuBarWrap::QMenuBarWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
@@ -1,9 +1,8 @@
 
-#include "QtWidgets/QPlainTextEdit/qplaintextedit_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QPlainTextEdit/qplaintextedit_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QPlainTextEditWrap::constructor;
@@ -52,6 +51,7 @@ QPlainTextEditWrap::QPlainTextEditWrap(const Napi::CallbackInfo &info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
@@ -1,8 +1,9 @@
 
+#include "QtWidgets/QPlainTextEdit/qplaintextedit_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QPlainTextEdit/qplaintextedit_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QPlainTextEditWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QProgressBar/qprogressbar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QProgressBar/qprogressbar_wrap.cpp
@@ -1,8 +1,9 @@
 
+#include "QtWidgets/QProgressBar/qprogressbar_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QProgressBar/qprogressbar_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QProgressBarWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QProgressBar/qprogressbar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QProgressBar/qprogressbar_wrap.cpp
@@ -1,9 +1,8 @@
 
-#include "QtWidgets/QProgressBar/qprogressbar_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QProgressBar/qprogressbar_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QProgressBarWrap::constructor;
@@ -42,6 +41,7 @@ QProgressBarWrap::QProgressBarWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its own size.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QRadioButton/qradiobutton_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QRadioButton/qradiobutton_wrap.cpp
@@ -1,9 +1,8 @@
 
-#include "QtWidgets/QRadioButton/qradiobutton_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QRadioButton/qradiobutton_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QRadioButtonWrap::constructor;
@@ -38,6 +37,7 @@ QRadioButtonWrap::QRadioButtonWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its own size.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QRadioButton/qradiobutton_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QRadioButton/qradiobutton_wrap.cpp
@@ -1,8 +1,9 @@
 
+#include "QtWidgets/QRadioButton/qradiobutton_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
-#include "QtWidgets/QRadioButton/qradiobutton_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QRadioButtonWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QScrollArea/qscrollarea_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QScrollArea/qscrollarea_wrap.cpp
@@ -1,6 +1,5 @@
-#include "QtWidgets/QScrollArea/qscrollarea_wrap.h"
-
 #include "Extras/Utils/nutils.h"
+#include "QtWidgets/QScrollArea/qscrollarea_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QScrollAreaWrap::constructor;
@@ -40,7 +39,7 @@ QScrollAreaWrap::QScrollAreaWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
-  this->instance->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its own size.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QScrollArea/qscrollarea_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QScrollArea/qscrollarea_wrap.cpp
@@ -1,5 +1,6 @@
-#include "Extras/Utils/nutils.h"
 #include "QtWidgets/QScrollArea/qscrollarea_wrap.h"
+
+#include "Extras/Utils/nutils.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QScrollAreaWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QShortcut/qshortcut_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QShortcut/qshortcut_wrap.cpp
@@ -1,9 +1,10 @@
+#include "QtWidgets/QShortcut/qshortcut_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
 #include "QtWidgets/QMenu/qmenu_wrap.h"
-#include "QtWidgets/QShortcut/qshortcut_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QShortcutWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QShortcut/qshortcut_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QShortcut/qshortcut_wrap.cpp
@@ -1,10 +1,9 @@
-#include "QtWidgets/QShortcut/qshortcut_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
 #include "QtWidgets/QMenu/qmenu_wrap.h"
+#include "QtWidgets/QShortcut/qshortcut_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QShortcutWrap::constructor;
@@ -18,8 +17,7 @@ Napi::Object QShortcutWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("setAutoRepeat", &QShortcutWrap::setAutoRepeat),
        InstanceMethod("setKey", &QShortcutWrap::setKey),
        InstanceMethod("setContext", &QShortcutWrap::setContext),
-       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE
-           EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QShortcutWrap)});
+       EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QShortcutWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -41,6 +39,7 @@ QShortcutWrap::QShortcutWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QShortcutWrap::~QShortcutWrap() { extrautils::safeDelete(this->instance); }

--- a/src/cpp/lib/QtWidgets/QSpinBox/qspinbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSpinBox/qspinbox_wrap.cpp
@@ -1,6 +1,7 @@
+#include "QtWidgets/QSpinBox/qspinbox_wrap.h"
+
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QIcon/qicon_wrap.h"
-#include "QtWidgets/QSpinBox/qspinbox_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QSpinBoxWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QSpinBox/qspinbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSpinBox/qspinbox_wrap.cpp
@@ -1,7 +1,6 @@
-#include "QtWidgets/QSpinBox/qspinbox_wrap.h"
-
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QIcon/qicon_wrap.h"
+#include "QtWidgets/QSpinBox/qspinbox_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QSpinBoxWrap::constructor;
@@ -45,6 +44,7 @@ QSpinBoxWrap::QSpinBoxWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.cpp
@@ -1,9 +1,10 @@
+#include "QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.h"
+
 #include <QWidget>
 #include <iostream>
 
 #include "Extras/Utils/nutils.h"
 #include "QtWidgets/QMenu/qmenu_wrap.h"
-#include "QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QSystemTrayIconWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.cpp
@@ -1,10 +1,9 @@
-#include "QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.h"
-
 #include <QWidget>
 #include <iostream>
 
 #include "Extras/Utils/nutils.h"
 #include "QtWidgets/QMenu/qmenu_wrap.h"
+#include "QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QSystemTrayIconWrap::constructor;
@@ -20,9 +19,7 @@ Napi::Object QSystemTrayIconWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("isVisible", &QSystemTrayIconWrap::isVisible),
        InstanceMethod("setToolTip", &QSystemTrayIconWrap::setToolTip),
        InstanceMethod("setContextMenu", &QSystemTrayIconWrap::setContextMenu),
-
-       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE
-           EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QSystemTrayIconWrap)});
+       EVENTWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QSystemTrayIconWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -50,6 +47,7 @@ QSystemTrayIconWrap::QSystemTrayIconWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 QSystemTrayIconWrap::~QSystemTrayIconWrap() {

--- a/src/cpp/lib/QtWidgets/QTabWidget/qtabwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTabWidget/qtabwidget_wrap.cpp
@@ -1,8 +1,9 @@
+#include "QtWidgets/QTabWidget/qtabwidget_wrap.h"
+
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QIcon/qicon_wrap.h"
-#include "QtWidgets/QTabWidget/qtabwidget_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QTabWidgetWrap::constructor;

--- a/src/cpp/lib/QtWidgets/QTabWidget/qtabwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTabWidget/qtabwidget_wrap.cpp
@@ -1,9 +1,8 @@
-#include "QtWidgets/QTabWidget/qtabwidget_wrap.h"
-
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "QtGui/QIcon/qicon_wrap.h"
+#include "QtWidgets/QTabWidget/qtabwidget_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QTabWidgetWrap::constructor;
@@ -47,6 +46,7 @@ QTabWidgetWrap::QTabWidgetWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
   // Adds measure function on yoga node so that widget size is calculated based
   // on its text also.
   YGNodeSetMeasureFunc(this->instance->getFlexNode(),

--- a/src/cpp/lib/QtWidgets/QWidget/qwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QWidget/qwidget_wrap.cpp
@@ -1,7 +1,6 @@
-#include "QtWidgets/QWidget/qwidget_wrap.h"
-
 #include "Extras/Utils/nutils.h"
 #include "QtWidgets/QLayout/qlayout_wrap.h"
+#include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QWidgetWrap::constructor;
 
@@ -39,4 +38,5 @@ QWidgetWrap::QWidgetWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }

--- a/src/cpp/lib/QtWidgets/QWidget/qwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QWidget/qwidget_wrap.cpp
@@ -1,6 +1,7 @@
+#include "QtWidgets/QWidget/qwidget_wrap.h"
+
 #include "Extras/Utils/nutils.h"
 #include "QtWidgets/QLayout/qlayout_wrap.h"
-#include "QtWidgets/QWidget/qwidget_wrap.h"
 
 Napi::FunctionReference QWidgetWrap::constructor;
 

--- a/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp
+++ b/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp
@@ -1,8 +1,7 @@
 
-#include "core/FlexLayout/flexlayout_wrap.h"
-
 #include "Extras/Utils/nutils.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
+#include "core/FlexLayout/flexlayout_wrap.h"
 
 Napi::FunctionReference FlexLayoutWrap::constructor;
 
@@ -41,6 +40,7 @@ FlexLayoutWrap::FlexLayoutWrap(const Napi::CallbackInfo& info)
     Napi::TypeError::New(env, "Wrong number of arguments")
         .ThrowAsJavaScriptException();
   }
+  this->rawData = this->getInternalInstance();
 }
 
 Napi::Value FlexLayoutWrap::addWidget(const Napi::CallbackInfo& info) {

--- a/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp
+++ b/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp
@@ -1,7 +1,8 @@
 
+#include "core/FlexLayout/flexlayout_wrap.h"
+
 #include "Extras/Utils/nutils.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
-#include "core/FlexLayout/flexlayout_wrap.h"
 
 Napi::FunctionReference FlexLayoutWrap::constructor;
 

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -3,6 +3,7 @@ import { QWidget } from './lib/QtWidgets/QWidget';
 import { FlexLayout } from './lib/core/FlexLayout';
 import { QLabel } from './lib/QtWidgets/QLabel';
 import { AlignmentFlag } from './lib/QtEnums';
+import { QPixmap } from './lib/QtGui/QPixmap';
 
 const win = new QMainWindow();
 const view = new QWidget();
@@ -23,6 +24,8 @@ world.setStyleSheet(`
     border: 1px solid blue;
     qproperty-alignment: AlignCenter;
 `);
+const pixmap = new QPixmap('/Users/atulr/Project/nodegui/nodegui/extras/assets/kitchen.png');
+hello.setProperty('pixmap', pixmap);
 
 hello.setProperty('alignment', AlignmentFlag.AlignCenter);
 

--- a/src/lib/QtCore/QObject.ts
+++ b/src/lib/QtCore/QObject.ts
@@ -8,7 +8,8 @@ export abstract class NodeObject extends EventWidget {
         return this.native.inherits(className);
     }
     setProperty(name: string, value: any): boolean {
-        return this.native.setProperty(name, value);
+        const finalValue = value.native || value;
+        return this.native.setProperty(name, finalValue);
     }
     setObjectName(objectName: string): void {
         this.native.setObjectName(objectName);


### PR DESCRIPTION
This will allow us to implement all properties of all the widgets with ease.
We can call setProperty on a widget that inherits QObject
All we now need to do is implement all QVariant classes. That should allow use to call setProperty on all widgets to set any widget property using QVariant.
Thus suddenly, we wont need to implement a huge number of widget methods. :) 