### PR TITLE
Feature/key events

### DIFF
--- a/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
@@ -20,6 +20,7 @@ class QKeyEventWrap : public Napi::ObjectWrap<QKeyEventWrap> {
   static Napi::FunctionReference constructor;
   // wrapped methods
   Napi::Value text(const Napi::CallbackInfo& info);
+  Napi::Value key(const Napi::CallbackInfo& info);
 
   COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
@@ -21,6 +21,9 @@ class QKeyEventWrap : public Napi::ObjectWrap<QKeyEventWrap> {
   // wrapped methods
   Napi::Value text(const Napi::CallbackInfo& info);
   Napi::Value key(const Napi::CallbackInfo& info);
+  Napi::Value modifiers(const Napi::CallbackInfo& info);
+  Napi::Value count(const Napi::CallbackInfo& info);
+  Napi::Value isAutoRepeat(const Napi::CallbackInfo& info);
 
   COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -13,6 +13,9 @@ Napi::Object QKeyEventWrap::init(Napi::Env env, Napi::Object exports) {
       DefineClass(env, CLASSNAME,
                   {InstanceMethod("text", &QKeyEventWrap::text),
                    InstanceMethod("key", &QKeyEventWrap::key),
+                   InstanceMethod("modifiers", &QKeyEventWrap::modifiers),
+                   InstanceMethod("count", &QKeyEventWrap::count),
+                   InstanceMethod("isAutoRepeat", &QKeyEventWrap::isAutoRepeat),
                    COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -51,4 +54,22 @@ Napi::Value QKeyEventWrap::key(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   int key = static_cast<int>(this->instance->key());
   return Napi::Number::From(env, key);
+}
+
+Napi::Value QKeyEventWrap::modifiers(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int key = static_cast<int>(this->instance->modifiers());
+  return Napi::Number::From(env, key);
+}
+
+Napi::Value QKeyEventWrap::count(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int count = static_cast<int>(this->instance->count());
+  return Napi::Number::From(env, count);
+}
+
+Napi::Value QKeyEventWrap::isAutoRepeat(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  bool isAutoRepeat = static_cast<bool>(this->instance->isAutoRepeat());
+  return Napi::Boolean::From(env, isAutoRepeat);
 }

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -12,6 +12,7 @@ Napi::Object QKeyEventWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::Function func =
       DefineClass(env, CLASSNAME,
                   {InstanceMethod("text", &QKeyEventWrap::text),
+                   InstanceMethod("key", &QKeyEventWrap::key),
                    COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -44,4 +45,10 @@ Napi::Value QKeyEventWrap::text(const Napi::CallbackInfo& info) {
   QString text = this->instance->text();
   Napi::String keyValue = Napi::String::New(env, text.toStdString());
   return keyValue;
+}
+
+Napi::Value QKeyEventWrap::key(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int key = static_cast<int>(this->instance->key());
+  return Napi::Number::From(env, key);
 }

--- a/src/cpp/lib/core/Events/eventwidget.cpp
+++ b/src/cpp/lib/core/Events/eventwidget.cpp
@@ -2,10 +2,6 @@
 
 #include <napi.h>
 
-#include <QKeyEvent>
-
-#include "QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h"
-
 #include "deps/spdlog/spdlog.h"
 
 void EventWidget::subscribeToQtEvent(std::string evtString) {
@@ -45,25 +41,11 @@ void EventWidget::event(QEvent* event) {
       std::string eventTypeString = subscribedEvents.at(evtType);
       Napi::Env env = this->emitOnNode.Env();
       Napi::HandleScope scope(env);
-      std::vector<napi_value> args;
 
-      switch (evtType) {
-        case QEvent::KeyPress:
-        case QEvent::KeyRelease: {
-          // Cast to QKeyEvent and create a JS friendly keyEvent object 
-          QKeyEvent* nativeKeyEvent = static_cast<QKeyEvent*>(event);
-          Napi::Object keyEvent = QKeyEventWrap::constructor.New(
-              {Napi::External<QKeyEvent>::New(env, nativeKeyEvent)});
+      Napi::Value nativeEvent = Napi::External<QEvent>::New(env, event);
+      std::vector<napi_value> args = {Napi::String::New(env, eventTypeString),
+                                      nativeEvent};
 
-          args = {Napi::String::New(env, eventTypeString), keyEvent};
-          break;
-        }
-
-        default: {
-          Napi::Value nativeEvent = Napi::External<QEvent>::New(env, event);
-          args = {Napi::String::New(env, eventTypeString), nativeEvent};
-        }
-      }
       this->emitOnNode.Call(args);
     } catch (...) {
       // Do nothing

--- a/src/lib/QtGui/QEvent/QKeyEvent.ts
+++ b/src/lib/QtGui/QEvent/QKeyEvent.ts
@@ -10,7 +10,7 @@ export class QKeyEvent {
     text = (): string => {
         return this.native.text();
     };
-    key = (): string => {
+    key = (): number => {
         return this.native.key();
     };    
     modifiers = (): number => {

--- a/src/lib/QtGui/QEvent/QKeyEvent.ts
+++ b/src/lib/QtGui/QEvent/QKeyEvent.ts
@@ -10,4 +10,7 @@ export class QKeyEvent {
     text = (): string => {
         return this.native.text();
     };
+    key = (): string => {
+        return this.native.key();
+    };    
 }

--- a/src/lib/QtGui/QEvent/QKeyEvent.ts
+++ b/src/lib/QtGui/QEvent/QKeyEvent.ts
@@ -13,4 +13,13 @@ export class QKeyEvent {
     key = (): string => {
         return this.native.key();
     };    
+    modifiers = (): number => {
+        return this.native.modifiers();
+    };    
+    count = (): number => {
+        return this.native.count();
+    };    
+    isAutoRepeat = (): boolean => {
+        return this.native.isAutoRepeat();
+    };    
 }


### PR DESCRIPTION
Added better support for KeyEvents so that the JS side can now receive text, key codes, modifiers and other properties when subscribing to QWidget's KeyPress and KeyRelease events. Such event listeners now receive QKeyEvents.

Example based on demo.ts: 
```
const edit = new QLineEdit();
edit.addEventListener(QLabelEvents.KeyPress, (nativeEvent) => {
    let event = new QKeyEvent(nativeEvent);
    let modifierBits = event.modifiers();
    let modifiers = [];
    for (let modifierValue in KeyboardModifier) {                
        if ((modifierBits & parseInt(modifierValue, 0)) !== 0) {
            modifiers.push(KeyboardModifier[modifierValue]);
        }
    }    
    console.log(event.key(), event.text(), modifiers.join(', '), event.isAutoRepeat(), event.count());    
});
```

The eventwidget.cpp may be a bit hacky, as I'm not strong on c++ nor familiar with QT. Is this the right place to handle the casting? Also, perhaps the QT key constants listed in eventsmap.cpp should be made available to JS somehow? 