### PR TITLE
QImage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 /.idea/
 /prebuilds
 miniqt
+cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(${CORE_WIDGETS_ADDON} SHARED
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QPicture/qpicture_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp"
+    "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QFont/qfont_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp"
     "${PROJECT_SOURCE_DIR}/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp"

--- a/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
@@ -18,6 +18,11 @@ class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
   static Napi::Object init(Napi::Env env, Napi::Object exports);
   QImageWrap(const Napi::CallbackInfo& info);
   ~QImageWrap();
+  QImage* getInternalInstance();
+
+  Napi::Value allGray(const Napi::CallbackInfo& info);
+  Napi::Value bitPlaneCount(const Napi::CallbackInfo& info);
+  Napi::Value bytesPeerLine(const Napi::CallbackInfo& info);
 };
 
 namespace StaticQImageWrapMethods {

--- a/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
@@ -35,6 +35,20 @@ class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
   Napi::Value dotsPerMeterY(const Napi::CallbackInfo& info);
   void fill(const Napi::CallbackInfo& info);
   Napi::Value format(const Napi::CallbackInfo& info);
+  Napi::Value hasAlphaChannel(const Napi::CallbackInfo& info);
+  Napi::Value height(const Napi::CallbackInfo& info);
+  void invertPixels(const Napi::CallbackInfo& info);
+  Napi::Value isGrayscale(const Napi::CallbackInfo& info);
+  Napi::Value isNull(const Napi::CallbackInfo& info);
+  Napi::Value load(const Napi::CallbackInfo& info);
+  Napi::Value loadFromData(const Napi::CallbackInfo& info);
+  Napi::Value mirrored(const Napi::CallbackInfo& info);
+  Napi::Value offset(const Napi::CallbackInfo& info);
+  Napi::Value pixelColor(const Napi::CallbackInfo& info);
+  Napi::Value pixelIndex(const Napi::CallbackInfo& info);
+  Napi::Value rect(const Napi::CallbackInfo& info);
+  Napi::Value reinterpretAsFormat(const Napi::CallbackInfo& info);
+  Napi::Value save(const Napi::CallbackInfo& info);
 };
 
 namespace StaticQImageWrapMethods {

--- a/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <napi.h>
+
+#include <QImage>
+
+#include "Extras/Export/export.h"
+#include "core/Component/component_macro.h"
+
+class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
+  COMPONENT_WRAPPED_METHODS_DECLARATION
+
+ private:
+  std::unique_ptr<QImage> instance;
+
+ public:
+  static Napi::FunctionReference constructor;
+  static Napi::Object init(Napi::Env env, Napi::Object exports);
+  QImageWrap(const Napi::CallbackInfo& info);
+  ~QImageWrap();
+};
+
+namespace StaticQImageWrapMethods {
+DLL_EXPORT Napi::Value fromQVariant(const Napi::CallbackInfo& info);
+}  // namespace StaticQImageWrapMethods

--- a/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
@@ -22,7 +22,7 @@ class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
 
   Napi::Value allGray(const Napi::CallbackInfo& info);
   Napi::Value bitPlaneCount(const Napi::CallbackInfo& info);
-  Napi::Value bytesPeerLine(const Napi::CallbackInfo& info);
+  Napi::Value bytesPerLine(const Napi::CallbackInfo& info);
 };
 
 namespace StaticQImageWrapMethods {

--- a/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
@@ -24,6 +24,8 @@ class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
   Napi::Value bitPlaneCount(const Napi::CallbackInfo& info);
   Napi::Value bytesPerLine(const Napi::CallbackInfo& info);
   Napi::Value cacheKey(const Napi::CallbackInfo& info);
+  Napi::Value color(const Napi::CallbackInfo& info);
+  Napi::Value colorCount(const Napi::CallbackInfo& info);
   void convertTo(const Napi::CallbackInfo& info);
   Napi::Value convertToFormat(const Napi::CallbackInfo& info);
   Napi::Value copy(const Napi::CallbackInfo& info);
@@ -49,6 +51,26 @@ class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
   Napi::Value rect(const Napi::CallbackInfo& info);
   Napi::Value reinterpretAsFormat(const Napi::CallbackInfo& info);
   Napi::Value save(const Napi::CallbackInfo& info);
+  Napi::Value scaled(const Napi::CallbackInfo& info);
+  Napi::Value scaledToHeight(const Napi::CallbackInfo& info);
+  Napi::Value scaledToWidth(const Napi::CallbackInfo& info);
+  void setAlphaChannel(const Napi::CallbackInfo& info);
+  void setColor(const Napi::CallbackInfo& info);
+  void setColorCount(const Napi::CallbackInfo& info);
+  void setDevicePixelRatio(const Napi::CallbackInfo& info);
+  void setDotsPerMeterX(const Napi::CallbackInfo& info);
+  void setDotsPerMeterY(const Napi::CallbackInfo& info);
+  void setOffset(const Napi::CallbackInfo& info);
+  void setPixel(const Napi::CallbackInfo& info);
+  void setPixelColor(const Napi::CallbackInfo& info);
+  void setText(const Napi::CallbackInfo& info);
+  Napi::Value size(const Napi::CallbackInfo& info);
+  Napi::Value sizeInBytes(const Napi::CallbackInfo& info);
+  void swap(const Napi::CallbackInfo& info);
+  Napi::Value text(const Napi::CallbackInfo& info);
+  Napi::Value textKeys(const Napi::CallbackInfo& info);
+  Napi::Value valid(const Napi::CallbackInfo& info);
+  Napi::Value width(const Napi::CallbackInfo& info);
 };
 
 namespace StaticQImageWrapMethods {

--- a/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QImage/qimage_wrap.h
@@ -23,6 +23,18 @@ class DLL_EXPORT QImageWrap : public Napi::ObjectWrap<QImageWrap> {
   Napi::Value allGray(const Napi::CallbackInfo& info);
   Napi::Value bitPlaneCount(const Napi::CallbackInfo& info);
   Napi::Value bytesPerLine(const Napi::CallbackInfo& info);
+  Napi::Value cacheKey(const Napi::CallbackInfo& info);
+  void convertTo(const Napi::CallbackInfo& info);
+  Napi::Value convertToFormat(const Napi::CallbackInfo& info);
+  Napi::Value copy(const Napi::CallbackInfo& info);
+  Napi::Value createAlphaMask(const Napi::CallbackInfo& info);
+  Napi::Value createHeuristicMask(const Napi::CallbackInfo& info);
+  Napi::Value depth(const Napi::CallbackInfo& info);
+  Napi::Value devicePixelRatio(const Napi::CallbackInfo& info);
+  Napi::Value dotsPerMeterX(const Napi::CallbackInfo& info);
+  Napi::Value dotsPerMeterY(const Napi::CallbackInfo& info);
+  void fill(const Napi::CallbackInfo& info);
+  Napi::Value format(const Napi::CallbackInfo& info);
 };
 
 namespace StaticQImageWrapMethods {

--- a/src/cpp/include/nodegui/QtGui/QPixmap/qpixmap_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QPixmap/qpixmap_wrap.h
@@ -26,6 +26,7 @@ class DLL_EXPORT QPixmapWrap : public Napi::ObjectWrap<QPixmapWrap> {
   Napi::Value scaled(const Napi::CallbackInfo& info);
   Napi::Value height(const Napi::CallbackInfo& info);
   Napi::Value width(const Napi::CallbackInfo& info);
+  static Napi::Value fromImage(const Napi::CallbackInfo& info);
 };
 
 namespace StaticQPixmapWrapMethods {

--- a/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
+++ b/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
@@ -1,19 +1,33 @@
 #include "QtGui/QImage/qimage_wrap.h"
 
 #include "Extras/Utils/nutils.h"
+#include "QtCore/QRect/qrect_wrap.h"
 #include "QtCore/QSize/qsize_wrap.h"
+#include "QtGui/QColor/qcolor_wrap.h"
 
 Napi::FunctionReference QImageWrap::constructor;
 
 Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QImage";
-  Napi::Function func =
-      DefineClass(env, CLASSNAME,
-                  {InstanceMethod("allGray", &QImageWrap::allGray),
-                   InstanceMethod("bitPlaneCount", &QImageWrap::bitPlaneCount),
-                   InstanceMethod("bytesPerLine", &QImageWrap::bytesPerLine),
-                   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
+  Napi::Function func = DefineClass(
+      env, CLASSNAME,
+      {InstanceMethod("allGray", &QImageWrap::allGray),
+       InstanceMethod("bitPlaneCount", &QImageWrap::bitPlaneCount),
+       InstanceMethod("bytesPerLine", &QImageWrap::bytesPerLine),
+       InstanceMethod("cacheKey", &QImageWrap::cacheKey),
+       InstanceMethod("convertTo", &QImageWrap::convertTo),
+       InstanceMethod("convertToFormat", &QImageWrap::convertToFormat),
+       InstanceMethod("copy", &QImageWrap::copy),
+       InstanceMethod("createAlphaMask", &QImageWrap::createAlphaMask),
+       InstanceMethod("createHeuristicMask", &QImageWrap::createHeuristicMask),
+       InstanceMethod("depth", &QImageWrap::depth),
+       InstanceMethod("devicePixelRatio", &QImageWrap::devicePixelRatio),
+       InstanceMethod("dotsPerMeterX", &QImageWrap::dotsPerMeterX),
+       InstanceMethod("dotsPerMeterY", &QImageWrap::dotsPerMeterY),
+       InstanceMethod("fill", &QImageWrap::fill),
+       InstanceMethod("format", &QImageWrap::format),
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -26,9 +40,12 @@ QImageWrap::QImageWrap(const Napi::CallbackInfo& info)
 
   if (info.Length() == 0) {
     this->instance = std::make_unique<QImage>();
-  } else if (info.Length() == 1) {
+  } else if (info.Length() == 1 && info[0].IsString()) {
     QString filename(info[0].As<Napi::String>().Utf8Value().c_str());
     this->instance = std::make_unique<QImage>(filename);
+  } else if (info.Length() == 1 && info[0].IsExternal()) {
+    this->instance =
+        std::unique_ptr<QImage>(info[0].As<Napi::External<QImage>>().Data());
   } else if (info.Length() == 3) {
     int32_t width = info[0].As<Napi::Number>();
     int32_t height = info[1].As<Napi::Number>();
@@ -67,4 +84,136 @@ Napi::Value QImageWrap::bytesPerLine(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->bytesPerLine());
+}
+
+Napi::Value QImageWrap::cacheKey(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Number::New(env, instance->cacheKey());
+}
+
+void QImageWrap::convertTo(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  QImage::Format format =
+      static_cast<QImage::Format>(info[0].As<Napi::Number>().Int32Value());
+  Qt::ImageConversionFlag conversionFlags =
+      static_cast<Qt::ImageConversionFlag>(
+          info[1].As<Napi::Number>().Int32Value());
+  this->instance->convertTo(format, conversionFlags);
+}
+
+Napi::Value QImageWrap::convertToFormat(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  QImage::Format format =
+      static_cast<QImage::Format>(info[0].As<Napi::Number>().Int32Value());
+  Qt::ImageConversionFlag conversionFlags =
+      static_cast<Qt::ImageConversionFlag>(
+          info[1].As<Napi::Number>().Int32Value());
+  auto img = this->instance->convertToFormat(format, conversionFlags);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(img))});
+  return instance;
+}
+
+Napi::Value QImageWrap::copy(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  if (info.Length() == 1) {
+    QRect* rect =
+        Napi::ObjectWrap<QRectWrap>::Unwrap(info[0].As<Napi::Object>())
+            ->getInternalInstance();
+    QImage img = this->instance->copy(*rect);
+    auto instance = QImageWrap::constructor.New(
+        {Napi::External<QImage>::New(env, new QImage(img))});
+    return instance;
+  }
+
+  int64_t x = info[0].As<Napi::Number>();
+  int64_t y = info[1].As<Napi::Number>();
+  int64_t width = info[2].As<Napi::Number>();
+  int64_t height = info[3].As<Napi::Number>();
+  QImage img = this->instance->copy(x, y, width, height);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(img))});
+  return instance;
+}
+
+Napi::Value QImageWrap::createAlphaMask(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  Qt::ImageConversionFlags flags = static_cast<Qt::ImageConversionFlags>(
+      info[0].As<Napi::Number>().Int32Value());
+  QImage img = this->instance->createAlphaMask(flags);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(img))});
+  return instance;
+}
+
+Napi::Value QImageWrap::createHeuristicMask(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  bool clipTight = info[0].As<Napi::Boolean>();
+  QImage img = this->instance->createHeuristicMask(clipTight);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(img))});
+  img.save(QString("test.png"));
+  return instance;
+}
+
+Napi::Value QImageWrap::depth(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Number::New(env, instance->depth());
+  ;
+}
+
+Napi::Value QImageWrap::devicePixelRatio(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Number::New(env, instance->devicePixelRatio());
+  ;
+}
+
+Napi::Value QImageWrap::dotsPerMeterX(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Number::New(env, instance->dotsPerMeterX());
+  ;
+}
+
+Napi::Value QImageWrap::dotsPerMeterY(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Number::New(env, instance->dotsPerMeterY());
+  ;
+}
+
+void QImageWrap::fill(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info[0].IsObject()) {
+    QColor* color =
+        Napi::ObjectWrap<QColorWrap>::Unwrap(info[0].As<Napi::Object>())
+            ->getInternalInstance();
+    this->instance->fill(*color);
+    return;
+  }
+
+  int32_t color = info[0].As<Napi::Number>();
+  this->instance->fill(static_cast<Qt::GlobalColor>(color));
+}
+
+Napi::Value QImageWrap::format(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Number::New(env, this->instance->format());
 }

