### PR TITLE
Add painter.drawPie method and fix painterPath.arcTo arguments

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QPainter/qpainter_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QPainter/qpainter_wrap.h
@@ -30,6 +30,8 @@ class DLL_EXPORT QPainterWrap : public Napi::ObjectWrap<QPainterWrap> {
   Napi::Value setRenderHint(const Napi::CallbackInfo& info);
   Napi::Value setBrush(const Napi::CallbackInfo& info);
   Napi::Value drawLine(const Napi::CallbackInfo& info);
+  Napi::Value drawEllipse(const Napi::CallbackInfo& info);
+  Napi::Value drawPie(const Napi::CallbackInfo& info);
   Napi::Value scale(const Napi::CallbackInfo& info);
   Napi::Value translate(const Napi::CallbackInfo& info);
   Napi::Value drawConvexPolygon(const Napi::CallbackInfo& info);

--- a/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
@@ -17,6 +17,8 @@ Napi::Object QPainterWrap::init(Napi::Env env, Napi::Object exports) {
       env, CLASSNAME,
       {InstanceMethod("drawText", &QPainterWrap::drawText),
        InstanceMethod("drawPath", &QPainterWrap::drawPath),
+       InstanceMethod("drawPie", &QPainterWrap::drawPie),
+       InstanceMethod("drawEllipse", &QPainterWrap::drawEllipse),
        InstanceMethod("strokePath", &QPainterWrap::strokePath),
        InstanceMethod("begin", &QPainterWrap::begin),
        InstanceMethod("end", &QPainterWrap::end),
@@ -134,6 +136,40 @@ Napi::Value QPainterWrap::setPen(const Napi::CallbackInfo& info) {
     QPen* pen = penWrap->getInternalInstance();
     this->instance->setPen(*pen);
   }
+  return env.Null();
+}
+Napi::Value QPainterWrap::drawEllipse(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  if (info.Length() < 4) {
+    Napi::TypeError::New(env, "Invalid number of arguments to drawEllipse")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  qreal x = info[0].As<Napi::Number>().DoubleValue();
+  qreal y = info[1].As<Napi::Number>().DoubleValue();
+  qreal width = info[2].As<Napi::Number>().DoubleValue();
+  qreal height = info[3].As<Napi::Number>().DoubleValue();
+  this->instance->drawEllipse(x, y, width, height);
+
+  return env.Null();
+}
+Napi::Value QPainterWrap::drawPie(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  if (info.Length() < 6) {
+    Napi::TypeError::New(env, "Invalid number of arguments to drawPie")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  qreal x = info[0].As<Napi::Number>().DoubleValue();
+  qreal y = info[1].As<Napi::Number>().DoubleValue();
+  qreal width = info[2].As<Napi::Number>().DoubleValue();
+  qreal height = info[3].As<Napi::Number>().DoubleValue();
+  qreal startAngle = info[4].As<Napi::Number>().DoubleValue();
+  qreal sweepLength = info[5].As<Napi::Number>().DoubleValue();
+  this->instance->drawPie(x, y, width, height, startAngle, sweepLength);
+
   return env.Null();
 }
 Napi::Value QPainterWrap::drawLine(const Napi::CallbackInfo& info) {

--- a/src/cpp/lib/QtWidgets/QPainterPath/qpainterpath_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPainterPath/qpainterpath_wrap.cpp
@@ -247,7 +247,7 @@ Napi::Value QPainterPathWrap::arcTo(const Napi::CallbackInfo& info) {
   qreal width = info[2].As<Napi::Number>().DoubleValue();
   qreal height = info[3].As<Napi::Number>().DoubleValue();
   qreal startAngle = info[4].As<Napi::Number>().DoubleValue();
-  qreal sweepLength = info[4].As<Napi::Number>().DoubleValue();
+  qreal sweepLength = info[5].As<Napi::Number>().DoubleValue();
   this->instance->arcTo(x, y, width, height, startAngle, sweepLength);
 
   return env.Null();

--- a/src/lib/QtWidgets/QPainter.ts
+++ b/src/lib/QtWidgets/QPainter.ts
@@ -93,6 +93,14 @@ export class QPainter extends Component {
         this.native.setRenderHint(hint, on);
     }
 
+    drawEllipse(x: number, y: number, width: number, height: number): void {
+        return this.native.drawEllipse(x, y, width, height);
+    }
+
+    drawPie(x: number, y: number, width: number, height: number, startAngle: number, sweepLength: number): void {
+        return this.native.drawPie(x, y, width, height, startAngle, sweepLength);
+    }
+
     drawLine(x1: number, y1: number, x2: number, y2: number): void {
         this.native.drawLine(x1, y1, x2, y2);
     }


### PR DESCRIPTION
## New Feature

### QPainter.drawPie

Was add QPainter.drawPie method found into QT QPainter class.

## Hotfix

### QPainterPath.arcTo

The wrapper is passing startAngle argument as sweepLength. Causing the wrong draw of arcs

These changes help me build it:
![image](https://user-images.githubusercontent.com/14454/103529494-afaa8a80-4e7d-11eb-8bc5-6d66bc1f433c.png)

![image](https://user-images.githubusercontent.com/14454/103836112-fcf64a00-507f-11eb-81f0-ec0b61b48fd4.png)


