### PR TITLE
Throttle flex layout calculation calls to improve performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(${CORE_WIDGETS_ADDON} SHARED
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp"
     # Custom widgets (include them for automoc since they contain Q_OBJECT)
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtCore/QObject/nobject.hpp"
+    "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/core/FlexLayout/flexlayout.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtGui/QMovie/nmovie.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QWidget/nwidget.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QLabel/nlabel.hpp"

--- a/src/cpp/include/nodegui/Extras/Utils/nutils.h
+++ b/src/cpp/include/nodegui/Extras/Utils/nutils.h
@@ -5,7 +5,7 @@
 #include <QPointer>
 #include <QVariant>
 
-#include "core/FlexLayout/flexlayout.h"
+#include "core/FlexLayout/flexlayout.hpp"
 #include "core/FlexLayout/flexutils.h"
 namespace extrautils {
 

--- a/src/cpp/include/nodegui/QtGui/QFontDatabase/qfontdatabase_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QFontDatabase/qfontdatabase_wrap.h
@@ -20,7 +20,7 @@ class QFontDatabaseWrap : public Napi::ObjectWrap<QFontDatabaseWrap> {
   Napi::Value bold(const Napi::CallbackInfo& info);
   Napi::Value italic(const Napi::CallbackInfo& info);
   Napi::Value weight(const Napi::CallbackInfo& info);
- 
+
   COMPONENT_WRAPPED_METHODS_DECLARATION
 };
 

--- a/src/cpp/include/nodegui/core/FlexLayout/flexlayout.hpp
+++ b/src/cpp/include/nodegui/core/FlexLayout/flexlayout.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QLayout>
+#include <QTimer>
 
 #include "core/Events/eventwidget_macro.h"
 #include "deps/yoga/YGNode.h"
@@ -19,12 +20,20 @@ YGNodeNew(); FlexLayout * flayout = new FlexLayout(container,root);
  */
 
 class FlexLayout : public QLayout, public EventWidget {
+  Q_OBJECT
  private:
   YGNodeRef node;
   YGNodeRef getRootNode(YGNodeRef node) const;
   void calculateLayout() const;
   void restoreNodeMinStyle(YGValue &previousMinWidth,
                            YGValue &previousMinHeight);
+
+  // performance memebers
+  QTimer throttleTimer;
+  QRect cachedRect;
+  // end of performance memeber
+ private slots:
+  void performLayout();
 
  public:
   FlexLayout(QWidget *parentWidget = nullptr, YGNodeRef parentNode = nullptr);
@@ -45,3 +54,5 @@ class FlexLayout : public QLayout, public EventWidget {
 
   EVENTWIDGET_IMPLEMENTATIONS(QLayout)
 };
+
+// class FlexLayoutWorker: public Q

--- a/src/cpp/include/nodegui/core/FlexLayout/flexlayout_wrap.h
+++ b/src/cpp/include/nodegui/core/FlexLayout/flexlayout_wrap.h
@@ -6,7 +6,7 @@
 #include <QPointer>
 
 #include "QtWidgets/QLayout/qlayout_macro.h"
-#include "flexlayout.h"
+#include "flexlayout.hpp"
 
 class FlexLayoutWrap : public Napi::ObjectWrap<FlexLayoutWrap> {
  private:

--- a/src/cpp/lib/QtGui/QFontDatabase/qfontdatabase_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFontDatabase/qfontdatabase_wrap.cpp
@@ -7,17 +7,16 @@ Napi::FunctionReference QFontDatabaseWrap::constructor;
 Napi::Object QFontDatabaseWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QFontDatabase";
-  Napi::Function func =
-      DefineClass(
-          env, CLASSNAME,
-          {InstanceMethod("bold", &QFontDatabaseWrap::bold),
-           InstanceMethod("italic", &QFontDatabaseWrap::italic),
-           InstanceMethod("weight", &QFontDatabaseWrap::weight),
-           StaticMethod("addApplicationFont", 
-                        &StaticQFontDatabaseWrapMethods::addApplicationFont),
-           StaticMethod("removeApplicationFont", 
-                        &StaticQFontDatabaseWrapMethods::removeApplicationFont),
-           COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
+  Napi::Function func = DefineClass(
+      env, CLASSNAME,
+      {InstanceMethod("bold", &QFontDatabaseWrap::bold),
+       InstanceMethod("italic", &QFontDatabaseWrap::italic),
+       InstanceMethod("weight", &QFontDatabaseWrap::weight),
+       StaticMethod("addApplicationFont",
+                    &StaticQFontDatabaseWrapMethods::addApplicationFont),
+       StaticMethod("removeApplicationFont",
+                    &StaticQFontDatabaseWrapMethods::removeApplicationFont),
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -31,8 +30,8 @@ QFontDatabaseWrap::QFontDatabaseWrap(const Napi::CallbackInfo& info)
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
 }
 
-QFontDatabase* QFontDatabaseWrap::getInternalInstance() { 
-  return this->instance.get(); 
+QFontDatabase* QFontDatabaseWrap::getInternalInstance() {
+  return this->instance.get();
 }
 
 Napi::Value QFontDatabaseWrap::bold(const Napi::CallbackInfo& info) {
@@ -70,8 +69,8 @@ Napi::Value StaticQFontDatabaseWrapMethods::addApplicationFont(
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   std::string fileName = info[0].As<Napi::String>().Utf8Value();
-  int id = 
-    QFontDatabase::addApplicationFont(QString::fromUtf8(fileName.c_str()));
+  int id =
+      QFontDatabase::addApplicationFont(QString::fromUtf8(fileName.c_str()));
   return Napi::Value::From(env, id);
 }
 

--- a/src/cpp/lib/core/FlexLayout/flexlayout.cpp
+++ b/src/cpp/lib/core/FlexLayout/flexlayout.cpp
@@ -1,15 +1,21 @@
-#include "core/FlexLayout/flexlayout.h"
-
 #include <QDebug>
 #include <QWidget>
 
+#include "Extras/Utils/nutils.h"
 #include "core/FlexLayout/flexitem.h"
+#include "core/FlexLayout/flexlayout.hpp"
 #include "core/FlexLayout/flexutils.h"
 #include "core/YogaWidget/yogawidget.h"
 
 FlexLayout::FlexLayout(QWidget* parentWidget, YGNodeRef parentNode)
     : QLayout(parentWidget) {
   this->node = parentNode;
+  // Throttle the setGeometry calls that may happen when dealing with huge
+  // lists.
+  this->throttleTimer.setTimerType(Qt::PreciseTimer);
+  this->throttleTimer.setSingleShot(true);
+  QObject::connect(&this->throttleTimer, &QTimer::timeout, this,
+                   &FlexLayout::performLayout);
 }
 
 FlexLayout::~FlexLayout() {
@@ -147,9 +153,19 @@ QSize FlexLayout::minimumSize() const {
 }
 
 void FlexLayout::setGeometry(const QRect& rect) {
+  this->cachedRect = rect;
+  if (this->throttleTimer.isActive()) {
+    return;
+  }
+  this->throttleTimer.start(10);
+  // This will call performLayout and throttle requests between 10ms.
+}
+
+void FlexLayout::performLayout() {
   if (!this->node) {
     return;
   }
+  QRect rect = this->cachedRect;
   if (!rect.isValid() || rect != geometry()) {
     bool isSizeControlled = flexutils::isFlexNodeSizeControlled(this->node);
     YGValue prevStyleMinWidth = YGNodeStyleGetMinWidth(this->node);

--- a/src/cpp/lib/core/FlexLayout/flexlayout.cpp
+++ b/src/cpp/lib/core/FlexLayout/flexlayout.cpp
@@ -1,9 +1,10 @@
+#include "core/FlexLayout/flexlayout.hpp"
+
 #include <QDebug>
 #include <QWidget>
 
 #include "Extras/Utils/nutils.h"
 #include "core/FlexLayout/flexitem.h"
-#include "core/FlexLayout/flexlayout.hpp"
 #include "core/FlexLayout/flexutils.h"
 #include "core/YogaWidget/yogawidget.h"
 


### PR DESCRIPTION
This makes sure flex layout calculation for same instance of flex layout happens only once in a given interval of time. This prevents duplicate calculations and thereby improving performance.

Next step: is to run the actual calculations in a separate thread than main thread.