### PR TITLE
Add QDesktopWidget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ add_library(${CORE_WIDGETS_ADDON} SHARED
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtWidgets/QStandardItemModel/qstandarditemmodel_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtWidgets/QStandardItem/qstandarditem_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtWidgets/QSvgWidget/qsvgwidget_wrap.cpp"
+    "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtWidgets/QDesktopWidget/qdesktopwidget_wrap.cpp"
     # Custom widgets (include them for automoc since they contain Q_OBJECT)
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtCore/QObject/nobject.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/core/FlexLayout/flexlayout.hpp"
@@ -200,6 +201,7 @@ add_library(${CORE_WIDGETS_ADDON} SHARED
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QTextBrowser/ntextbrowser.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QTextEdit/ntextedit.hpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QSvgWidget/nsvgwidget.hpp"
+    "${PROJECT_SOURCE_DIR}/src/cpp/include/nodegui/QtWidgets/QDesktopWidget/nqdesktopwidget.hpp"
 )
 
 AddCommonConfig(${CORE_WIDGETS_ADDON})

--- a/src/cpp/include/nodegui/QtWidgets/QDesktopWidget/nqdesktopwidget.hpp
+++ b/src/cpp/include/nodegui/QtWidgets/QDesktopWidget/nqdesktopwidget.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "core/NodeWidget/nodewidget.h"
+#include <QDesktopWidget>
+#include <QApplication>
+
+class NQDesktopWidget : public QDesktopWidget, public NodeWidget {
+ public:
+  Q_OBJECT
+  NODEWIDGET_IMPLEMENTATIONS(QDesktopWidget)
+ public:
+  using QDesktopWidget::QDesktopWidget;  // inherit all constructors of QStatusBar
+};

--- a/src/cpp/include/nodegui/QtWidgets/QDesktopWidget/qdesktopwidget_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QDesktopWidget/qdesktopwidget_wrap.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "napi.h"
+#include "QtWidgets/QWidget/qwidget_macro.h"
+#include <QPointer>
+#include "nqdesktopwidget.hpp"
+
+class QDesktopWidgetWrap : public Napi::ObjectWrap<QDesktopWidgetWrap> {
+ private:
+  QPointer<NQDesktopWidget> instance;
+
+ public:
+  static Napi::Object init(Napi::Env env, Napi::Object exports);
+  QDesktopWidgetWrap(const Napi::CallbackInfo &info);
+  ~QDesktopWidgetWrap();
+  NQDesktopWidget *getInternalInstance();
+  static Napi::FunctionReference constructor;
+  // wrapped methods
+  Napi::Value availableGeometry(const Napi::CallbackInfo &info);
+  Napi::Value screenGeometry(const Napi::CallbackInfo &info);
+  Napi::Value screenNumber(const Napi::CallbackInfo &info);
+
+  QWIDGET_WRAPPED_METHODS_DECLARATION
+};

--- a/src/cpp/lib/QtWidgets/QDesktopWidget/qdesktopwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDesktopWidget/qdesktopwidget_wrap.cpp
@@ -1,0 +1,70 @@
+#include "QtWidgets/QDesktopWidget/qdesktopwidget_wrap.h"
+
+#include "Extras/Utils/nutils.h"
+#include "QtWidgets/QWidget/qwidget_wrap.h"
+#include "QtCore/QRect/qrect_wrap.h"
+
+#include <QWidget>
+
+Napi::FunctionReference QDesktopWidgetWrap::constructor;
+
+Napi::Object QDesktopWidgetWrap::init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  char CLASSNAME[] = "QDesktopWidget";
+  Napi::Function func =
+      DefineClass(env, CLASSNAME,
+                  {InstanceMethod("screenGeometry", &QDesktopWidgetWrap::screenGeometry),
+                   InstanceMethod("availableGeometry", &QDesktopWidgetWrap::availableGeometry),
+                   InstanceMethod("screenNumber", &QDesktopWidgetWrap::screenNumber),
+                   QWIDGET_WRAPPED_METHODS_EXPORT_DEFINE(QDesktopWidgetWrap)});
+  constructor = Napi::Persistent(func);
+  exports.Set(CLASSNAME, func);
+  return exports;
+}
+
+NQDesktopWidget *QDesktopWidgetWrap::getInternalInstance() { return this->instance; }
+
+QDesktopWidgetWrap::QDesktopWidgetWrap(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<QDesktopWidgetWrap>(info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() == 0) {
+    this->instance = new NQDesktopWidget();
+  } else {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+  }
+  this->rawData = extrautils::configureQWidget(
+      this->getInternalInstance(), this->getInternalInstance()->getFlexNode(),
+      true);
+}
+
+QDesktopWidgetWrap::~QDesktopWidgetWrap() { extrautils::safeDelete(this->instance); }
+
+Napi::Value QDesktopWidgetWrap::screenGeometry(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Number screen = info[0].As<Napi::Number>();
+  QRect rect = this->instance->screenGeometry(screen);
+  auto instance = QRectWrap::constructor.New({Napi::External<QRect>::New(env, new QRect(rect))});
+  return instance;
+}
+
+Napi::Value QDesktopWidgetWrap::availableGeometry(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Napi::Number screen = info[0].As<Napi::Number>();
+  QRect rect = this->instance->availableGeometry(screen);
+  auto instance = QRectWrap::constructor.New({Napi::External<QRect>::New(env, new QRect(rect))});
+  return instance;
+}
+
+Napi::Value QDesktopWidgetWrap::screenNumber(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  int value = this->instance->screenNumber();
+  return Napi::Value::From(env, value);
+}

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -99,6 +99,7 @@
 #include "QtWidgets/QToolButton/qtoolbutton_wrap.h"
 #include "QtWidgets/QTreeWidget/qtreewidget_wrap.h"
 #include "QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.h"