--- a/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
+++ b/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
@@ -12,7 +12,7 @@ Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
       DefineClass(env, CLASSNAME,
                   {InstanceMethod("allGray", &QImageWrap::allGray),
                    InstanceMethod("bitPlaneCount", &QImageWrap::bitPlaneCount),
-                   InstanceMethod("bytesPeerLine", &QImageWrap::bytesPeerLine),
+                   InstanceMethod("bytesPerLine", &QImageWrap::bytesPerLine),
                    COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -63,7 +63,7 @@ Napi::Value QImageWrap::bitPlaneCount(const Napi::CallbackInfo& info) {
   return Napi::Number::New(env, instance->bitPlaneCount());
 }
 
-Napi::Value QImageWrap::bytesPeerLine(const Napi::CallbackInfo& info) {
+Napi::Value QImageWrap::bytesPerLine(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->bytesPerLine());

--- a/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
+++ b/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
@@ -2,6 +2,7 @@
 
 #include "Extras/Utils/nutils.h"
 #include "QtCore/QPoint/qpoint_wrap.h"
+#include "QtCore/QVariant/qvariant_wrap.h"
 #include "QtCore/QRect/qrect_wrap.h"
 #include "QtCore/QSize/qsize_wrap.h"
 #include "QtGui/QColor/qcolor_wrap.h"
@@ -17,6 +18,8 @@ Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("bitPlaneCount", &QImageWrap::bitPlaneCount),
        InstanceMethod("bytesPerLine", &QImageWrap::bytesPerLine),
        InstanceMethod("cacheKey", &QImageWrap::cacheKey),
+       InstanceMethod("color", &QImageWrap::color),
+       InstanceMethod("colorCount", &QImageWrap::colorCount),
        InstanceMethod("convertTo", &QImageWrap::convertTo),
        InstanceMethod("convertToFormat", &QImageWrap::convertToFormat),
        InstanceMethod("copy", &QImageWrap::copy),
@@ -42,6 +45,26 @@ Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("rect", &QImageWrap::rect),
        InstanceMethod("reinterpretAsFormat", &QImageWrap::reinterpretAsFormat),
        InstanceMethod("save", &QImageWrap::save),
+       InstanceMethod("scaled", &QImageWrap::scaled),
+       InstanceMethod("scaledToHeight", &QImageWrap::scaledToHeight),
+       InstanceMethod("scaledToWidth", &QImageWrap::scaledToWidth),
+       InstanceMethod("setAlphaChannel", &QImageWrap::setAlphaChannel),
+       InstanceMethod("setColor", &QImageWrap::setColor),
+       InstanceMethod("setColorCount", &QImageWrap::setColorCount),
+       InstanceMethod("setDevicePixelRatio", &QImageWrap::setDevicePixelRatio),
+       InstanceMethod("setDotsPerMeterX", &QImageWrap::setDotsPerMeterX),
+       InstanceMethod("setDotsPerMeterY", &QImageWrap::setDotsPerMeterY),
+       InstanceMethod("setOffset", &QImageWrap::setOffset),
+       InstanceMethod("setPixel", &QImageWrap::setPixel),
+       InstanceMethod("setPixelColor", &QImageWrap::setPixelColor),
+       InstanceMethod("setText", &QImageWrap::setText),
+       InstanceMethod("size", &QImageWrap::size),
+       InstanceMethod("sizeInBytes", &QImageWrap::sizeInBytes),
+       InstanceMethod("swap", &QImageWrap::swap),
+       InstanceMethod("text", &QImageWrap::text),
+       InstanceMethod("textKeys", &QImageWrap::textKeys),
+       InstanceMethod("valid", &QImageWrap::valid),
+       InstanceMethod("width", &QImageWrap::width),
        COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -105,6 +128,19 @@ Napi::Value QImageWrap::cacheKey(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->cacheKey());
+}
+
+Napi::Value QImageWrap::color(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  int64_t i = info[0].As<Napi::Number>();
+  return Napi::Number::New(env, instance->color(i));
+}
+
+Napi::Value QImageWrap::colorCount(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Number::New(env, instance->colorCount());
 }
 
 void QImageWrap::convertTo(const Napi::CallbackInfo& info) {
@@ -398,4 +434,264 @@ Napi::Value QImageWrap::save(const Napi::CallbackInfo& info) {
                format.IsNull() ? nullptr
                                : format.As<Napi::String>().Utf8Value().c_str(),
                quality));
+}
+
+Napi::Value QImageWrap::scaled(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() == 3) {
+    QSize* size =
+        Napi::ObjectWrap<QSizeWrap>::Unwrap(info[0].As<Napi::Object>())
+            ->getInternalInstance();
+    Qt::AspectRatioMode aspectRatioMode = static_cast<Qt::AspectRatioMode>(
+        info[1].As<Napi::Number>().Int32Value());
+    Qt::TransformationMode transformMode = static_cast<Qt::TransformationMode>(
+        info[2].As<Napi::Number>().Int32Value());
+    QImage image =
+        this->instance->scaled(*size, aspectRatioMode, transformMode);
+    auto instance = QImageWrap::constructor.New(
+        {Napi::External<QImage>::New(env, new QImage(image))});
+    return instance;
+  }
+
+  int64_t width = info[0].As<Napi::Number>();
+  int64_t height = info[1].As<Napi::Number>();
+  Qt::AspectRatioMode aspectRatioMode =
+      static_cast<Qt::AspectRatioMode>(info[2].As<Napi::Number>().Int32Value());
+  Qt::TransformationMode transformMode = static_cast<Qt::TransformationMode>(
+      info[3].As<Napi::Number>().Int32Value());
+  QImage image =
+      this->instance->scaled(width, height, aspectRatioMode, transformMode);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(image))});
+  return instance;
+}
+
+Napi::Value QImageWrap::scaledToHeight(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t height = info[0].As<Napi::Number>();
+  Qt::TransformationMode mode = static_cast<Qt::TransformationMode>(
+      info[1].As<Napi::Number>().Int32Value());
+  QImage image = this->instance->scaledToHeight(height, mode);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(image))});
+  return instance;
+}
+
+Napi::Value QImageWrap::scaledToWidth(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t width = info[0].As<Napi::Number>();
+  Qt::TransformationMode mode = static_cast<Qt::TransformationMode>(
+      info[1].As<Napi::Number>().Int32Value());
+  QImage image = this->instance->scaledToWidth(width, mode);
+  auto instance = QImageWrap::constructor.New(
+      {Napi::External<QImage>::New(env, new QImage(image))});
+  return instance;
+}
+
+void QImageWrap::setAlphaChannel(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QImage* image =
+      Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())
+          ->getInternalInstance();
+  this->instance->setAlphaChannel(*image);
+}
+
+void QImageWrap::setColor(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t index = info[0].As<Napi::Number>();
+  int64_t colorValue = info[1].As<Napi::Number>();
+  this->instance->setColor(index, colorValue);
+}
+
+void QImageWrap::setColorCount(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t colorCount = info[0].As<Napi::Number>();
+  this->instance->setColorCount(colorCount);
+}
+
+void QImageWrap::setDevicePixelRatio(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t scaleFactor = info[0].As<Napi::Number>();
+  this->instance->setDevicePixelRatio(scaleFactor);
+}
+
+void QImageWrap::setDotsPerMeterX(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t x = info[0].As<Napi::Number>();
+  this->instance->setDotsPerMeterX(x);
+}
+
+void QImageWrap::setDotsPerMeterY(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int64_t y = info[0].As<Napi::Number>();
+  this->instance->setDotsPerMeterY(y);
+}
+
+void QImageWrap::setOffset(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QPoint* offset =
+      Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
+          ->getInternalInstance();
+  this->instance->setOffset(*offset);
+}
+
+void QImageWrap::setPixel(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() == 2) {
+    QPoint* position =
+        Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
+            ->getInternalInstance();
+    int64_t index_or_rgb = info[1].As<Napi::Number>();
+    this->instance->setPixel(*position, index_or_rgb);
+    return;
+  }
+
+  int64_t x = info[0].As<Napi::Number>();
+  int64_t y = info[1].As<Napi::Number>();
+  int64_t index_or_rgb = info[2].As<Napi::Number>();
+  this->instance->setPixel(x, y, index_or_rgb);
+}
+
+void QImageWrap::setPixelColor(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() == 2) {
+    QPoint* position =
+        Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
+            ->getInternalInstance();
+    QColor* color =
+        Napi::ObjectWrap<QColorWrap>::Unwrap(info[1].As<Napi::Object>())
+            ->getInternalInstance();
+    this->instance->setPixelColor(*position, *color);
+    return;
+  }
+
+  int64_t x = info[0].As<Napi::Number>();
+  int64_t y = info[1].As<Napi::Number>();
+  QColor* color =
+      Napi::ObjectWrap<QColorWrap>::Unwrap(info[2].As<Napi::Object>())
+          ->getInternalInstance();
+  this->instance->setPixelColor(x, y, *color);
+}
+
+void QImageWrap::setText(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QString key(info[0].As<Napi::String>().Utf8Value().c_str());
+  QString value(info[1].As<Napi::String>().Utf8Value().c_str());
+  this->instance->setText(key, value);
+}
+
+Napi::Value QImageWrap::size(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QSize size = this->instance->size();
+  auto instance = QSizeWrap::constructor.New(
+      {Napi::External<QSize>::New(env, new QSize(size))});
+  return instance;
+}
+
+Napi::Value QImageWrap::sizeInBytes(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Number::New(env, this->instance->sizeInBytes());
+}
+
+void QImageWrap::swap(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QImage* image =
+      Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())
+          ->getInternalInstance();
+  this->instance->swap(*image);
+}
+
+Napi::Value QImageWrap::text(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QString key =
+      this->instance->text(info[0].As<Napi::String>().Utf8Value().c_str());
+  return Napi::String::New(env, key.toUtf8().constData());
+}
+
+Napi::Value QImageWrap::textKeys(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QStringList keys = this->instance->textKeys();
+  Napi::Array js_array = Napi::Array::New(env, keys.size());
+
+  for (int i = 0; i < keys.size(); i++) {
+    Napi::Value value = Napi::String::New(env, keys.at(i).toUtf8().constData());
+    js_array[i] = value;
+  }
+
+  return js_array;
+}
+
+Napi::Value QImageWrap::valid(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() == 1) {
+    QPoint* point =
+        Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
+            ->getInternalInstance();
+    return Napi::Boolean::New(env, this->instance->valid(*point));
+  }
+
+  int64_t x = info[0].As<Napi::Number>();
+  int64_t y = info[1].As<Napi::Number>();
+
+  return Napi::Boolean::New(env, this->instance->valid(x, y));
+}
+
+Napi::Value QImageWrap::width(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Number::New(env, this->instance->width());
+}
+
+
+Napi::Value StaticQImageWrapMethods::fromQVariant(                                                                                                                   
+    const Napi::CallbackInfo& info) {                                                                                                                                 
+  Napi::Env env = info.Env();                                                                                                                                         
+  Napi::HandleScope scope(env);                                                                                                                                       
+  Napi::Object variantObject = info[0].As<Napi::Object>();                                                                                                            
+  QVariantWrap* variantWrap =                                                                                                                                         
+    Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);                                                                                                          
+  QVariant* variant = variantWrap->getInternalInstance();                                                                                                             
+  QImage image = variant->value<QImage>();                                                                                                                         
+  auto instance = QImageWrap::constructor.New(                                                                                                                       
+      {Napi::External<QImage>::New(env, new QImage(image))});                                                                                                      
+  return instance;                                                                                                                                                    
 }

