### PR TITLE
QMouseEvent() wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ set(CORE_WIDGETS_ADDON "nodegui_core")
 
 project(${CORE_WIDGETS_ADDON})
 
-add_library(${CORE_WIDGETS_ADDON} SHARED  
+add_library(${CORE_WIDGETS_ADDON} SHARED
     "${CMAKE_JS_SRC}"
     "${PROJECT_SOURCE_DIR}/src/cpp/main.cpp"
-    # core internals 
+    # core internals
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/Extras/Utils/nutils.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/core/FlexLayout/flexlayout.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/core/FlexLayout/flexitem.cpp"
@@ -34,10 +34,11 @@ add_library(${CORE_WIDGETS_ADDON} SHARED
     "${PROJECT_SOURCE_DIR}/src/cpp/include/deps/yoga/Yoga.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/deps/yoga/event/event.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/deps/yoga/internal/experiments.cpp"
-    # wrapped cpps 
+    # wrapped cpps
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp"
+    "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp"
@@ -88,14 +89,14 @@ add_library(${CORE_WIDGETS_ADDON} SHARED
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QMenu/nmenu.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QLayout/nlayout.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QGridLayout/ngridlayout.hpp"
-) 
+)
 
 AddCommonConfig(${CORE_WIDGETS_ADDON})
 AddQtSupport(${CORE_WIDGETS_ADDON})
 AddNapiSupport(${CORE_WIDGETS_ADDON})
 
-target_include_directories(${CORE_WIDGETS_ADDON} PRIVATE 
-    "${CMAKE_JS_INC}" 
+target_include_directories(${CORE_WIDGETS_ADDON} PRIVATE
+    "${CMAKE_JS_INC}"
     "${PROJECT_SOURCE_DIR}"
     "${PROJECT_SOURCE_DIR}/src/cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include"

--- a/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <napi.h>
+#include <stdlib.h>
+
+#include <QMouseEvent>
+
+#include "core/Component/component_macro.h"
+
+class QMouseEventWrap : public Napi::ObjectWrap<QMouseEventWrap> {
+ private:
+  QMouseEvent* instance;
+
+ public:
+  static Napi::Object init(Napi::Env env, Napi::Object exports);
+  QMouseEventWrap(const Napi::CallbackInfo& info);
+  ~QMouseEventWrap();
+  QMouseEvent* getInternalInstance();
+  // class constructor
+  static Napi::FunctionReference constructor;
+  // wrapped methods
+  Napi::Value button(const Napi::CallbackInfo& info);
+  Napi::Value x(const Napi::CallbackInfo& info);
+  Napi::Value y(const Napi::CallbackInfo& info);
+  // Napi::Value key(const Napi::CallbackInfo& info);
+  // Napi::Value modifiers(const Napi::CallbackInfo& info);
+  // Napi::Value count(const Napi::CallbackInfo& info);
+  // Napi::Value isAutoRepeat(const Napi::CallbackInfo& info);
+
+  COMPONENT_WRAPPED_METHODS_DECLARATION
+};

--- a/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
@@ -22,10 +22,9 @@ class QMouseEventWrap : public Napi::ObjectWrap<QMouseEventWrap> {
   Napi::Value button(const Napi::CallbackInfo& info);
   Napi::Value x(const Napi::CallbackInfo& info);
   Napi::Value y(const Napi::CallbackInfo& info);
-  // Napi::Value key(const Napi::CallbackInfo& info);
-  // Napi::Value modifiers(const Napi::CallbackInfo& info);
-  // Napi::Value count(const Napi::CallbackInfo& info);
-  // Napi::Value isAutoRepeat(const Napi::CallbackInfo& info);
+  Napi::Value globalX(const Napi::CallbackInfo& info);
+  Napi::Value globalY(const Napi::CallbackInfo& info);
+
 
   COMPONENT_WRAPPED_METHODS_DECLARATION
 };

--- a/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
@@ -9,16 +9,15 @@ Napi::FunctionReference QMouseEventWrap::constructor;
 Napi::Object QMouseEventWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QMouseEvent";
-  Napi::Function func =
-      DefineClass(env, CLASSNAME,
-                  {InstanceMethod("button", &QMouseEventWrap::button),
-                   InstanceMethod("x", &QMouseEventWrap::x),
-                   InstanceMethod("y", &QMouseEventWrap::y),
-                  //  InstanceMethod("key", &QMouseEventWrap::key),
-                  //  InstanceMethod("modifiers", &QMouseEventWrap::modifiers),
-                  //  InstanceMethod("count", &QMouseEventWrap::count),
-                  //  InstanceMethod("isAutoRepeat", &QMouseEventWrap::isAutoRepeat),
-                   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
+  Napi::Function func = DefineClass(
+      env, CLASSNAME,
+      {InstanceMethod("button", &QMouseEventWrap::button),
+       InstanceMethod("x", &QMouseEventWrap::x),
+       InstanceMethod("y", &QMouseEventWrap::y),
+       InstanceMethod("globalX", &QMouseEventWrap::globalX),
+       InstanceMethod("globalY", &QMouseEventWrap::globalY),
+
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -45,13 +44,6 @@ QMouseEventWrap::~QMouseEventWrap() {
   // Do not destroy instance here. It will be done by Qt Event loop.
 }
 
-// Napi::Value QMouseEventWrap::button(const Napi::CallbackInfo& info) {
-//   Napi::Env env = info.Env();
-//   QString button = this->instance->button();
-//   Napi::String keyValue = Napi::String::New(env, text.toStdString());
-//   return keyValue;
-// }
-
 Napi::Value QMouseEventWrap::button(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   int button = static_cast<int>(this->instance->button());
@@ -70,20 +62,14 @@ Napi::Value QMouseEventWrap::y(const Napi::CallbackInfo& info) {
   return Napi::Number::From(env, y);
 }
 
-// Napi::Value QKeyEventWrap::modifiers(const Napi::CallbackInfo& info) {
-//   Napi::Env env = info.Env();
-//   int key = static_cast<int>(this->instance->modifiers());
-//   return Napi::Number::From(env, key);
-// }
+Napi::Value QMouseEventWrap::globalX(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int globalX = static_cast<int>(this->instance->globalX());
+  return Napi::Number::From(env, globalX);
+}
 
-// Napi::Value QKeyEventWrap::count(const Napi::CallbackInfo& info) {
-//   Napi::Env env = info.Env();
-//   int count = static_cast<int>(this->instance->count());
-//   return Napi::Number::From(env, count);
-// }
-
-// Napi::Value QKeyEventWrap::isAutoRepeat(const Napi::CallbackInfo& info) {
-//   Napi::Env env = info.Env();
-//   bool isAutoRepeat = static_cast<bool>(this->instance->isAutoRepeat());
-//   return Napi::Boolean::From(env, isAutoRepeat);
-// }
+Napi::Value QMouseEventWrap::globalY(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int globalY = static_cast<int>(this->instance->globalY());
+  return Napi::Number::From(env, globalY);
+}

--- a/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
@@ -1,0 +1,89 @@
+#include "QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h"
+
+#include <QString>
+
+#include "Extras/Utils/nutils.h"
+
+Napi::FunctionReference QMouseEventWrap::constructor;
+
+Napi::Object QMouseEventWrap::init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  char CLASSNAME[] = "QMouseEvent";
+  Napi::Function func =
+      DefineClass(env, CLASSNAME,
+                  {InstanceMethod("button", &QMouseEventWrap::button),
+                   InstanceMethod("x", &QMouseEventWrap::x),
+                   InstanceMethod("y", &QMouseEventWrap::y),
+                  //  InstanceMethod("key", &QMouseEventWrap::key),
+                  //  InstanceMethod("modifiers", &QMouseEventWrap::modifiers),
+                  //  InstanceMethod("count", &QMouseEventWrap::count),
+                  //  InstanceMethod("isAutoRepeat", &QMouseEventWrap::isAutoRepeat),
+                   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
+  constructor = Napi::Persistent(func);
+  exports.Set(CLASSNAME, func);
+  return exports;
+}
+
+QMouseEvent* QMouseEventWrap::getInternalInstance() { return this->instance; }
+
+QMouseEventWrap::QMouseEventWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<QMouseEventWrap>(info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  if (info.Length() == 1) {
+    Napi::External<QMouseEvent> eventObject =
+        info[0].As<Napi::External<QMouseEvent>>();
+    this->instance = static_cast<QMouseEvent*>(eventObject.Data());
+  } else {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+  }
+  this->rawData = this->getInternalInstance();
+}
+
+QMouseEventWrap::~QMouseEventWrap() {
+  // Do not destroy instance here. It will be done by Qt Event loop.
+}
+
+// Napi::Value QMouseEventWrap::button(const Napi::CallbackInfo& info) {
+//   Napi::Env env = info.Env();
+//   QString button = this->instance->button();
+//   Napi::String keyValue = Napi::String::New(env, text.toStdString());
+//   return keyValue;
+// }
+
+Napi::Value QMouseEventWrap::button(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int button = static_cast<int>(this->instance->button());
+  return Napi::Number::From(env, button);
+}
+
+Napi::Value QMouseEventWrap::x(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int x = static_cast<int>(this->instance->x());
+  return Napi::Number::From(env, x);
+}
+
+Napi::Value QMouseEventWrap::y(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int y = static_cast<int>(this->instance->y());
+  return Napi::Number::From(env, y);
+}
+
+// Napi::Value QKeyEventWrap::modifiers(const Napi::CallbackInfo& info) {
+//   Napi::Env env = info.Env();
+//   int key = static_cast<int>(this->instance->modifiers());
+//   return Napi::Number::From(env, key);
+// }
+
+// Napi::Value QKeyEventWrap::count(const Napi::CallbackInfo& info) {
+//   Napi::Env env = info.Env();
+//   int count = static_cast<int>(this->instance->count());
+//   return Napi::Number::From(env, count);
+// }
+
+// Napi::Value QKeyEventWrap::isAutoRepeat(const Napi::CallbackInfo& info) {
+//   Napi::Env env = info.Env();
+//   bool isAutoRepeat = static_cast<bool>(this->instance->isAutoRepeat());
+//   return Napi::Boolean::From(env, isAutoRepeat);
+// }

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -7,6 +7,7 @@
 #include "QtGui/QClipboard/qclipboard_wrap.h"
 #include "QtGui/QCursor/qcursor_wrap.h"
 #include "QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h"
+#include "QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h"
 #include "QtGui/QIcon/qicon_wrap.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
 #include "QtGui/QPixmap/qpixmap_wrap.h"
@@ -59,6 +60,7 @@ Napi::Object Main(Napi::Env env, Napi::Object exports) {
   QTabWidgetWrap::init(env, exports);
   QLineEditWrap::init(env, exports);
   QKeyEventWrap::init(env, exports);
+  QMouseEventWrap::init(env, exports);
   QPlainTextEditWrap::init(env, exports);
   QDialWrap::init(env, exports);
   QLabelWrap::init(env, exports);

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,9 +1,10 @@
 import { QMainWindow } from './index';
 import { QWidget } from './lib/QtWidgets/QWidget';
 import { FlexLayout } from './lib/core/FlexLayout';
-import { QLabel } from './lib/QtWidgets/QLabel';
+import { QLabel, QLabelEvents } from './lib/QtWidgets/QLabel';
 import { AlignmentFlag } from './lib/QtEnums';
 import { QPixmap } from './lib/QtGui/QPixmap';
+import { QMouseEvent } from './lib/QtGui/QEvent/QMouseEvent';
 
 const win = new QMainWindow();
 const view = new QWidget();
@@ -19,7 +20,11 @@ hello.setStyleSheet(`
     border: 1px solid blue;
 `);
 const world = new QLabel();
-world.setText('World');
+world.setText('Worldddd');
+world.addEventListener(QLabelEvents.MouseButtonPress, (e) => {
+    const event = new QMouseEvent(e)
+    console.log("clicked!", event.x(), event.y())
+})
 world.setStyleSheet(`
     border: 1px solid blue;
     qproperty-alignment: AlignCenter;

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -20,11 +20,11 @@ hello.setStyleSheet(`
     border: 1px solid blue;
 `);
 const world = new QLabel();
-world.setText('Worldddd');
-world.addEventListener(QLabelEvents.MouseButtonPress, (e) => {
-    const event = new QMouseEvent(e)
-    console.log("clicked!", event.x(), event.y())
-})
+world.setText('World');
+world.addEventListener(QLabelEvents.MouseButtonPress, e => {
+    const event = new QMouseEvent(e);
+    console.log('clicked!', event.x(), event.y());
+});
 world.setStyleSheet(`
     border: 1px solid blue;
     qproperty-alignment: AlignCenter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { QTextOptionWrapMode } from './lib/QtGui/QTextOption';
 export { QClipboard, QClipboardMode } from './lib/QtGui/QClipboard';
 // Events: Maybe a separate module ?
 export { QKeyEvent } from './lib/QtGui/QEvent/QKeyEvent';
+export { QMouseEvent } from './lib/QtGui/QEvent/QMouseEvent';
 export { NativeEvent, BaseWidgetEvents } from './lib/core/EventWidget';
 // Abstract:
 export { NodeWidget } from './lib/QtWidgets/QWidget';

--- a/src/lib/QtGui/QEvent/QMouseEvent.ts
+++ b/src/lib/QtGui/QEvent/QMouseEvent.ts
@@ -16,4 +16,10 @@ export class QMouseEvent {
     y = (): number => {
         return this.native.y();
     };
+    globalX = (): number => {
+        return this.native.globalX();
+    };
+    globalY = (): number => {
+        return this.native.globalY();
+    };
 }

--- a/src/lib/QtGui/QEvent/QMouseEvent.ts
+++ b/src/lib/QtGui/QEvent/QMouseEvent.ts
@@ -1,0 +1,19 @@
+import addon from '../../utils/addon';
+import { NativeElement } from '../../core/Component';
+import { NativeEvent } from '../../core/EventWidget';
+
+export class QMouseEvent {
+    native: NativeElement;
+    constructor(event: NativeEvent) {
+        this.native = new addon.QMouseEvent(event);
+    }
+    button = (): string => {
+        return this.native.button();
+    };
+    x = (): number => {
+        return this.native.x();
+    };
+    y = (): number => {
+        return this.native.y();
+    };
+}


### PR DESCRIPTION
I made a simple wrapper for the QMouseEvent class so mouse event details can be read from the event handler as well. button, x, y, and global x,y seem to work.

I did not wrap all fields specified in the [Qt docs,](https://doc.qt.io/qt-5/qmouseevent.html) so this is also a question: which other fields would be nice to expose more? 