+#include "QtWidgets/QDesktopWidget/qdesktopwidget_wrap.h"
 #include "QtWidgets/QWidget/qwidget_wrap.h"
 #include "core/FlexLayout/flexlayout_wrap.h"
 #include "core/Integration/integration.h"
@@ -210,6 +211,7 @@ Napi::Object Main(Napi::Env env, Napi::Object exports) {
   QStandardItemModelWrap::init(env, exports);
   QStandardItemWrap::init(env, exports);
   QSvgWidgetWrap::init(env, exports);
+  QDesktopWidgetWrap::init(env, exports);
   return exports;
 }
 

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -5,16 +5,25 @@ import { QTreeWidget } from './lib/QtWidgets/QTreeWidget';
 import { QTreeWidgetItem } from './lib/QtWidgets/QTreeWidgetItem';
 import { QIcon } from './lib/QtGui/QIcon';
 import { QDesktopWidget } from './lib/QtWidgets/QDesktopWidget';
+import { QApplication } from './lib/QtGui/QApplication';
 
 const win = new QMainWindow();
 win.resize(500, 500);
 
+// ex 1
 const desktop = new QDesktopWidget();
 const availableGeometry = desktop.availableGeometry();
 const screenGeometry = desktop.screenGeometry();
 console.log(availableGeometry.width() + 'x' + availableGeometry.height());
 console.log(screenGeometry.width() + 'x' + screenGeometry.height());
 console.log(desktop.screenNumber());
+// ex 2
+const qApp = QApplication.desktop()
+const availableGeometry2 = qApp.availableGeometry();
+const screenGeometry2 = qApp.screenGeometry();
+console.log(availableGeometry2.width() + 'x' + availableGeometry2.height());
+console.log(screenGeometry2.width() + 'x' + screenGeometry2.height());
+console.log(qApp.screenNumber());
 
 const outer = new QWidget();
 const outerLayout = new QGridLayout();

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -4,9 +4,17 @@ import { QLabel } from './lib/QtWidgets/QLabel';
 import { QTreeWidget } from './lib/QtWidgets/QTreeWidget';
 import { QTreeWidgetItem } from './lib/QtWidgets/QTreeWidgetItem';
 import { QIcon } from './lib/QtGui/QIcon';
+import { QDesktopWidget } from './lib/QtWidgets/QDesktopWidget';
 
 const win = new QMainWindow();
 win.resize(500, 500);
+
+const desktop = new QDesktopWidget();
+const availableGeometry = desktop.availableGeometry();
+const screenGeometry = desktop.screenGeometry();
+console.log(availableGeometry.width() + 'x' + availableGeometry.height());
+console.log(screenGeometry.width() + 'x' + screenGeometry.height());
+console.log(desktop.screenNumber());
 
 const outer = new QWidget();
 const outerLayout = new QGridLayout();

