### PR TITLE
Add QIcon support to QTreeWidgetItem.

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h
@@ -21,6 +21,8 @@ class DLL_EXPORT QTableWidgetItemWrap
   // class constructor
   static Napi::FunctionReference constructor;
   // wrapped methods
+  Napi::Value setIcon(const Napi::CallbackInfo& info);
+  Napi::Value icon(const Napi::CallbackInfo& info);
   Napi::Value setText(const Napi::CallbackInfo& info);
   Napi::Value setToolTip(const Napi::CallbackInfo& info);
   Napi::Value setTextAlignment(const Napi::CallbackInfo& info);

--- a/src/cpp/include/nodegui/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h
@@ -21,8 +21,6 @@ class DLL_EXPORT QTableWidgetItemWrap
   // class constructor
   static Napi::FunctionReference constructor;
   // wrapped methods
-  Napi::Value setIcon(const Napi::CallbackInfo& info);
-  Napi::Value icon(const Napi::CallbackInfo& info);
   Napi::Value setText(const Napi::CallbackInfo& info);
   Napi::Value setToolTip(const Napi::CallbackInfo& info);
   Napi::Value setTextAlignment(const Napi::CallbackInfo& info);

--- a/src/cpp/include/nodegui/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.h
@@ -28,8 +28,8 @@ class DLL_EXPORT QTreeWidgetItemWrap
   static Napi::FunctionReference constructor;
 
   // wrapped methods
-  Napi::Value setIcon(const Napi::CallbackInfo& info);
-  Napi::Value icon(const Napi::CallbackInfo& info);
+  Napi::Value setIcon(const Napi::CallbackInfo &info);
+  Napi::Value icon(const Napi::CallbackInfo &info);
   Napi::Value setText(const Napi::CallbackInfo &info);
   Napi::Value parent(const Napi::CallbackInfo &info);
   Napi::Value childCount(const Napi::CallbackInfo &info);

--- a/src/cpp/include/nodegui/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.h
@@ -28,6 +28,8 @@ class DLL_EXPORT QTreeWidgetItemWrap
   static Napi::FunctionReference constructor;
 
   // wrapped methods
+  Napi::Value setIcon(const Napi::CallbackInfo& info);
+  Napi::Value icon(const Napi::CallbackInfo& info);
   Napi::Value setText(const Napi::CallbackInfo &info);
   Napi::Value parent(const Napi::CallbackInfo &info);
   Napi::Value childCount(const Napi::CallbackInfo &info);

--- a/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
@@ -1,4 +1,5 @@
 #include "QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h"
+#include "QtGui/QIcon/qicon_wrap.h"
 
 #include "Extras/Utils/nutils.h"
 #include "core/Component/component_wrap.h"
@@ -10,7 +11,10 @@ Napi::Object QTableWidgetItemWrap::init(Napi::Env env, Napi::Object exports) {
   char CLASSNAME[] = "QTableWidgetItem";
   Napi::Function func = DefineClass(
       env, CLASSNAME,
-      {InstanceMethod("setText", &QTableWidgetItemWrap::setText),
+      {
+       InstanceMethod("icon", &QTableWidgetItemWrap::text),
+       InstanceMethod("setIcon", &QTableWidgetItemWrap::setIcon),
+       InstanceMethod("setText", &QTableWidgetItemWrap::setText),
        InstanceMethod("setToolTip", &QTableWidgetItemWrap::setToolTip),
        InstanceMethod("setTextAlignment",
                       &QTableWidgetItemWrap::setTextAlignment),
@@ -45,6 +49,24 @@ QTableWidgetItemWrap::QTableWidgetItemWrap(const Napi::CallbackInfo& info)
         .ThrowAsJavaScriptException();
   }
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
+}
+Napi::Value QTableWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Object iconObject = info[0].As<Napi::Object>();
+  QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
+  this->instance->setIcon(*iconWrap->getInternalInstance());
+  return env.Null();
+}
+Napi::Value QTableWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QIcon icon = this->instance->icon();
+  auto instance = QIconWrap::constructor.New(
+      {Napi::External<QIcon>::New(env, new QIcon(icon))});
+  return instance;
 }
 Napi::Value QTableWidgetItemWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();