--- a/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
+++ b/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
@@ -1,15 +1,70 @@
 #include "QtGui/QImage/qimage_wrap.h"
 
 #include "Extras/Utils/nutils.h"
+#include "QtCore/QSize/qsize_wrap.h"
 
 Napi::FunctionReference QImageWrap::constructor;
 
 Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QImage";
-  Napi::Function func = DefineClass(
-      env, CLASSNAME, {COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
+  Napi::Function func =
+      DefineClass(env, CLASSNAME,
+                  {InstanceMethod("allGray", &QImageWrap::allGray),
+                   InstanceMethod("bitPlaneCount", &QImageWrap::bitPlaneCount),
+                   InstanceMethod("bytesPeerLine", &QImageWrap::bytesPeerLine),
+                   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
+}
+
+QImageWrap::QImageWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<QImageWrap>(info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  if (info.Length() == 0) {
+    this->instance = std::make_unique<QImage>();
+  } else if (info.Length() == 1) {
+    QString filename(info[0].As<Napi::String>().Utf8Value().c_str());
+    this->instance = std::make_unique<QImage>(filename);
+  } else if (info.Length() == 3) {
+    int32_t width = info[0].As<Napi::Number>();
+    int32_t height = info[1].As<Napi::Number>();
+    QImage::Format format =
+        static_cast<QImage::Format>(info[2].As<Napi::Number>().Int32Value());
+    this->instance = std::make_unique<QImage>(width, height, format);
+  } else if (info.Length() == 2) {
+    QSizeWrap* size =
+        Napi::ObjectWrap<QSizeWrap>::Unwrap(info[0].As<Napi::Object>());
+    QImage::Format format =
+        static_cast<QImage::Format>(info[1].As<Napi::Number>().Int32Value());
+    this->instance =
+        std::make_unique<QImage>(*(size->getInternalInstance()), format);
+  } else {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+  }
+}
+
+QImageWrap::~QImageWrap() { this->instance.reset(); }
+QImage* QImageWrap::getInternalInstance() { return this->instance.get(); }
+
+Napi::Value QImageWrap::allGray(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Boolean::New(env, instance->allGray());
+}
+
+Napi::Value QImageWrap::bitPlaneCount(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Number::New(env, instance->bitPlaneCount());
+}
+
+Napi::Value QImageWrap::bytesPeerLine(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Number::New(env, instance->bytesPerLine());
 }

--- a/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
+++ b/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
@@ -1,0 +1,15 @@
+#include "QtGui/QImage/qimage_wrap.h"
+
+#include "Extras/Utils/nutils.h"
+
+Napi::FunctionReference QImageWrap::constructor;
+
+Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  char CLASSNAME[] = "QImage";
+  Napi::Function func = DefineClass(
+      env, CLASSNAME, {COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QImageWrap)});
+  constructor = Napi::Persistent(func);
+  exports.Set(CLASSNAME, func);
+  return exports;
+}

--- a/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
@@ -149,10 +149,13 @@ Napi::Value QPixmapWrap::fromImage(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  QImage* img = Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())->getInternalInstance();
-  Qt::ImageConversionFlags flags = static_cast<Qt::ImageConversionFlags>(info[1].As<Napi::Number>().Int32Value());
+  QImage* img = Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())
+                    ->getInternalInstance();
+  Qt::ImageConversionFlags flags = static_cast<Qt::ImageConversionFlags>(
+      info[1].As<Napi::Number>().Int32Value());
   QPixmap pixmap = QPixmap::fromImage(*img, flags);
-  auto instance = QPixmapWrap::constructor.New({ Napi::External<QPixmap>::New(env, new QPixmap(pixmap) )});
+  auto instance = QPixmapWrap::constructor.New(
+      {Napi::External<QPixmap>::New(env, new QPixmap(pixmap))});
   return instance;
 }
 

--- a/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
@@ -2,6 +2,7 @@
 
 #include "Extras/Utils/nutils.h"
 #include "QtCore/QVariant/qvariant_wrap.h"
+#include "QtGui/QImage/qimage_wrap.h"
 
 Napi::FunctionReference QPixmapWrap::constructor;
 
@@ -16,6 +17,7 @@ Napi::Object QPixmapWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("scaled", &QPixmapWrap::scaled),
        InstanceMethod("height", &QPixmapWrap::height),
        InstanceMethod("width", &QPixmapWrap::width),
+       StaticMethod("fromImage", &QPixmapWrap::fromImage),
        StaticMethod("fromQVariant", &StaticQPixmapWrapMethods::fromQVariant),
        COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QPixmapWrap)});
   constructor = Napi::Persistent(func);
