### PR TITLE
Add bigobj compiler option to win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ target_include_directories(${CORE_WIDGETS_ADDON} PRIVATE
 
 
 if (WIN32) 
+    add_definitions(/bigobj)
     target_compile_definitions(${CORE_WIDGETS_ADDON} PRIVATE
         ENABLE_DLL_EXPORT=1
     )


### PR DESCRIPTION
When I try to build nodegui in windows 10 (x64, 2004, vs2019), I face C1128 problem while cmake so I have put bigobj compiler option to CMakeList.txt

This will fix build problem in windows vs2019 compiler.

https://docs.microsoft.com/en-US/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=vs-2019

![image](https://user-images.githubusercontent.com/9389278/86390449-09fe3f00-bcd3-11ea-9294-0a27d2f762e1.png)