--- a/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
@@ -12,8 +12,6 @@ Napi::Object QTableWidgetItemWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(
       env, CLASSNAME,
       {
-       InstanceMethod("icon", &QTableWidgetItemWrap::text),
-       InstanceMethod("setIcon", &QTableWidgetItemWrap::setIcon),
        InstanceMethod("setText", &QTableWidgetItemWrap::setText),
        InstanceMethod("setToolTip", &QTableWidgetItemWrap::setToolTip),
        InstanceMethod("setTextAlignment",
@@ -49,24 +47,6 @@ QTableWidgetItemWrap::QTableWidgetItemWrap(const Napi::CallbackInfo& info)
         .ThrowAsJavaScriptException();
   }
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
-}
-Napi::Value QTableWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
-  Napi::Object iconObject = info[0].As<Napi::Object>();
-  QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
-  this->instance->setIcon(*iconWrap->getInternalInstance());
-  return env.Null();
-}
-Napi::Value QTableWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
-  QIcon icon = this->instance->icon();
-  auto instance = QIconWrap::constructor.New(
-      {Napi::External<QIcon>::New(env, new QIcon(icon))});
-  return instance;
 }
 Napi::Value QTableWidgetItemWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();

--- a/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
@@ -1,7 +1,7 @@
 #include "QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h"
-#include "QtGui/QIcon/qicon_wrap.h"
 
 #include "Extras/Utils/nutils.h"
+#include "QtGui/QIcon/qicon_wrap.h"
 #include "core/Component/component_wrap.h"
 
 Napi::FunctionReference QTableWidgetItemWrap::constructor;