--- a/src/lib/QtGui/QApplication.ts
+++ b/src/lib/QtGui/QApplication.ts
@@ -4,6 +4,7 @@ import { checkIfNativeElement } from '../utils/helpers';
 import { QClipboard } from './QClipboard';
 import { QStyle } from './QStyle';
 import { QObjectSignals, NodeObject } from '../QtCore/QObject';
+import { QDesktopWidget } from '../QtWidgets/QDesktopWidget';
 
 /**
  
@@ -63,6 +64,9 @@ export class QApplication extends NodeObject<QApplicationSignals> {
     }
     static style(): QStyle {
         return new QStyle(addon.QApplication.style());
+    }
+    static desktop(): QDesktopWidget {
+        return new QDesktopWidget();
     }
 }
 

--- a/src/lib/QtWidgets/QDesktopWidget.ts
+++ b/src/lib/QtWidgets/QDesktopWidget.ts
@@ -1,0 +1,29 @@
+import { QRect } from '../QtCore/QRect';
+import { NodeWidget, QWidgetSignals } from './QWidget';
+import { NativeElement } from '../core/Component';
+import addon from '../utils/addon';
+
+export type QDesktopWidgetSignals = QWidgetSignals;
+export class QDesktopWidget extends NodeWidget<QDesktopWidgetSignals> {
+    native: NativeElement;
+    constructor(parent?: NodeWidget<any>) {
+        let native;
+        if (parent) {
+            native = new addon.QDesktopWidget(parent.native);
+        } else {
+            native = new addon.QDesktopWidget();
+        }
+        super(native);
+        this.native = native;
+        this.nodeParent = parent;
+    }
+    availableGeometry(screen = -1): QRect {
+        return new QRect(this.native.availableGeometry(screen));
+    }
+    screenGeometry(screen = -1): QRect {
+        return new QRect(this.native.screenGeometry(screen));
+    }
+    screenNumber(): number {
+        return this.native.screenNumber();
+    }
+}

--- a/src/lib/QtWidgets/QDesktopWidget.ts
+++ b/src/lib/QtWidgets/QDesktopWidget.ts
@@ -3,6 +3,27 @@ import { NodeWidget, QWidgetSignals } from './QWidget';
 import { NativeElement } from '../core/Component';
 import addon from '../utils/addon';
 
+/**
+ 
+> QDesktopWidget is a class that provides access to screen information on multi-head systems..
+
+* **This class is a JS wrapper around Qt's [QDesktopWidget Class](https://doc.qt.io/qt-5/qdesktopwidget.html)**
+
+The QDesktopWidget class provides information about the user's desktop, such as its total size, number of screens, the geometry of each screen, and whether they are configured as separate desktops or a single virtual desktop.
+
+### Example
+
+```js
+const { QDesktopWidget } = require("@nodegui/nodegui");
+
+const desktop = new QDesktopWidget();
+const availableGeometry = desktop.availableGeometry();
+const screenGeometry = desktop.screenGeometry();
+console.log(availableGeometry.width() + 'x' + availableGeometry.height());
+console.log(screenGeometry.width() + 'x' + screenGeometry.height());
+console.log(desktop.screenNumber());
+```
+ */
 export type QDesktopWidgetSignals = QWidgetSignals;
 export class QDesktopWidget extends NodeWidget<QDesktopWidgetSignals> {
     native: NativeElement;


### PR DESCRIPTION
The is simple implement of qdesktop QDesktopWidget.

The api will work something like this (demo.ts example):

```
const desktop = new QDesktopWidget();
const availableGeometry = desktop.availableGeometry();
const screenGeometry = desktop.screenGeometry();
console.log(availableGeometry.width() + 'x' + availableGeometry.height());
console.log(screenGeometry.width() + 'x' + screenGeometry.height());
console.log(desktop.screenNumber());
```

or 

```
const qApp = QApplication.desktop()
const availableGeometry2 = qApp.availableGeometry();
const screenGeometry2 = qApp.screenGeometry();
console.log(availableGeometry2.width() + 'x' + availableGeometry2.height());
console.log(screenGeometry2.width() + 'x' + screenGeometry2.height());
console.log(qApp.screenNumber());
```

Obs : Test on windows and linux  and works as expected.