### PR TITLE
Added echoMode to QLineEdit

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QLineEdit/qlineedit_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QLineEdit/qlineedit_wrap.h
@@ -25,6 +25,7 @@ class QLineEditWrap : public Napi::ObjectWrap<QLineEditWrap> {
   Napi::Value setPlaceholderText(const Napi::CallbackInfo& info);
   Napi::Value setReadOnly(const Napi::CallbackInfo& info);
   Napi::Value clear(const Napi::CallbackInfo& info);
+  Napi::Value setEchoMode(const Napi::CallbackInfo& info);
 
   QWIDGET_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
@@ -18,6 +18,7 @@ Napi::Object QLineEditWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("text", &QLineEditWrap::text),
        InstanceMethod("setReadOnly", &QLineEditWrap::setReadOnly),
        InstanceMethod("clear", &QLineEditWrap::clear),
+       InstanceMethod("setEchoMode", &QLineEditWrap::setEchoMode),
        QWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QLineEditWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -81,9 +82,19 @@ Napi::Value QLineEditWrap::setPlaceholderText(const Napi::CallbackInfo& info) {
   this->instance->setPlaceholderText(text.Utf8Value().c_str());
   return env.Null();
 }
+
 Napi::Value QLineEditWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   this->instance->clear();
+  return env.Null();
+}
+
+Napi::Value QLineEditWrap::setEchoMode(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  Napi::Number mode = info[0].As<Napi::Number>();
+  this->instance->setEchoMode(
+      static_cast<QLineEdit::EchoMode>(mode.Int32Value()));
   return env.Null();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export { QWidget, QWidgetEvents } from './lib/QtWidgets/QWidget';
 export { QCheckBox, QCheckBoxEvents } from './lib/QtWidgets/QCheckBox';
 export { QLabel, QLabelEvents } from './lib/QtWidgets/QLabel';
 export { QDial, QDialEvents } from './lib/QtWidgets/QDial';
-export { QLineEdit, QLineEditEvents } from './lib/QtWidgets/QLineEdit';
+export { QLineEdit, QLineEditEvents, EchoMode } from './lib/QtWidgets/QLineEdit';
 export { QMainWindow, QMainWindowEvents } from './lib/QtWidgets/QMainWindow';
 export { QProgressBar, QProgressBarEvents } from './lib/QtWidgets/QProgressBar';
 export { QPushButton, QPushButtonEvents } from './lib/QtWidgets/QPushButton';

--- a/src/lib/QtWidgets/QLineEdit.ts
+++ b/src/lib/QtWidgets/QLineEdit.ts
@@ -3,6 +3,12 @@ import { NodeWidget } from './QWidget';
 import { BaseWidgetEvents } from '../core/EventWidget';
 import { NativeElement } from '../core/Component';
 
+export enum EchoMode {
+    Normal,
+    NoEcho,
+    Password,
+    PasswordEchoOnEdit,    
+};
 export const QLineEditEvents = Object.freeze({
     ...BaseWidgetEvents,
     cursorPositionChanged: 'cursorPositionChanged',
@@ -47,5 +53,8 @@ export class QLineEdit extends NodeWidget {
     clear(): void {
         // react:✓
         this.native.clear();
+    }
+    setEchoMode(mode: EchoMode): void {
+        this.native.setEchoMode(mode);
     }
 }


### PR DESCRIPTION
This fix adds setEchoMode() to QLineEdit and the corresponding enum QLineEdit.EchoModes. https://doc.qt.io/qt-5/qlineedit.html#echoMode-prop