### PR TITLE
add setFont() and font() to QWidget and font() to QAction

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,23 +1,32 @@
-import { QMessageBox } from './index';
-import { QToolButton } from './lib/QtWidgets/QToolButton';
+import { FlexLayout, QMainWindow, QWidget } from './index';
+import { QLabel } from './lib/QtWidgets/QLabel';
+import { QFont, QFontCapitalization } from './lib/QtGui/QFont';
+import { QPushButton } from './lib/QtWidgets/QPushButton';
 
-const msgBox = new QMessageBox();
-// const msgBoxButton = msgBox.addButton('Another button');
-// console.log(msgBoxButton);
-msgBox.setText('hellllooo');
-
-const btn = new QToolButton();
-btn.setText('yolo');
-msgBox.addButton(btn);
-msgBox.addEventListener('buttonClicked', rawButtonPtr => {
-    console.log(rawButtonPtr);
-    const btn2 = new QToolButton(rawButtonPtr);
-    btn2.setText('Helloooo');
-    const newMsg = new QMessageBox();
-    newMsg.exec();
+const win = new QMainWindow();
+const center = new QWidget();
+const layout = new FlexLayout();
+center.setLayout(layout);
+const label = new QLabel();
+const font = new QFont('Mono', 14);
+label.setFont(font);
+label.setText('label 1');
+const btn = new QPushButton();
+btn.setText('Change font');
+btn.setFont(new QFont('Helvetica', 20));
+btn.addEventListener('clicked', () => {
+    const font2 = label.font();
+    font2.setCapitalization(QFontCapitalization.AllUppercase);
+    font2.setItalic(true);
+    font2.setFamily('Times');
+    console.log('point', font2.pointSize());
+    label.setFont(font2);
 });
-msgBox.exec();
+layout.addWidget(label);
+layout.addWidget(btn);
 
-(global as any).msg = msgBox;
+win.setCentralWidget(center);
+win.resize(400, 400);
 
-setInterval(() => null, 1000);
+win.show();
+(global as any).win = win;

--- a/src/lib/QtGui/QFont.ts
+++ b/src/lib/QtGui/QFont.ts
@@ -37,7 +37,7 @@ export class QFont extends Component {
     native: NativeElement;
     constructor();
     constructor(font?: QFont);
-    constructor(family?: string, pointSize?: number, weight?: number, italic?: boolean);
+    constructor(family?: string, pointSize?: number, weight?: QFontWeight, italic?: boolean);
     constructor(arg?: QFont | string, pointSize = -1, weight = -1, italic = false) {
         super();
         if (arg instanceof QFont) {

--- a/src/lib/QtGui/QFont.ts
+++ b/src/lib/QtGui/QFont.ts
@@ -1,6 +1,7 @@
 import { Component, NativeElement } from '../core/Component';
 import addon from '../utils/addon';
 import { QVariant } from '../QtCore/QVariant';
+import { checkIfNativeElement } from '../utils/helpers';
 
 export enum QFontStretch {
     AnyStretch = 0,
@@ -36,11 +37,14 @@ export enum QFontWeight {
 export class QFont extends Component {
     native: NativeElement;
     constructor();
-    constructor(font?: QFont);
-    constructor(family?: string, pointSize?: number, weight?: QFontWeight, italic?: boolean);
-    constructor(arg?: QFont | string, pointSize = -1, weight = -1, italic = false) {
+    constructor(font: QFont);
+    constructor(native: NativeElement);
+    constructor(family: string, pointSize?: number, weight?: QFontWeight, italic?: boolean);
+    constructor(arg?: QFont | string | NativeElement, pointSize = -1, weight = -1, italic = false) {
         super();
-        if (arg instanceof QFont) {
+        if (checkIfNativeElement(arg)) {
+            this.native = arg as NativeElement;
+        } else if (arg instanceof QFont) {
             this.native = arg.native;
         } else if (typeof arg === 'string') {
             this.native = new addon.QFont(arg, pointSize, weight, italic);

--- a/src/lib/QtWidgets/QAction.ts
+++ b/src/lib/QtWidgets/QAction.ts
@@ -96,4 +96,7 @@ export class QAction extends NodeObject<QActionSignals> {
     setFont(font: QFont): void {
         this.native.setFont(font.native);
     }
+    font(): QFont {
+        return QFont.fromQVariant(this.property('font'));
+    }
 }

--- a/src/lib/QtWidgets/QWidget.ts
+++ b/src/lib/QtWidgets/QWidget.ts
@@ -12,6 +12,7 @@ import { YogaWidget } from '../core/YogaWidget';
 import { QSize } from '../QtCore/QSize';
 import { QRect } from '../QtCore/QRect';
 import { QObjectSignals } from '../QtCore/QObject';
+import { QFont } from '../QtGui/QFont';
 
 /**
  
@@ -204,6 +205,12 @@ export abstract class NodeWidget<Signals extends QWidgetSignals> extends YogaWid
     }
     showNormal(): void {
         this.native.showNormal();
+    }
+    setFont(font: QFont): void {
+        this.native.setProperty('font', font.native);
+    }
+    font(): QFont {
+        return QFont.fromQVariant(this.property('font'));
     }
 }
 


### PR DESCRIPTION
@master-atul when i do this: `const font2 = label.font();` it doesn't preserve `pointSize` (on demo it goes back to what i think is the default font size), from Qt docs it doesn't look like it's the native behaviour, what do u think?