@@ -141,6 +143,17 @@ Napi::Value QPixmapWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->width());
+}
+
+Napi::Value QPixmapWrap::fromImage(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  QImage* img = Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())->getInternalInstance();
+  Qt::ImageConversionFlags flags = static_cast<Qt::ImageConversionFlags>(info[1].As<Napi::Number>().Int32Value());
+  QPixmap pixmap = QPixmap::fromImage(*img, flags);
+  auto instance = QPixmapWrap::constructor.New({ Napi::External<QPixmap>::New(env, new QPixmap(pixmap) )});
+  return instance;
 }
 
 Napi::Value StaticQPixmapWrapMethods::fromQVariant(

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -32,6 +32,7 @@
 #include "QtGui/QFont/qfont_wrap.h"
 #include "QtGui/QFontDatabase/qfontdatabase_wrap.h"
 #include "QtGui/QIcon/qicon_wrap.h"
+#include "QtGui/QImage/qimage_wrap.h"
 #include "QtGui/QKeySequence/qkeysequence_wrap.h"
 #include "QtGui/QMovie/qmovie_wrap.h"
 #include "QtGui/QPen/qpen_wrap.h"
@@ -137,6 +138,7 @@ Napi::Object Main(Napi::Env env, Napi::Object exports) {
   QKeySequenceWrap::init(env, exports);
   QFontDatabaseWrap::init(env, exports);
   QIconWrap::init(env, exports);
+  QImageWrap::init(env, exports);
   QFontWrap::init(env, exports);
   QMovieWrap::init(env, exports);
   QStyleWrap::init(env, exports);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { QKeySequence } from './lib/QtGui/QKeySequence';
 export { QPicture } from './lib/QtGui/QPicture';
 export { QPixmap, ImageFormats } from './lib/QtGui/QPixmap';
 export { QIcon, QIconMode, QIconState } from './lib/QtGui/QIcon';
+export { QImage } from './lib/QtGui/QImage';
 export { QFont, QFontCapitalization, QFontStretch, QFontWeight } from './lib/QtGui/QFont';
 export { QMovie, CacheMode, MovieState } from './lib/QtGui/QMovie';
 export { QCursor } from './lib/QtGui/QCursor';

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -8,13 +8,36 @@ import { QPoint } from '../QtCore/QPoint';
 import { QVariant } from '../QtCore/QVariant';
 import { QColor } from '../QtGui/QColor';
 
+/**
+
+> The QImage class provides a hardware-independent image representation that
+  allows direct access to the pixel data, and can be used as a paint device.
+
+* **This class is a JS wrapper around Qt's [QImage class](https://doc.qt.io/qt-5/qimage.html)**
+
+### Example
+
+```javascript
+const { QImage } = require('@nodegui/nodegui');
+
+const image = new QImage();
+```
+ */
 export class QImage extends Component {
     native!: NativeElement;
 
+    /** Constructs a null image */
     constructor();
+
     constructor(native: NativeElement);
+
+    /** Constructs an image and tries to load the image from the file with the given fileName */
     constructor(filename: string);
+
+    /** Constructs an image with the given width, height and format */
     constructor(width: number, height: number, format: QImageFormat);
+
+    /** Constructs an image with the given size and format */
     constructor(size: QSize, format: QImageFormat);
     constructor(
         arg?: QImage | NativeElement | QSize | string | number,
@@ -36,39 +59,57 @@ export class QImage extends Component {
         }
     }
 
+    /**
+     * Returns true if all the colors in the image are shades of gray (i.e. their
+     * red, green and blue components are equal); otherwise false
+     */
     allGray(): boolean {
         return this.native.allGray();
     }
 
+    /** Returns the number of bit planes in the image */
     bitPlaneCount(): number {
         return this.native.bitPlaneCount();
     }
 
+    /** Returns the number of bytes per image scanline */
     bytesPerLine(): number {
         return this.native.bytesPerLine();
     }
 
+    /**
+     * Returns a number that identifies the contents of this QImage object. Distinct
+     * QImage objects can only have the same key if they refer to the same contents
+     */
     cacheKey(): number {
         return this.native.cacheKey();
     }
 
+    /**
+     * Returns the color in the color table at index i. The first color is at index 0
+     */
     color(i: number): number {
         return this.native.color(i);
     }
 
+    /** Returns the size of the color table for the image */
     colorCount(): number {
         return this.native.colorCount();
     }
 
+    /** Detach and convert the image to the given format in place */
     convertTo(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor): void {
         this.native.convertTo(format, flags);
     }
 
+    /** Returns a copy of the image in the given format */
     convertToFormat(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor): QImage {
         return new QImage(this.native.convertToFormat(format, flags));
     }
 
+    /** Returns a sub-area of the image as a new image */
     copy(rectangle: QRect): QImage;
+    /** This is an overloaded function */
     copy(x: number, y: number, width: number, height: number): QImage;
     copy(rectangleOrX: QRect | number, y?: number, width?: number, height?: number): QImage {
         if (rectangleOrX instanceof QRect) {
@@ -78,78 +119,122 @@ export class QImage extends Component {
         return new QImage(this.native.copy(rectangleOrX, y, width, height));
     }
 
+    /**
+     * Builds and returns a 1-bpp mask from the alpha buffer in this image. Returns
+     * a null image if the image's format is QImageFormat::Format_RGB32
+     */
     createAlphaMask(flags: ImageConversionFlag = ImageConversionFlag.AutoColor): QImage {
         return new QImage(this.native.createAlphaMask(flags));
     }
 
+    /** Creates and returns a 1-bpp heuristic mask for this image */
     createHeuristicMask(clipTight = true): QImage {
         return new QImage(this.native.createHeuristicMask(clipTight));
     }
 
+    /** Returns the depth of the image */
     depth(): number {
         return this.native.depth();
     }
 
+    /**
+     * Returns the device pixel ratio for the image. This is the ratio
+     * between device pixels and device independent pixels.
+     */
     devicePixelRatio(): number {
         return this.native.devicePixelRatio();
     }
 
+    /**
+     * Returns the number of pixels that fit horizontally in a physical meter. Together
+     * with dotsPerMeterY(), this number defines the intended scale and aspect ratio of
+     * the image
+     */
     dotsPerMeterX(): number {
         return this.native.dotsPerMeterX();
     }
 
+    /**
+     * Returns the number of pixels that fit vertically in a physical meter. Together with
+     * dotsPerMeterX(), this number defines the intended scale and aspect ratio of the image
+     */
     dotsPerMeterY(): number {
         return this.native.dotsPerMeterY();
     }
 
+    /** Fills the entire image with the given color */
     fill(color: QColor | GlobalColor): void {
         this.native.fill(color instanceof QColor ? color.native : color);
     }
 
+    /** Returns the format of the image */
     format(): QImageFormat {
         return this.native.format();
     }
 
+    /**
+     * Returns true if the image has a format that respects the alpha channel, otherwise
+     * returns false
+     */
     hasAlphaChannel(): boolean {
         return this.native.hasAlphaChannel();
     }
 
+    /** Returns the height of the image */
     height(): number {
         return this.native.height();
     }
 
+    /** Inverts all pixel values in the image */
     // eslint-disable-next-line
     invertPixels(mode: QImageInvertMode = QImageInvertMode.InvertRgb): void {
         this.native.invertPixels(mode);
     }
 
+    /** For 32-bit images, this function is equivalent to allGray() */
     isGrayscale(): boolean {
         return this.native.isGrayscale();
     }
 
+    /** Returns true if it is a null image, otherwise returns false */
     isNull(): boolean {
         return this.native.isNull();
     }
 
+    /**
+     * Loads an image from the file with the given fileName. Returns true if the image was
+     * successfully loaded; otherwise invalidates the image and returns false
+     */
     load(fileName: string, format: string | null = null): boolean {
         return this.native.load(fileName, format);
     }
 
+    /** Loads an image from the specified buffer */
     loadFromData(data: Buffer, format: string | null = null): boolean {
         return this.native.loadFromData(data, format);
     }
 
+    /**
+     * Returns a mirror of the image, mirrored in the horizontal and/or the vertical direction
+     * depending on whether horizontal and vertical are set to true or false
+     */
     mirrored(horizontal = false, vertical = true): QImage {
         const native = this.native.mirrored(horizontal, vertical);
         return new QImage(native);
     }
 
+    /**
+     * Returns the number of pixels by which the image is intended to be offset by when
+     * positioning relative to other images
+     */
     offset(): QPoint {
         const native = this.native.offset();
         return new QPoint(native);
     }
 
+    /** Returns the color of the pixel at the given position as a QColor */
     pixelColor(point: QPoint): QColor;
+    /** Returns the color of the pixel at coordinates (x, y) as a QColor  */
     pixelColor(x: number, y: number): QColor;
     pixelColor(pointOrX: QPoint | number, y?: number): QColor {
         const native =
@@ -157,28 +242,48 @@ export class QImage extends Component {
         return new QColor(native);
     }
 
+    /** Returns the pixel index at the given position */
     pixelIndex(point: QPoint): number;
+    /** Returns the pixel index at (x, y) */
     pixelIndex(x: number, y: number): number;
     pixelIndex(pointOrX: QPoint | number, y?: number): number {
         const pixelIndex =
             pointOrX instanceof QPoint ? this.native.pixelIndex(pointOrX.native) : this.native.pixelIndex(pointOrX, y);
         return pixelIndex;
     }
-
+    
+    /** Returns the enclosing rectangle (0, 0, width(), height()) of the image */
     rect(): QRect {
         const native = this.native.rect();
         return new QRect(native);
     }
 
+    /**
+     * Changes the format of the image to format without changing the data. Only works
+     * between formats of the same depth. Returns true if successful
+     */
     reinterpretAsFormat(format: QImageFormat): boolean {
         return this.native.reinterpretAsFormat(format);
     }
 
+    /**
+     * Saves the image to the file with the given fileName, using the given image file
+     * format and quality factor. If format is null, QImage will attempt to guess the
+     * format by looking at fileName's suffix.
+     */
     save(fileName: string, format: string | null = null, quality = -1): boolean {
         return this.native.save(fileName, format, quality);
     }
 
+    /**
+     * Returns a copy of the image scaled to a rectangle defined by the given size according
+     * to the given aspectRatioMode and transformMode.
+     */
     scaled(size: QSize, aspectRatioMode: AspectRatioMode, transformMode: TransformationMode): QImage;
+    /**
+     * Returns a copy of the image scaled to a rectangle with the given width and height
+     * according to the given aspectRatioMode and transformMode.
+     */
     scaled(width: number, height: number, aspectRatioMode: AspectRatioMode, transformMode: TransformationMode): QImage;
     scaled(
         sizeOrWidth: QSize | number,
@@ -195,45 +300,79 @@ export class QImage extends Component {
         return new QImage(native);
     }
 
+    /**
+     * Returns a scaled copy of the image. The returned image is scaled to the given height
+     * using the specified transformation mode
+     */
     scaledToHeight(height: number, mode: TransformationMode = TransformationMode.FastTransformation): QImage {
         const native = this.native.scaledToHeight(height, mode);
         return new QImage(native);
     }
 
+    /**
+     * Returns a scaled copy of the image. The returned image is scaled to the given width
+     * using the specified transformation mode
+     */
     scaledToWidth(width: number, mode: TransformationMode = TransformationMode.FastTransformation): QImage {
         const native = this.native.scaledToWidth(width, mode);
         return new QImage(native);
     }
 
+    /**
+     * Sets the alpha channel of this image to the given alphaChannel
+     */
     setAlphaChannel(alphaChannel: QImage): void {
         this.native.setAlphaChannel(alphaChannel.native);
     }
 
+    /**
+     * Sets the color at the given index in the color table, to the given to colorValue.
+     * The color value is an ARGB quadruplet
+     */
     setColor(index: number, colorValue: number): void {
         this.native.setColor(index, colorValue);
     }
 
+    /**
+     * Resizes the color table to contain colorCount entries
+     */
     setColorCount(colorCount: number): void {
         this.native.setColorCount(colorCount);
     }
 
+    /**
+     * Sets the device pixel ratio for the image. This is the ratio between image pixels
+     * and device-independent pixels
+     */
     setDevicePixelRatio(scaleFactory: number): void {
         this.native.setDevicePixelRatio(scaleFactory);
     }
 
+    /**
+     * Sets the number of pixels that fit horizontally in a physical meter, to x
+     */
     setDotsPerMeterX(x: number): void {
         this.native.setDotsPerMeterX(x);
     }
 
+    /**
+     * Sets the number of pixels that fit vertically in a physical meter, to y
+     */
     setDotsPerMeterY(y: number): void {
         this.native.setDotsPerMeterY(y);
     }
 
+    /**
+     * Sets the number of pixels by which the image is intended to be offset by
+     * when positioning relative to other images, to offset
+     */
     setOffset(offset: QPoint): void {
         this.native.setOffset(offset.native);
     }
 
+    /** Sets the pixel index or color at the given position to indexOrRgb */
     setPixel(position: QPoint, indexOrRgb: number): void;
+    /** Sets the pixel index or color at (x, y) to indexOrRgb */
     setPixel(x: number, y: number, indexOrRgb: number): void;
     setPixel(positionOrX: QPoint | number, indexOrRgbOrY: number, indexOrRgb?: number): void {
         if (positionOrX instanceof QPoint) {
@@ -243,7 +382,9 @@ export class QImage extends Component {
         this.native.setPixel(positionOrX, indexOrRgbOrY, indexOrRgb);
     }
 
+    /** Sets the color at the given position to color */
     setPixelColor(position: QPoint, color: QColor): void;
+    /** Sets the pixel color at (x, y) to color */
     setPixelColor(x: number, y: number, color: QColor): void;
     setPixelColor(positionOrX: QPoint | number, colorOrY: QColor | number, color?: QColor): void {
         if (positionOrX instanceof QPoint) {
@@ -253,32 +394,46 @@ export class QImage extends Component {
         this.native.setPixel(positionOrX, colorOrY, color!.native);
     }
 
+    /** Sets the image text to the given text and associate it with the given key */
     setText(key: string, value: string): void {
         this.native.setText(key, value);
     }
 
+    /** Returns the size of the image, i.e. its width() and height() */
     size(): QSize {
         const native = this.native.size();
         return new QSize(native);
     }
 
+    /** Returns the image data size in bytes */
     sizeInBytes(): number {
         return this.native.sizeInBytes();
     }
 
+    /** Swaps image other with this image. This operation is very fast and never fails */
     swap(other: QImage): void {
         this.native.swap(other.native);
     }
 
+    /**
+     * Returns the image text associated with the given key. If the specified key is an empty
+     * string, the whole image text is returned, with each key-text pair separated by a newline
+     */
     text(key: string): string {
         return this.native.text(key);
     }
 
+    /** Returns the text keys for this image */
     textKeys(): string[] {
         return this.native.textKeys();
     }
 
+    /** Returns true if pos is a valid coordinate pair within the image; otherwise returns false */
     valid(pos: QPoint): boolean;
+    /**
+     * Returns true if QPoint(x, y) is a valid coordinate pair within the image; otherwise returns
+     * false
+     */
     valid(x: number, y: number): boolean;
     valid(posOrX: QPoint | number, y?: number): boolean {
         if (posOrX instanceof QPoint) {
@@ -287,6 +442,7 @@ export class QImage extends Component {
         return this.native.valid(posOrX, y);
     }
 
+    /** Returns the width of the image */
     width(): number {
         return this.native.width();
     }

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -1,10 +1,11 @@
 import { Component, NativeElement } from '../core/Component';
 import { checkIfNativeElement } from '../utils/helpers';
 import addon from '../utils/addon';
-import { ImageConversionFlag, GlobalColor } from '../QtEnums';
+import { ImageConversionFlag, GlobalColor, AspectRatioMode, TransformationMode } from '../QtEnums';
 import { QSize } from '../QtCore/QSize';
 import { QRect } from '../QtCore/QRect';
 import { QPoint } from '../QtCore/QPoint';
+import { QVariant } from '../QtCore/QVariant';
 import { QColor } from '../QtGui/QColor';
 
 export class QImage extends Component {
@@ -49,6 +50,14 @@ export class QImage extends Component {
 
     cacheKey(): number {
         return this.native.cacheKey();
+    }
+
+    color(i: number): number {
+        return this.native.color(i);
+    }
+
+    colorCount(): number {
+        return this.native.colorCount();
     }
 
     convertTo(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor): void {
@@ -109,6 +118,7 @@ export class QImage extends Component {
         return this.native.height();
     }
 
+    // eslint-disable-next-line
     invertPixels(mode: QImageInvertMode = QImageInvertMode.InvertRgb): void {
         this.native.invertPixels(mode);
     }
@@ -164,8 +174,125 @@ export class QImage extends Component {
         return this.native.reinterpretAsFormat(format);
     }
 
-    save(fileName: string, format: string | null = null, quality: number = -1): boolean {
+    save(fileName: string, format: string | null = null, quality = -1): boolean {
         return this.native.save(fileName, format, quality);
+    }
+
+    scaled(size: QSize, aspectRatioMode: AspectRatioMode, transformMode: TransformationMode): QImage;
+    scaled(width: number, height: number, aspectRatioMode: AspectRatioMode, transformMode: TransformationMode): QImage;
+    scaled(
+        sizeOrWidth: QSize | number,
+        modeOrHeight: any,
+        transformOrAspectRatioMode: any,
+        transformMode?: any,
+    ): QImage {
+        let native;
+        if (sizeOrWidth instanceof QSize) {
+            native = this.native.scaled(sizeOrWidth.native, modeOrHeight, transformOrAspectRatioMode);
+        } else {
+            native = this.native.scaled(sizeOrWidth, modeOrHeight, transformOrAspectRatioMode, transformMode);
+        }
+        return new QImage(native);
+    }
+
+    scaledToHeight(height: number, mode: TransformationMode = TransformationMode.FastTransformation): QImage {
+        const native = this.native.scaledToHeight(height, mode);
+        return new QImage(native);
+    }
+
+    scaledToWidth(width: number, mode: TransformationMode = TransformationMode.FastTransformation): QImage {
+        const native = this.native.scaledToWidth(width, mode);
+        return new QImage(native);
+    }
+
+    setAlphaChannel(alphaChannel: QImage): void {
+        this.native.setAlphaChannel(alphaChannel.native);
+    }
+
+    setColor(index: number, colorValue: number): void {
+        this.native.setColor(index, colorValue);
+    }
+
+    setColorCount(colorCount: number): void {
+        this.native.setColorCount(colorCount);
+    }
+
+    setDevicePixelRatio(scaleFactory: number): void {
+        this.native.setDevicePixelRatio(scaleFactory);
+    }
+
+    setDotsPerMeterX(x: number): void {
+        this.native.setDotsPerMeterX(x);
+    }
+
+    setDotsPerMeterY(y: number): void {
+        this.native.setDotsPerMeterY(y);
+    }
+
+    setOffset(offset: QPoint): void {
+        this.native.setOffset(offset.native);
+    }
+
+    setPixel(position: QPoint, indexOrRgb: number): void;
+    setPixel(x: number, y: number, indexOrRgb: number): void;
+    setPixel(positionOrX: QPoint | number, indexOrRgbOrY: number, indexOrRgb?: number): void {
+        if (positionOrX instanceof QPoint) {
+            this.native.setPixel(positionOrX.native, indexOrRgbOrY);
+            return;
+        }
+        this.native.setPixel(positionOrX, indexOrRgbOrY, indexOrRgb);
+    }
+
+    setPixelColor(position: QPoint, color: QColor): void;
+    setPixelColor(x: number, y: number, color: QColor): void;
+    setPixelColor(positionOrX: QPoint | number, colorOrY: QColor | number, color?: QColor): void {
+        if (positionOrX instanceof QPoint) {
+            this.native.setPixel(positionOrX.native, colorOrY);
+            return;
+        }
+        this.native.setPixel(positionOrX, colorOrY, color!.native);
+    }
+
+    setText(key: string, value: string): void {
+        this.native.setText(key, value);
+    }
+
+    size(): QSize {
+        const native = this.native.size();
+        return new QSize(native);
+    }
+
+    sizeInBytes(): number {
+        return this.native.sizeInBytes();
+    }
+
+    swap(other: QImage): void {
+        this.native.swap(other.native);
+    }
+
+    text(key: string): string {
+        return this.native.text(key);
+    }
+
+    textKeys(): string[] {
+        return this.native.textKeys();
+    }
+
+    valid(pos: QPoint): boolean;
+    valid(x: number, y: number): boolean;
+    valid(posOrX: QPoint | number, y?: number): boolean {
+        if (posOrX instanceof QPoint) {
+            return this.native.valid(posOrX.native);
+        }
+        return this.native.valid(posOrX, y);
+    }
+
+    width(): number {
+        return this.native.width();
+    }
+
+    static fromQVariant(variant: QVariant): QImage {
+        return new QImage(addon.QImage.fromQVariant(variant.native));
     }
 }
 

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -39,8 +39,8 @@ export class QImage extends Component {
         return this.native.bitPlaneCount();
     }
 
-    bytesPeerLine(): number {
-        return this.native.bytesPeerLine();
+    bytesPerLine(): number {
+        return this.native.bytesPerLine();
     }
 }
 

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -1,0 +1,9 @@
+import { Component, NativeElement } from '../core/Component';
+
+export class QImage extends Component {
+    native!: NativeElement;
+
+    constructor() {
+        super();
+    }
+}

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -1,9 +1,10 @@
 import { Component, NativeElement } from '../core/Component';
-import { QSize } from '../QtCore/QSize';
 import { checkIfNativeElement } from '../utils/helpers';
 import addon from '../utils/addon';
 import { ImageConversionFlag, GlobalColor } from '../QtEnums';
+import { QSize } from '../QtCore/QSize';
 import { QRect } from '../QtCore/QRect';
+import { QPoint } from '../QtCore/QPoint';
 import { QColor } from '../QtGui/QColor';
 
 export class QImage extends Component {
@@ -64,7 +65,7 @@ export class QImage extends Component {
         if (rectangleOrX instanceof QRect) {
             return new QImage(this.native.copy(rectangleOrX.native));
         }
-        // eslint-disable-next-line prefer-rest-params
+
         return new QImage(this.native.copy(rectangleOrX, y, width, height));
     }
 
@@ -99,6 +100,73 @@ export class QImage extends Component {
     format(): QImageFormat {
         return this.native.format();
     }
+
+    hasAlphaChannel(): boolean {
+        return this.native.hasAlphaChannel();
+    }
+
+    height(): number {
+        return this.native.height();
+    }
+
+    invertPixels(mode: QImageInvertMode = QImageInvertMode.InvertRgb): void {
+        this.native.invertPixels(mode);
+    }
+
+    isGrayscale(): boolean {
+        return this.native.isGrayscale();
+    }
+
+    isNull(): boolean {
+        return this.native.isNull();
+    }
+
+    load(fileName: string, format: string | null = null): boolean {
+        return this.native.load(fileName, format);
+    }
+
+    loadFromData(data: Buffer, format: string | null = null): boolean {
+        return this.native.loadFromData(data, format);
+    }
+
+    mirrored(horizontal = false, vertical = true): QImage {
+        const native = this.native.mirrored(horizontal, vertical);
+        return new QImage(native);
+    }
+
+    offset(): QPoint {
+        const native = this.native.offset();
+        return new QPoint(native);
+    }
+
+    pixelColor(point: QPoint): QColor;
+    pixelColor(x: number, y: number): QColor;
+    pixelColor(pointOrX: QPoint | number, y?: number): QColor {
+        const native =
+            pointOrX instanceof QPoint ? this.native.pixelColor(pointOrX.native) : this.native.pixelColor(pointOrX, y);
+        return new QColor(native);
+    }
+
+    pixelIndex(point: QPoint): number;
+    pixelIndex(x: number, y: number): number;
+    pixelIndex(pointOrX: QPoint | number, y?: number): number {
+        const pixelIndex =
+            pointOrX instanceof QPoint ? this.native.pixelIndex(pointOrX.native) : this.native.pixelIndex(pointOrX, y);
+        return pixelIndex;
+    }
+
+    rect(): QRect {
+        const native = this.native.rect();
+        return new QRect(native);
+    }
+
+    reinterpretAsFormat(format: QImageFormat): boolean {
+        return this.native.reinterpretAsFormat(format);
+    }
+
+    save(fileName: string, format: string | null = null, quality: number = -1): boolean {
+        return this.native.save(fileName, format, quality);
+    }
 }
 
 export enum QImageFormat {
@@ -132,4 +200,9 @@ export enum QImageFormat {
     RGBA64,
     RGBA64_Premultiplied,
     BGR888,
+}
+
+export enum QImageInvertMode {
+    InvertRgb,
+    InvertRgba,
 }

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -1,9 +1,78 @@
 import { Component, NativeElement } from '../core/Component';
+import { QSize } from '../QtCore/QSize';
+import { checkIfNativeElement } from '../utils/helpers';
+import addon from '../utils/addon';
 
 export class QImage extends Component {
     native!: NativeElement;
 
-    constructor() {
+    constructor();
+    constructor(native: NativeElement);
+    constructor(filename: string);
+    constructor(width: number, height: number, format: QImageFormat);
+    constructor(size: QSize, format: QImageFormat);
+    constructor(
+        arg?: QImage | NativeElement | QSize | string | number,
+        formatOrHeight?: QImageFormat | string | number,
+        format?: QImageFormat,
+    ) {
         super();
+
+        if (checkIfNativeElement(arg)) {
+            this.native = arg as NativeElement;
+        } else if (typeof arg === 'string') {
+            this.native = new addon.QImage(arg);
+        } else if (typeof arg === 'number') {
+            this.native = new addon.QImage(arg, formatOrHeight, format);
+        } else if (arg instanceof QSize) {
+            this.native = new addon.QImage(arg.native, formatOrHeight);
+        } else {
+            this.native = new addon.QImage();
+        }
     }
+
+    allGray(): boolean {
+        return this.native.allGray();
+    }
+
+    bitPlaneCount(): number {
+        return this.native.bitPlaneCount();
+    }
+
+    bytesPeerLine(): number {
+        return this.native.bytesPeerLine();
+    }
+}
+
+export enum QImageFormat {
+    Invalid,
+    Mono,
+    MonoLSB,
+    Indexed8,
+    RGB32,
+    ARGB32,
+    ARGB32_Premultiplied,
+    RGB16,
+    ARGB8565_Premultiplied,
+    RGB666,
+    ARGB6666_Premultiplied,
+    RGB555,
+    ARGB8555_Premultiplied,
+    RGB888,
+    RGB444,
+    ARGB4444_Premultiplied,
+    RGBX8888,
+    RGBA8888,
+    RGBA8888_Premultiplied,
+    BGR30,
+    A2BGR30_Premultiplied,
+    RGB30,
+    A2RGB30_Premultiplied,
+    Alpha8,
+    Grayscale8,
+    Grayscale16,
+    RGBX64,
+    RGBA64,
+    RGBA64_Premultiplied,
+    BGR888,
 }

--- a/src/lib/QtGui/QImage.ts
+++ b/src/lib/QtGui/QImage.ts
@@ -2,6 +2,9 @@ import { Component, NativeElement } from '../core/Component';
 import { QSize } from '../QtCore/QSize';
 import { checkIfNativeElement } from '../utils/helpers';
 import addon from '../utils/addon';
+import { ImageConversionFlag, GlobalColor } from '../QtEnums';
+import { QRect } from '../QtCore/QRect';
+import { QColor } from '../QtGui/QColor';
 
 export class QImage extends Component {
     native!: NativeElement;
@@ -41,6 +44,60 @@ export class QImage extends Component {
 
     bytesPerLine(): number {
         return this.native.bytesPerLine();
+    }
+
+    cacheKey(): number {
+        return this.native.cacheKey();
+    }
+
+    convertTo(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor): void {
+        this.native.convertTo(format, flags);
+    }
+
+    convertToFormat(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor): QImage {
+        return new QImage(this.native.convertToFormat(format, flags));
+    }
+
+    copy(rectangle: QRect): QImage;
+    copy(x: number, y: number, width: number, height: number): QImage;
+    copy(rectangleOrX: QRect | number, y?: number, width?: number, height?: number): QImage {
+        if (rectangleOrX instanceof QRect) {
+            return new QImage(this.native.copy(rectangleOrX.native));
+        }
+        // eslint-disable-next-line prefer-rest-params
+        return new QImage(this.native.copy(rectangleOrX, y, width, height));
+    }
+
+    createAlphaMask(flags: ImageConversionFlag = ImageConversionFlag.AutoColor): QImage {
+        return new QImage(this.native.createAlphaMask(flags));
+    }
+
+    createHeuristicMask(clipTight = true): QImage {
+        return new QImage(this.native.createHeuristicMask(clipTight));
+    }
+
+    depth(): number {
+        return this.native.depth();
+    }
+
+    devicePixelRatio(): number {
+        return this.native.devicePixelRatio();
+    }
+
+    dotsPerMeterX(): number {
+        return this.native.dotsPerMeterX();
+    }
+
+    dotsPerMeterY(): number {
+        return this.native.dotsPerMeterY();
+    }
+
+    fill(color: QColor | GlobalColor): void {
+        this.native.fill(color instanceof QColor ? color.native : color);
+    }
+
+    format(): QImageFormat {
+        return this.native.format();
     }
 }
 

--- a/src/lib/QtGui/QPixmap.ts
+++ b/src/lib/QtGui/QPixmap.ts
@@ -1,9 +1,9 @@
 import addon from '../utils/addon';
 import { Component, NativeElement } from '../core/Component';
-import {AspectRatioMode, ImageConversionFlag, TransformationMode} from '../QtEnums';
+import { AspectRatioMode, ImageConversionFlag, TransformationMode } from '../QtEnums';
 import { checkIfNativeElement } from '../utils/helpers';
 import { QVariant } from '../QtCore/QVariant';
-import {QImage} from "./QImage";
+import { QImage } from './QImage';
 
 /**
  

--- a/src/lib/QtGui/QPixmap.ts
+++ b/src/lib/QtGui/QPixmap.ts
@@ -1,8 +1,9 @@
 import addon from '../utils/addon';
 import { Component, NativeElement } from '../core/Component';
-import { AspectRatioMode, TransformationMode } from '../QtEnums';
+import {AspectRatioMode, ImageConversionFlag, TransformationMode} from '../QtEnums';
 import { checkIfNativeElement } from '../utils/helpers';
 import { QVariant } from '../QtCore/QVariant';
+import {QImage} from "./QImage";
 
 /**
  
@@ -67,6 +68,10 @@ export class QPixmap extends Component {
     }
     width(): number {
         return this.native.width();
+    }
+    static fromImage(image: QImage, flags: ImageConversionFlag): QPixmap {
+        const native = addon.QPixmap.fromImage(image.native, flags);
+        return new QPixmap(native);
     }
     static fromQVariant(variant: QVariant): QPixmap {
         return new QPixmap(addon.QPixmap.fromQVariant(variant.native));


### PR DESCRIPTION
## QImage support

This PR adds support for QImage

QImage: https://doc.qt.io/qt-5/qimage.html




|   Status   | C++ Qt5 API                                                  | NodeGUI API |
| :--------: | ------------------------------------------------------------ | ----------- |
|            | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-10)**(QImage &&*other*) |             |
|  | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-9)**(const QImage &*image*) |             |
|       :heavy_check_mark:       | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-8)**(const QString &*fileName*, const char **format* = nullptr) | constructor(filename: string) |
|              | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-7)**(const char *const [] *xpm*) |             |
|            | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-6)**(const uchar **data*, int *width*, int *height*, int *bytesPerLine*, QImage::Format *format*, QImageCleanupFunction *cleanupFunction* = nullptr, void **cleanupInfo* = nullptr) |             |
|            | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-5)**(uchar **data*, int *width*, int *height*, int *bytesPerLine*, QImage::Format *format*, QImageCleanupFunction *cleanupFunction* = nullptr, void **cleanupInfo* = nullptr) |             |
|            | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-4)**(const uchar **data*, int *width*, int *height*, QImage::Format *format*, QImageCleanupFunction *cleanupFunction* = nullptr, void **cleanupInfo* = nullptr) |             |
|            | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-3)**(uchar **data*, int *width*, int *height*, QImage::Format *format*, QImageCleanupFunction *cleanupFunction* = nullptr, void **cleanupInfo* = nullptr) |             |
| :heavy_check_mark: | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-2)**(int *width*, int *height*, QImage::Format *format*) | constructor(width: number, height: number, format: QImageFormat) |
|       :heavy_check_mark:       | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage-1)**(const QSize &*size*, QImage::Format *format*) | constructor(size: QSize, format: QImageFormat) |
|       :heavy_check_mark:       | **[QImage](https://doc.qt.io/qt-5/qimage.html#QImage)**()    | constructor() |
| :question: | **[operator=](https://doc.qt.io/qt-5/qimage.html#operator-eq-1)**(QImage &&*other*) |             |
| :question: | **[operator=](https://doc.qt.io/qt-5/qimage.html#operator-eq)**(const QImage &*image*) |             |
|       :heavy_check_mark:       | **[allGray](https://doc.qt.io/qt-5/qimage.html#allGray)**() const | .allGray(): boolean |
|            | **[applyColorTransform](https://doc.qt.io/qt-5/qimage.html#applyColorTransform)**(const QColorTransform &*transform*) |             |
|       :heavy_check_mark:       | **[bitPlaneCount](https://doc.qt.io/qt-5/qimage.html#bitPlaneCount)**() const | .bitPlaneCount(): number |
|            | **[bits](https://doc.qt.io/qt-5/qimage.html#bits)**()        |             |
| :heavy_check_mark: | **[bytesPerLine](https://doc.qt.io/qt-5/qimage.html#bytesPerLine)**() const | .bytesPerLine(): number |
| :heavy_check_mark: ​​ | **[cacheKey](https://doc.qt.io/qt-5/qimage.html#cacheKey)**() const | .cacheKey(): number |
| :heavy_check_mark: | **[color](https://doc.qt.io/qt-5/qimage.html#color)**(int *i*) const | .color(i: number): number |
| :heavy_check_mark: | **[colorCount](https://doc.qt.io/qt-5/qimage.html#colorCount)**() const | .colorCount(): number                                        |
|            | **[colorSpace](https://doc.qt.io/qt-5/qimage.html#colorSpace)**() const |             |
|            | **[colorTable](https://doc.qt.io/qt-5/qimage.html#colorTable)**() const |             |
|            | **[constBits](https://doc.qt.io/qt-5/qimage.html#constBits)**() const |             |
|            | **[constScanLine](https://doc.qt.io/qt-5/qimage.html#constScanLine)**(int *i*) const |             |
| :heavy_check_mark: | **[convertTo](https://doc.qt.io/qt-5/qimage.html#convertTo)**(QImage::Format *format*, Qt::ImageConversionFlags *flags* = Qt::AutoColor) | .convertTo(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor): void |
|            | **[convertToColorSpace](https://doc.qt.io/qt-5/qimage.html#convertToColorSpace)**(const QColorSpace &*colorSpace*) |             |
| :heavy_check_mark: | **[convertToFormat](https://doc.qt.io/qt-5/qimage.html#convertToFormat)**(QImage::Format *format*, Qt::ImageConversionFlags *flags* = Qt::AutoColor) const & | .convertToFormat(format: QImageFormat, flags: ImageConversionFlag = ImageConversionFlag.AutoColor) |
|            | **[convertToFormat](https://doc.qt.io/qt-5/qimage.html#convertToFormat-1)**(QImage::Format *format*, Qt::ImageConversionFlags *flags* = Qt::AutoColor) && |             |
|            | **[convertToFormat](https://doc.qt.io/qt-5/qimage.html#convertToFormat-2)**(QImage::Format *format*, const QVector<QRgb> &*colorTable*, Qt::ImageConversionFlags *flags* = Qt::AutoColor) const |             |
|            | **[convertedToColorSpace](https://doc.qt.io/qt-5/qimage.html#convertedToColorSpace)**(const QColorSpace &*colorSpace*) const |             |
| :heavy_check_mark: | **[copy](https://doc.qt.io/qt-5/qimage.html#copy)**(const QRect &*rectangle* = QRect()) const | .copy(rectangle: QRect): QImage |
| :heavy_check_mark: | **[copy](https://doc.qt.io/qt-5/qimage.html#copy-1)**(int *x*, int *y*, int *width*, int *height*) const | .copy(x: number, y: number, width: number, height: number): QImage |
| :heavy_check_mark: | **[createAlphaMask](https://doc.qt.io/qt-5/qimage.html#createAlphaMask)**(Qt::ImageConversionFlags *flags* = Qt::AutoColor) const | .createAlphaMask(flags: ImageConversionFlag = ImageConversionFlag.AutoColor) |
| :heavy_check_mark: | **[createHeuristicMask](https://doc.qt.io/qt-5/qimage.html#createHeuristicMask)**(bool *clipTight* = true) const | .createHeuristicMask(clipTight: boolean = true): QImage |
|  | **[createMaskFromColor](https://doc.qt.io/qt-5/qimage.html#createMaskFromColor)**(QRgb *color*, Qt::MaskMode *mode* = Qt::MaskInColor) const |             |
| :heavy_check_mark: | **[depth](https://doc.qt.io/qt-5/qimage.html#depth)**() const | .depth(): number |
| :heavy_check_mark: | **[devicePixelRatio](https://doc.qt.io/qt-5/qimage.html#devicePixelRatio)**() const | .devicePixelRatio() |
| :heavy_check_mark: | **[dotsPerMeterX](https://doc.qt.io/qt-5/qimage.html#dotsPerMeterX)**() const | .dotsPerMeterX() |
| :heavy_check_mark: | **[dotsPerMeterY](https://doc.qt.io/qt-5/qimage.html#dotsPerMeterY)**() const | .dotsPerMeterY() |
|  | **[fill](https://doc.qt.io/qt-5/qimage.html#fill)**(uint *pixelValue*) |             |
| :heavy_check_mark: | **[fill](https://doc.qt.io/qt-5/qimage.html#fill-1)**(const QColor &*color*) | .fill(color: QColor): void |
| :heavy_check_mark: | **[fill](https://doc.qt.io/qt-5/qimage.html#fill-2)**(Qt::GlobalColor *color*) | .fill(color: GlobalColor): void |
| :heavy_check_mark: | **[format](https://doc.qt.io/qt-5/qimage.html#format)**() const | .format(): QImageFormat |
| :heavy_check_mark: | **[hasAlphaChannel](https://doc.qt.io/qt-5/qimage.html#hasAlphaChannel)**() const | .hasAlphaChannel(): boolean |
| :heavy_check_mark: | **[height](https://doc.qt.io/qt-5/qimage.html#height)**() const | .height(): boolean |
| :heavy_check_mark: | **[invertPixels](https://doc.qt.io/qt-5/qimage.html#invertPixels)**(QImage::InvertMode *mode* = InvertRgb) | .invertPixels(mode: QImageInvertMode = QImageInvertMode.InvertRgb): void |
| :heavy_check_mark: | **[isGrayscale](https://doc.qt.io/qt-5/qimage.html#isGrayscale)**() const | .isGrayscale(): boolean |
| :heavy_check_mark: | **[isNull](https://doc.qt.io/qt-5/qimage.html#isNull)**() const | .isNull(): boolean |
| :heavy_check_mark: | **[load](https://doc.qt.io/qt-5/qimage.html#load)**(const QString &*fileName*, const char **format* = nullptr) | .load(fileName: string, format: string \| null = null): boolean |
|            | **[load](https://doc.qt.io/qt-5/qimage.html#load-1)**(QIODevice **device*, const char **format*) |             |
| :heavy_check_mark: | **[loadFromData](https://doc.qt.io/qt-5/qimage.html#loadFromData)**(const uchar **data*, int *len*, const char **format* = nullptr) | .loadFromData(data: Buffer, format: string \| null = null): boolean |
|            | **[loadFromData](https://doc.qt.io/qt-5/qimage.html#loadFromData-1)**(const QByteArray &*data*, const char **format* = nullptr) |             |
| :heavy_check_mark: | **[mirrored](https://doc.qt.io/qt-5/qimage.html#mirrored)**(bool *horizontal* = false, bool *vertical* = true) const & | .mirrored(horizontal: boolean = false, vertical: boolean = true): QImage |
|            | **[mirrored](https://doc.qt.io/qt-5/qimage.html#mirrored-1)**(bool *horizontal* = false, bool *vertical* = true) && |             |
| :heavy_check_mark: | **[offset](https://doc.qt.io/qt-5/qimage.html#offset)**() const | .offset(): QPoint |
|            | **[pixel](https://doc.qt.io/qt-5/qimage.html#pixel)**(const QPoint &*position*) const |             |
|                     | **[pixel](https://doc.qt.io/qt-5/qimage.html#pixel-1)**(int *x*, int *y*) const |  |
| :heavy_check_mark: | **[pixelColor](https://doc.qt.io/qt-5/qimage.html#pixelColor)**(const QPoint &*position*) const | .pixelColor(point: QPoint): QColor |
| :heavy_check_mark: | **[pixelColor](https://doc.qt.io/qt-5/qimage.html#pixelColor-1)**(int *x*, int *y*) const | .pixelColor(x: number, y: number): QColor |
|  | **[pixelFormat](https://doc.qt.io/qt-5/qimage.html#pixelFormat)**() const |             |
| :heavy_check_mark:  | **[pixelIndex](https://doc.qt.io/qt-5/qimage.html#pixelIndex)**(const QPoint &*position*) const | .pixelIndex(point: QPoint): number |
| :heavy_check_mark:  | **[pixelIndex](https://doc.qt.io/qt-5/qimage.html#pixelIndex-1)**(int *x*, int *y*) const | .pixelIndex(x: number, y: number): number |
| :heavy_check_mark:  | **[rect](https://doc.qt.io/qt-5/qimage.html#rect)**() const  | .rect(): QRect |
| :heavy_check_mark:  | **[reinterpretAsFormat](https://doc.qt.io/qt-5/qimage.html#reinterpretAsFormat)**(QImage::Format *format*) | .reinterpretAsFormat(format: QImageFormat): boolean |
|                     | **[rgbSwapped](https://doc.qt.io/qt-5/qimage.html#rgbSwapped)**() const & |             |
|            | **[rgbSwapped](https://doc.qt.io/qt-5/qimage.html#rgbSwapped-1)**() && |             |
| :heavy_check_mark: | **[save](https://doc.qt.io/qt-5/qimage.html#save)**(const QString &*fileName*, const char **format* = nullptr, int *quality* = -1) const | .save(fileName: string, format: string \| null = null, quality: number = -1): boolean |
|            | **[save](https://doc.qt.io/qt-5/qimage.html#save-1)**(QIODevice **device*, const char **format* = nullptr, int *quality* = -1) const |             |
| :heavy_check_mark: | **[scaled](https://doc.qt.io/qt-5/qimage.html#scaled)**(const QSize &*size*, Qt::AspectRatioMode *aspectRatioMode* = Qt::IgnoreAspectRatio, Qt::TransformationMode *transformMode* = Qt::FastTransformation) const | .scaled(size: QSize, aspectRatioMode: AspectRatioMode, transformMode: TransformationMode): QImage |
| :heavy_check_mark: | **[scaled](https://doc.qt.io/qt-5/qimage.html#scaled-1)**(int *width*, int *height*, Qt::AspectRatioMode *aspectRatioMode* = Qt::IgnoreAspectRatio, Qt::TransformationMode *transformMode* = Qt::FastTransformation) const | .scaled(width: number, height: number, aspectRatioMode: AspectRatioMode, transformMode: TransformationMode): QImage |
| :heavy_check_mark: | **[scaledToHeight](https://doc.qt.io/qt-5/qimage.html#scaledToHeight)**(int *height*, Qt::TransformationMode *mode* = Qt::FastTransformation) const | .scaledToHeight(height: number, mode: TransformationMode = TransformationMode.FastTransformation): QImage |
| :heavy_check_mark: | **[scaledToWidth](https://doc.qt.io/qt-5/qimage.html#scaledToWidth)**(int *width*, Qt::TransformationMode *mode* = Qt::FastTransformation) const | .scaledToWidth(width: number, mode: TransformationMode = TransformationMode.FastTransformation): QImage |
|            | **[scanLine](https://doc.qt.io/qt-5/qimage.html#scanLine)**(int *i*) |             |
|            | **[scanLine](https://doc.qt.io/qt-5/qimage.html#scanLine-1)**(int *i*) const |             |
| :heavy_check_mark: | **[setAlphaChannel](https://doc.qt.io/qt-5/qimage.html#setAlphaChannel)**(const QImage &*alphaChannel*) | .setAlphaChannel(alphaChannel: QImage): void |
| :heavy_check_mark: | **[setColor](https://doc.qt.io/qt-5/qimage.html#setColor)**(int *index*, QRgb *colorValue*) | .setColor(index: number, colorValue: number): void |
| :heavy_check_mark: | **[setColorCount](https://doc.qt.io/qt-5/qimage.html#setColorCount)**(int *colorCount*) | .setColorCount(colorCount: number): void |
|                     | **[setColorSpace](https://doc.qt.io/qt-5/qimage.html#setColorSpace)**(const QColorSpace &*colorSpace*) |             |
|            | **[setColorTable](https://doc.qt.io/qt-5/qimage.html#setColorTable)**(const QVector<QRgb> *colors*) |             |
| :heavy_check_mark: | **[setDevicePixelRatio](https://doc.qt.io/qt-5/qimage.html#setDevicePixelRatio)**(qreal *scaleFactor*) | .setDevicePixelRatio(scaleFactory: number): void |
| :heavy_check_mark: | **[setDotsPerMeterX](https://doc.qt.io/qt-5/qimage.html#setDotsPerMeterX)**(int *x*) | .setDotsPerMeterX(x: number): void |
| :heavy_check_mark: | **[setDotsPerMeterY](https://doc.qt.io/qt-5/qimage.html#setDotsPerMeterY)**(int *y*) | .setDotsPerMeterY(y: number): void |
| :heavy_check_mark: | **[setOffset](https://doc.qt.io/qt-5/qimage.html#setOffset)**(const QPoint &*offset*) | .setOffset(offset: QPoint): void |
| :heavy_check_mark: | **[setPixel](https://doc.qt.io/qt-5/qimage.html#setPixel)**(const QPoint &*position*, uint *index_or_rgb*) | .setPixel(position: QPoint, indexOrRgb: number): void |
| :heavy_check_mark:  | **[setPixel](https://doc.qt.io/qt-5/qimage.html#setPixel-1)**(int *x*, int *y*, uint *index_or_rgb*) | .setPixel(x: number, y: number, indexOrRgb: number): void |
| :heavy_check_mark:  | **[setPixelColor](https://doc.qt.io/qt-5/qimage.html#setPixelColor)**(const QPoint &*position*, const QColor &*color*) | .setPixelColor(position: QPoint, color: QColor): void |
| :heavy_check_mark:  | **[setPixelColor](https://doc.qt.io/qt-5/qimage.html#setPixelColor-1)**(int *x*, int *y*, const QColor &*color*) | .setPixelColor(x: number, y: number, color: QColor): void |
| :heavy_check_mark:  | **[setText](https://doc.qt.io/qt-5/qimage.html#setText)**(const QString &*key*, const QString &*text*) | .setText(key: string, value: string): void |
| :heavy_check_mark:  | **[size](https://doc.qt.io/qt-5/qimage.html#size)**() const  | .size(): QSize |
| :heavy_check_mark:  | **[sizeInBytes](https://doc.qt.io/qt-5/qimage.html#sizeInBytes)**() const | .sizeInBytes(): number |
| :heavy_check_mark:  | **[swap](https://doc.qt.io/qt-5/qimage.html#swap)**(QImage &*other*) | .swap(other: QImage): void |
| :heavy_check_mark:  | **[text](https://doc.qt.io/qt-5/qimage.html#text)**(const QString &*key* = QString()) const | .text(key: string): string |
| :heavy_check_mark:  | **[textKeys](https://doc.qt.io/qt-5/qimage.html#textKeys)**() const | .textKeys(): string[] |
|            | **[toCGImage](https://doc.qt.io/qt-5/qimage.html#toCGImage)**() const |             |
|  | **[transformed](https://doc.qt.io/qt-5/qimage.html#transformed-1)**(const QTransform &*matrix*, Qt::TransformationMode *mode* = Qt::FastTransformation) const |             |
| :heavy_check_mark:  | **[valid](https://doc.qt.io/qt-5/qimage.html#valid)**(const QPoint &*pos*) const | .valid(pos: QPoint): boolean |
| :heavy_check_mark:  | **[valid](https://doc.qt.io/qt-5/qimage.html#valid-1)**(int *x*, int *y*) const | .valid(x: number, y: number): boolean |
| :heavy_check_mark:  | **[width](https://doc.qt.io/qt-5/qimage.html#width)**() const | .width(): number |
| ​ | **[operator QVariant](https://doc.qt.io/qt-5/qimage.html#operator-QVariant)**() const |             |

