### PR TITLE
Fix default font issue in macos catalina

### DIFF
--- a/src/cpp/include/nodegui/Extras/Utils/nutils.h
+++ b/src/cpp/include/nodegui/Extras/Utils/nutils.h
@@ -23,4 +23,5 @@ void safeDelete(QPointer<T>& component) {
     delete component;
   }
 }
+void initAppSettings();
 }  // namespace extrautils

--- a/src/cpp/lib/Extras/Utils/nutils.cpp
+++ b/src/cpp/lib/Extras/Utils/nutils.cpp
@@ -1,5 +1,7 @@
 #include "Extras/Utils/nutils.h"
 
+#include <QApplication>
+#include <QFont>
 #include <QMetaType>
 #include <QWidget>
 #include <string>
@@ -84,4 +86,12 @@ void* extrautils::configureQWidget(QWidget* widget, YGNodeRef node,
                                    bool isLeafNode) {
   flexutils::configureFlexNode(widget, node, isLeafNode);
   return configureQObject(widget);
+}
+
+void extrautils::initAppSettings() {
+  QFont f = QApplication::font();
+  if (f.defaultFamily().isEmpty()) {
+    f.setFamily("Sans-Serif");
+    QApplication::setFont(f);
+  }
 }

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -35,6 +35,7 @@
 #include "core/FlexLayout/flexlayout_wrap.h"
 // These cant be instantiated in JS Side
 void InitPrivateHelpers(Napi::Env env) {
+  extrautils::initAppSettings();
   QLayoutWrap::init(env);  // Abstact class wrapper for pointing to any layout
 }
 


### PR DESCRIPTION
Adds fix for Qt bug where Qt fails to recognise a default font. In that case set the default font to Sans serif