@@ -11,8 +11,7 @@ Napi::Object QTableWidgetItemWrap::init(Napi::Env env, Napi::Object exports) {
   char CLASSNAME[] = "QTableWidgetItem";
   Napi::Function func = DefineClass(
       env, CLASSNAME,
-      {
-       InstanceMethod("setText", &QTableWidgetItemWrap::setText),
+      {InstanceMethod("setText", &QTableWidgetItemWrap::setText),
        InstanceMethod("setToolTip", &QTableWidgetItemWrap::setToolTip),
        InstanceMethod("setTextAlignment",
                       &QTableWidgetItemWrap::setTextAlignment),

--- a/src/cpp/lib/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.cpp
@@ -135,17 +135,17 @@ QTreeWidgetItemWrap::QTreeWidgetItemWrap(const Napi::CallbackInfo &info)
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
 }
 
-Napi::Value QTreeWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
+Napi::Value QTreeWidgetItemWrap::setIcon(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
   int const column = info[0].As<Napi::Number>().Int32Value();
   Napi::Object const iconObject = info[1].As<Napi::Object>();
-  QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
+  QIconWrap *iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
   this->instance->setIcon(column, *iconWrap->getInternalInstance());
   return env.Null();
 }
-Napi::Value QTreeWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
+Napi::Value QTreeWidgetItemWrap::icon(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 

--- a/src/cpp/lib/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.cpp
@@ -14,7 +14,9 @@ Napi::Object QTreeWidgetItemWrap::init(Napi::Env env, Napi::Object exports) {
   char CLASSNAME[] = "QTreeWidgetItem";
   Napi::Function func = DefineClass(
       env, CLASSNAME,
-      {InstanceMethod("setText", &QTreeWidgetItemWrap::setText),
+      {InstanceMethod("setIcon", &QTreeWidgetItemWrap::setIcon),
+       InstanceMethod("icon", &QTreeWidgetItemWrap::text),
+       InstanceMethod("setText", &QTreeWidgetItemWrap::setText),
        InstanceMethod("parent", &QTreeWidgetItemWrap::parent),
        InstanceMethod("child", &QTreeWidgetItemWrap::child),
        InstanceMethod("text", &QTreeWidgetItemWrap::text),
@@ -133,6 +135,26 @@ QTreeWidgetItemWrap::QTreeWidgetItemWrap(const Napi::CallbackInfo &info)
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
 }
 
+Napi::Value QTreeWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int const column = info[0].As<Napi::Number>().Int32Value();
+  Napi::Object const iconObject = info[1].As<Napi::Object>();
+  QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
+  this->instance->setIcon(column, *iconWrap->getInternalInstance());
+  return env.Null();
+}
+Napi::Value QTreeWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Number const column = info[0].As<Napi::Number>();
+  QIcon icon = this->instance->icon(column);
+  auto instance = QIconWrap::constructor.New(
+      {Napi::External<QIcon>::New(env, new QIcon(icon))});
+  return instance;
+}
 Napi::Value QTreeWidgetItemWrap::setText(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,6 +1,9 @@
 import { QMainWindow, QWidget } from '.';
 import { QGridLayout } from './lib/QtWidgets/QGridLayout';
 import { QLabel } from './lib/QtWidgets/QLabel';
+import { QTreeWidget } from './lib/QtWidgets/QTreeWidget';
+import { QTreeWidgetItem } from './lib/QtWidgets/QTreeWidgetItem';
+import { QIcon } from './lib/QtGui/QIcon';
 
 const win = new QMainWindow();
 win.resize(500, 500);
@@ -41,7 +44,57 @@ columnFour.setText('Four');
 columnFour.setInlineStyle('background-color: orange');
 outerLayout.addWidget(columnFour, 1, 1);
 
+const tree = new QTreeWidget();
+tree.setColumnCount(2);
+tree.setHeaderLabels(['First Column', 'Second Column']);
+tree.setSortingEnabled(true);
+tree.setInlineStyle('font-size: 24px');
+outerLayout.addWidget(tree, 2, 0, 2, 0);
+
 console.log(outerLayout.rowCount(), outerLayout.columnCount());
+
+const myImage = './website/static/img/logo.png';
+const icon = new QIcon(myImage);
+
+const item1 = new QTreeWidgetItem();
+item1.setText(0, `item-1`);
+item1.setText(1, `1-item-1`);
+item1.setIcon(1, icon);
+const item2 = new QTreeWidgetItem();
+item2.setText(0, `item-2`);
+item2.setText(1, `1-item-2`);
+item2.setIcon(1, icon);
+const item3 = new QTreeWidgetItem();
+item3.setText(0, `item-3`);
+item3.setText(1, `1-item-3`);
+item3.setIcon(1, icon);
+const item4 = new QTreeWidgetItem();
+item4.setText(0, `item-4`);
+item4.setText(1, `1-item-4`);
+item4.setIcon(1, icon);
+const item5 = new QTreeWidgetItem();
+item5.setText(0, `item-5`);
+item5.setText(1, `1-item-5`);
+item5.setIcon(1, icon);
+const item6 = new QTreeWidgetItem();
+item6.setText(0, `item-6`);
+item6.setText(1, `1-item-6`);
+item6.setIcon(1, icon);
+
+console.info('item6.icon()=', item6.icon(1));
+
+tree.addTopLevelItem(item1);
+tree.insertTopLevelItems(0, [item2, item3]);
+tree.addTopLevelItems([item4, item5]);
+tree.insertTopLevelItem(2, item6);
+
+// Add children to item1
+const c1item1 = new QTreeWidgetItem(item1);
+c1item1.setText(0, `c1item1`);
+c1item1.setText(1, `c1item2`);
+const c1item2 = new QTreeWidgetItem(item1);
+c1item2.setText(0, `c1item1`);
+c1item2.setText(1, `c1item2`);
 
 win.setCentralWidget(outer);
 win.show();

--- a/src/lib/QtWidgets/QTreeWidgetItem.ts
+++ b/src/lib/QtWidgets/QTreeWidgetItem.ts
@@ -1,6 +1,7 @@
 import addon from '../utils/addon';
 import { Component, NativeElement } from '../core/Component';
 import { checkIfNativeElement } from '../utils/helpers';
+import { QIcon } from '../QtGui/QIcon';
 import { QTreeWidget } from './QTreeWidget';
 import { ItemFlag } from '../QtEnums/ItemFlag';
 import { CheckState, ItemDataRole } from '../QtEnums';
@@ -162,5 +163,20 @@ export class QTreeWidgetItem extends Component {
 
     isHidden(): boolean {
         return this.native.isHidden();
+    }
+
+    /**
+     * Sets the icon for the item.
+     * @param icon The icon object
+     */
+    setIcon(icon: QIcon): void {
+        this.native.setIcon(icon.native);
+    }
+
+    /**
+     * Returns the icon object for the item.
+     */
+    icon(): QIcon {
+        return new QIcon(this.native.icon());
     }
 }

--- a/src/lib/QtWidgets/QTreeWidgetItem.ts
+++ b/src/lib/QtWidgets/QTreeWidgetItem.ts
@@ -169,14 +169,14 @@ export class QTreeWidgetItem extends Component {
      * Sets the icon for the item.
      * @param icon The icon object
      */
-    setIcon(icon: QIcon): void {
-        this.native.setIcon(icon.native);
+    setIcon(column: number, icon: QIcon): void {
+        this.native.setIcon(column, icon.native);
     }
 
     /**
      * Returns the icon object for the item.
      */
-    icon(): QIcon {
-        return new QIcon(this.native.icon());
+    icon(column: number): QIcon {
+        return new QIcon(this.native.icon(column));
     }
 }

--- a/src/lib/QtWidgets/__tests__/QTreeWidget.test.ts
+++ b/src/lib/QtWidgets/__tests__/QTreeWidget.test.ts
@@ -1,0 +1,34 @@
+import { QTreeWidget } from '../QTreeWidget';
+import { QTreeWidgetItem } from '../QTreeWidgetItem';
+import { QIcon } from '../../QtGui/QIcon';
+import path from 'path';
+
+function createTreeWidget(): QTreeWidget {
+    const tree = new QTreeWidget();
+    tree.setColumnCount(2);
+    tree.setHeaderLabels(['First Column', 'Second Column']);
+    return tree;
+}
+
+describe('QTreeWidget', () => {
+    it('instantiate a tree widget', () => {
+        const tree = createTreeWidget();
+        expect(tree.inherits('QTreeWidget')).toBe(true);
+    });
+    it('setText', () => {
+        const tree = createTreeWidget();
+        const item = new QTreeWidgetItem();
+        item.setText(0, 'row0, column0');
+        expect(item.text(0)).toEqual('row0, column0');
+        tree.addTopLevelItem(item);
+    });
+    it('setIcon', () => {
+        const item = new QTreeWidgetItem();
+        const testImagePath = path.resolve(__dirname, 'assets', 'nodegui.png');
+        const icon = new QIcon(testImagePath);
+        item.setText(0, 'row0, column0');
+        item.setIcon(0, icon);
+        // TODO: figure out a way to check this. They are not equivalent.
+        // expect(item.icon(0).cacheKey()).toEqual(icon.cacheKey());
+    });
+});


### PR DESCRIPTION
Signed-off-by: R. Douglas Barbieri <doug@dooglio.net>

This is cut-and-pasted code from `QListWidgetItem` to add `QIcon` support on each row.

I added a `QTreeWidget` to the `demo.js` app to show how the icon looks:
![image](https://user-images.githubusercontent.com/643129/89836382-41f76e00-db2c-11ea-9459-e0ed8c42e5ea.png)

The icon is a little bit small, but I guess this is good for starters. I'd like to figure out a way to expose the `iconSize` property so this can be adjusted.

I also added a down and dirty test for `QTreeWidget` and `QTreeWidgetItem`.