### PR TITLE
Fixed return type of QMouseEvent.button() method

### DIFF
--- a/src/lib/QtGui/QEvent/QMouseEvent.ts
+++ b/src/lib/QtGui/QEvent/QMouseEvent.ts
@@ -6,7 +6,7 @@ export class QMouseEvent {
     constructor(event: NativeElement) {
         this.native = new addon.QMouseEvent(event);
     }
-    button(): string {
+    button(): number {
         return this.native.button();
     }
     x(): number {


### PR DESCRIPTION
The actual return type is int, so it gets passed as a number instead of a string
https://github.com/nodegui/nodegui/blob/master/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp#L49