### PR TITLE
Add signals to QSystemTrayIcon

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QSystemTrayIcon/nsystemtrayicon.hpp
+++ b/src/cpp/include/nodegui/QtWidgets/QSystemTrayIcon/nsystemtrayicon.hpp
@@ -11,5 +11,22 @@ class NSystemTrayIcon : public QSystemTrayIcon, public EventWidget {
  public:
   using QSystemTrayIcon::QSystemTrayIcon;  // inherit all constructors of
                                            // QSystemTrayIcon
-  void connectWidgetSignalsToEventEmitter() {}
+  void connectWidgetSignalsToEventEmitter() {
+    QObject::connect(this, &QSystemTrayIcon::activated, [=](int reason) {
+      Napi::Env env = this->emitOnNode.Env();
+      Napi::HandleScope scope(env);
+      this->emitOnNode.Call({
+          Napi::String::New(env, "activated"),
+          Napi::Value::From(env, reason),
+      });
+    });
+
+    QObject::connect(this, &QSystemTrayIcon::messageClicked, [=]() {
+      Napi::Env env = this->emitOnNode.Env();
+      Napi::HandleScope scope(env);
+      this->emitOnNode.Call({
+          Napi::String::New(env, "messageClicked"),
+      });
+    });
+  }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,11 @@ export { QMenu, QMenuEvents } from './lib/QtWidgets/QMenu';
 export { QMenuBar, QMenuBarEvents } from './lib/QtWidgets/QMenuBar';
 export { QPlainTextEdit, QPlainTextEditEvents, LineWrapMode } from './lib/QtWidgets/QPlainTextEdit';
 export { QScrollArea, QScrollAreaEvents } from './lib/QtWidgets/QScrollArea';
-export { QSystemTrayIcon, QSystemTrayIconEvents } from './lib/QtWidgets/QSystemTrayIcon';
+export {
+    QSystemTrayIcon,
+    QSystemTrayIconEvents,
+    QSystemTrayIconActivationReason,
+} from './lib/QtWidgets/QSystemTrayIcon';
 export { QAction, QActionEvents } from './lib/QtWidgets/QAction';
 export { QShortcut, QShortcutEvents } from './lib/QtWidgets/QShortcut';
 export { QGroupBox, QGroupBoxEvents } from './lib/QtWidgets/QGroupBox';

--- a/src/lib/QtWidgets/QSystemTrayIcon.ts
+++ b/src/lib/QtWidgets/QSystemTrayIcon.ts
@@ -8,6 +8,15 @@ import { NodeObject } from '../QtCore/QObject';
 
 export const QSystemTrayIconEvents = Object.freeze({
     ...BaseWidgetEvents,
+    activated: 'activated',
+    messageClicked: 'messageClicked',
+});
+export const QSystemTrayIconActivationReason = Object.freeze({
+    Unknown: 0,
+    Context: 1,
+    DoubleClick: 2,
+    Trigger: 3,
+    MiddleClick: 4,
 });
 export class QSystemTrayIcon extends NodeObject {
     native: NativeElement;


### PR DESCRIPTION
- `activated(QSystemTrayIcon::ActivationReason reason)`
- `messageClicked()`

According to [docs](https://doc.qt.io/qt-5/qsystemtrayicon.html#signals).