### PR TITLE
Update QTreeWidget

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QTreeWidget/qtreewidget_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTreeWidget/qtreewidget_wrap.h
@@ -36,10 +36,9 @@ class DLL_EXPORT QTreeWidgetWrap : public Napi::ObjectWrap<QTreeWidgetWrap> {
   Napi::Value setItemWidget(const Napi::CallbackInfo &info);
   Napi::Value currentItem(const Napi::CallbackInfo &info);
   Napi::Value findItems(const Napi::CallbackInfo &info);
+  Napi::Value takeTopLevelItem(const Napi::CallbackInfo &info);
+  Napi::Value clear(const Napi::CallbackInfo &info);
 
-  // Napi::Value addTopLevelItems(const Napi::CallbackInfo& info);
   // Napi::Value setHorizontalScrollBarPolicy(const Napi::CallbackInfo& info);
   // Napi::Value setVerticalScrollBarPolicy(const Napi::CallbackInfo& info);
-  // Napi::Value takeTopLevelItem(const Napi::CallbackInfo& info);
-  // Napi::Value findItems(const Napi::CallbackInfo& info);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ export { QShortcut, QShortcutSignals } from './lib/QtWidgets/QShortcut';
 export { QGroupBox, QGroupBoxSignals } from './lib/QtWidgets/QGroupBox';
 export { QStatusBar, QStatusBarSignals } from './lib/QtWidgets/QStatusBar';
 export { QStandardItemModel, QStandardItemModelSignals } from './lib/QtWidgets/QStandardItemModel';
+export { QStandardItem } from './lib/QtWidgets/QStandardItem';
 // Core
 export { QDate } from './lib/QtCore/QDate';
 export { QDateTime } from './lib/QtCore/QDateTime';

--- a/src/lib/QtWidgets/QTreeWidget.ts
+++ b/src/lib/QtWidgets/QTreeWidget.ts
@@ -83,7 +83,6 @@ export class QTreeWidget extends QAbstractScrollArea<QTreeWidgetSignals> {
     }
 
     insertTopLevelItem(index: number, item: QTreeWidgetItem): void {
-        this.topLevelItems.add(item);
         this.native.insertTopLevelItem(index, item.native);
     }
 
@@ -145,8 +144,13 @@ export class QTreeWidget extends QAbstractScrollArea<QTreeWidgetSignals> {
     /**
      * Returns the current item in the tree widget.
      */
-    currentItem(): QTreeWidgetItem {
-        return new QTreeWidgetItem(this.native.currentItem());
+    currentItem(): QTreeWidgetItem | void {
+        const item = this.native.currentItem();
+        if (item) {
+            return new QTreeWidgetItem(item);
+        } else {
+            return undefined;
+        }
     }
 
     /**
@@ -162,6 +166,20 @@ export class QTreeWidget extends QAbstractScrollArea<QTreeWidgetSignals> {
         return nativeItems.map(function(eachItem: QTreeWidgetItem) {
             return new QTreeWidgetItem(eachItem);
         });
+    }
+
+    takeTopLevelItem(index: number): QTreeWidgetItem | void {
+        const item = this.native.takeTopLevelItem(index);
+        if (item) {
+            return new QTreeWidgetItem(item);
+        } else {
+            return undefined;
+        }
+    }
+
+    clear(): void {
+        this.topLevelItems.clear();
+        this.native.clear();
     }
 }
 

--- a/src/lib/QtWidgets/QTreeWidget.ts
+++ b/src/lib/QtWidgets/QTreeWidget.ts
@@ -87,6 +87,7 @@ export class QTreeWidget extends QAbstractScrollArea<QTreeWidgetSignals> {
     }
 
     insertTopLevelItems(index: number, items: QTreeWidgetItem[]): void {
+        this.topLevelItems.add(item)
         const napiItems: NativeElement[] = [];
         items.forEach(item => {
             this.topLevelItems.add(item);

--- a/src/lib/QtWidgets/QTreeWidget.ts
+++ b/src/lib/QtWidgets/QTreeWidget.ts
@@ -83,11 +83,11 @@ export class QTreeWidget extends QAbstractScrollArea<QTreeWidgetSignals> {
     }
 
     insertTopLevelItem(index: number, item: QTreeWidgetItem): void {
+        this.topLevelItems.add(item)
         this.native.insertTopLevelItem(index, item.native);
     }
 
     insertTopLevelItems(index: number, items: QTreeWidgetItem[]): void {
-        this.topLevelItems.add(item)
         const napiItems: NativeElement[] = [];
         items.forEach(item => {
             this.topLevelItems.add(item);


### PR DESCRIPTION
Fixed a bug with QTreeWidget::currentItem() crashing when nothing is selected and added QTreeWidget::takeTopLevelItem() and QTreeWidget::clear()