### PR TITLE
Add QT_LINK_MIRROR environment variable to allow for choosing binary mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ or a shorter version:
 npm i http://master-release.nodegui.org
 ```
 
+If the installation fails to download the Qt binaries, a mirror can be used by setting the following environment variable and running the install command again:
+
+```sh
+QT_LINK_MIRROR=<alternative domain> # eg. QT_LINK_MIRROR=https://qt-mirror.dannhauer.de
+
+npm install @nodegui/nodegui
+```
+
+See [FAQs](https://github.com/nodegui/nodegui/tree/master/website/docs/faq.md#why-does-installation-fail-at-minimal-qt-setup) for more details.
+
 **Community guides**
 
 -   [Tutorial: Build a native Meme Search Desktop app with Javascript (NodeGui) and Giphy API](https://www.sitepoint.com/build-native-desktop-gif-searcher-app-using-nodegui/)

--- a/config/qtConfig.js
+++ b/config/qtConfig.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 const SETUP_DIR = path.resolve(__dirname, '..', 'miniqt');
 const QT_VERSION = '5.14.1';
+const MIRROR = Boolean(process.env.QT_LINK_MIRROR) ? process.env.QT_LINK_MIRROR : "https://download.qt.io";
 
 const checkIfExists = fullPath => {
     return () => fs.existsSync(fullPath);
@@ -18,17 +19,17 @@ function getMiniQtConfig() {
                 artifacts: [
                     {
                         name: 'Qt Base',
-                        link: `https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qtbase-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qtbase-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'plugins', 'platforms', 'libqcocoa.dylib')),
                     },
                     {
                         name: 'Qt Svg',
-                        link: `https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qtsvg-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qtsvg-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'lib', 'QtSvg.framework', 'QtSvg')),
                     },
                     {
                         name: 'Qt Tools',
-                        link: `https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qttools-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qttools-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'bin', 'macdeployqt')),
                     },
                 ],
@@ -41,17 +42,17 @@ function getMiniQtConfig() {
                 artifacts: [
                     {
                         name: 'Qt Base',
-                        link: `https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5141/qt.qt5.5141.win64_msvc2017_64/5.14.1-0-202001240957qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/windows_x86/desktop/qt5_5141/qt.qt5.5141.win64_msvc2017_64/5.14.1-0-202001240957qtbase-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'bin', 'Qt5Core.dll')),
                     },
                     {
                         name: 'Qt SVG',
-                        link: `https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5141/qt.qt5.5141.win64_msvc2017_64/5.14.1-0-202001240957qtsvg-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/windows_x86/desktop/qt5_5141/qt.qt5.5141.win64_msvc2017_64/5.14.1-0-202001240957qtsvg-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'bin', 'Qt5Svg.dll')),
                     },
                     {
                         name: 'Qt Tools',
-                        link: `https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5141/qt.qt5.5141.win64_msvc2017_64/5.14.1-0-202001240957qttools-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/windows_x86/desktop/qt5_5141/qt.qt5.5141.win64_msvc2017_64/5.14.1-0-202001240957qttools-Windows-Windows_10-MSVC2017-Windows-Windows_10-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'bin', 'windeployqt.exe')),
                     },
                 ],
@@ -64,17 +65,17 @@ function getMiniQtConfig() {
                 artifacts: [
                     {
                         name: 'Qt Base',
-                        link: `https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt5_5141/qt.qt5.5141.gcc_64/5.14.1-0-202001240953qtbase-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/linux_x64/desktop/qt5_5141/qt.qt5.5141.gcc_64/5.14.1-0-202001240953qtbase-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'bin', 'moc')),
                     },
                     {
                         name: 'Qt SVG',
-                        link: `https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt5_5141/qt.qt5.5141.gcc_64/5.14.1-0-202001240953qtsvg-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/linux_x64/desktop/qt5_5141/qt.qt5.5141.gcc_64/5.14.1-0-202001240953qtsvg-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'lib', 'libQt5Svg.so')),
                     },
                     {
                         name: 'Qt ICU',
-                        link: `https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt5_5141/qt.qt5.5141.gcc_64/5.14.1-0-202001240953icu-linux-Rhel7.2-x64.7z`,
+                        link: `${MIRROR}/online/qtsdkrepository/linux_x64/desktop/qt5_5141/qt.qt5.5141.gcc_64/5.14.1-0-202001240953icu-linux-Rhel7.2-x64.7z`,
                         skipSetup: checkIfExists(path.resolve(qtHome, 'lib', 'libicuuc.so')),
                     },
                 ],

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -3,6 +3,57 @@ title: FAQ
 sidebar_label: FAQ
 ---
 
+## Why does installation fail at "Minimal Qt setup"?
+
+NodeGui currently relies on the [Qt framework](https://qt.io) to acheive cross-platform native interfaces. The library uses a minimal configuration of specific open source Qt components which are downloaded upon installation.
+
+If the server which hosts the component binaries is down or unavailable, the installation will fail and you might see something along the lines of:
+
+```sh
+Minimal Qt 5.14.1 setup:
+FetchError: request to https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_5141/qt.qt5.5141.clang_64/5.14.1-0-202001241000qttools-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z failed, reason: connect ETIMEDOUT 77.86.229.90:443
+    at ClientRequest.<anonymous> (.../nodegui/node_modules/node-fetch/lib/index.js:1461:11)
+    at ClientRequest.emit (events.js:315:20)
+    at TLSSocket.socketErrorListener (_http_client.js:426:9)
+    at TLSSocket.emit (events.js:315:20)
+    at emitErrorNT (internal/streams/destroy.js:92:8)
+    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
+    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
+  type: 'system',
+  errno: 'ETIMEDOUT',
+  code: 'ETIMEDOUT'
+}
+```
+
+In this scenario, you would need to find a mirror (alternate domain) for the binaries which can then be substituted using the `QT_LINK_MIRROR` environment variable. Let's assume we've found an active mirror, for example, `https://qt-mirror.dannhauer.de`, we can then follow these steps to configure the installation:
+
+#### **Unix / MacOS**
+
+```sh
+QT_LINK_MIRROR=https://qt-mirror.dannhauer.de
+
+npm install
+```
+
+
+#### **Windows**
+
+```cmd
+set QT_LINK_MIRROR=https://qt-mirror.dannhauer.de
+
+npm install
+```
+
+Now, instead of requesting the resource from
+
+`https://download.qt.io/online/...`
+
+as in the example above, the script responsible for installing these components would use 
+
+`https://qt-mirror.dannhauer.de/online/...`
+
+If this does not solve your problem, please make sure you have installed all the necessary [requirements](guides/getting-started.md#developer-environment)
+
 ## Why am I having trouble installing Qode?
 
 When running `npm install @nodegui/qode`, some users occasionally encounter

--- a/website/docs/guides/getting-started.md
+++ b/website/docs/guides/getting-started.md
@@ -129,6 +129,8 @@ npm start
 
 ```
 
+**Note**: If you encounter errors installing `nodegui`, please check the [FAQs](../faq.md#why-does-installation-fail-at-minimal-qt-setup) for additional help.
+
 That's it!
 
 Congratulations! You've successfully run and modified your first NodeGui app.


### PR DESCRIPTION
As per #793, it's not possible to install nodegui as a dependency when the artifact link points to a down/dead host. I suggest adding a way for users of this project to change the link domain to work around this in future.

I'm not sure what portion of the link should be configurable, I've just included the domain, but that wouldn't support mirrors which host the files in a different folder structure so perhaps this should be more nuanced.