### PR TITLE
Fix incorrect behavior of minimum size for yoga layout

### DIFF
--- a/src/lib/QtWidgets/QWidget.ts
+++ b/src/lib/QtWidgets/QWidget.ts
@@ -19,7 +19,7 @@ import memoizeOne from 'memoize-one';
 import { QGraphicsEffect } from './QGraphicsEffect';
 
 /**
- 
+
 > Abstract class to add functionalities common to all Widgets.
 
 **This class implements all methods, properties of Qt's [QWidget class](https://doc.qt.io/qt-5/qwidget.html) so that it can be inherited by all widgets**


### PR DESCRIPTION
This is a prospective fix for #592.

The original buggy behavior can be tracked back to some calls to `calculateLayout` without properly setting the width of `sizeControlled` nodes. The fix here:

1. Takes the provided `QRect` and sets height and width in Yoga _instead of_ minimum height and width
2. Updates the `minimumSize` method to ask Yoga for the minimum height and width instead of the current height and width

These changes, by my testing, fix two bugs:

1. The jumpy layout as reported in #592 
2. An apparently un-reported bug where the _initial_ size of a `QMainWindow` is artificially treated as its minimum size.

---

A test application to validate the expected behavior can be found here, slightly modified from the file in #592.

```ts
import { QMainWindow, QWidget } from '.';
import { QPushButton } from './lib/QtWidgets/QPushButton';
import { FlexLayout } from './lib/core/FlexLayout';

const win = new QMainWindow();
win.resize(500, 500);
win.setMinimumSize(200, 200);

const centralWidget = new QWidget();
const centralLayout = new FlexLayout();
centralLayout.setFlexNode(centralWidget.getFlexNode());
centralWidget.setLayout(centralLayout);

const outer = new QWidget();
const outerLayout = new FlexLayout();
outerLayout.setFlexNode(outer.getFlexNode());
outer.setLayout(outerLayout);

const inner = new QWidget();
const innerLayout = new FlexLayout();
innerLayout.setFlexNode(inner.getFlexNode());
inner.setLayout(innerLayout);


const button = new QPushButton();
button.addEventListener('clicked', () => {
    button.setText(button.text() === 'Toggle On' ? 'Toggle Off' : 'Toggle On');
});
button.setText('Toggle On');

innerLayout.addWidget(button);
outerLayout.addWidget(inner);
centralLayout.addWidget(outer);

centralWidget.setInlineStyle('background-color: red');
outer.setInlineStyle('background-color: blue');
inner.setInlineStyle('background-color: green');

// Add central to window
win.setCentralWidget(centralWidget);
win.show();
(global as any).win = win;

```
