### PR TITLE
Add extra `QMouseEvent` and `QPainter` methods

### DIFF
--- a/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
@@ -22,6 +22,7 @@ class DLL_EXPORT QMouseEventWrap : public Napi::ObjectWrap<QMouseEventWrap> {
   static Napi::FunctionReference constructor;
   // wrapped methods
   Napi::Value button(const Napi::CallbackInfo& info);
+  Napi::Value buttons(const Napi::CallbackInfo& info);
   Napi::Value x(const Napi::CallbackInfo& info);
   Napi::Value y(const Napi::CallbackInfo& info);
   Napi::Value globalX(const Napi::CallbackInfo& info);

--- a/src/cpp/include/nodegui/QtWidgets/QPainter/qpainter_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QPainter/qpainter_wrap.h
@@ -24,7 +24,9 @@ class DLL_EXPORT QPainterWrap : public Napi::ObjectWrap<QPainterWrap> {
   Napi::Value drawPath(const Napi::CallbackInfo& info);
   Napi::Value strokePath(const Napi::CallbackInfo& info);
   Napi::Value begin(const Napi::CallbackInfo& info);
+  Napi::Value beginNativePainting(const Napi::CallbackInfo& info);
   Napi::Value end(const Napi::CallbackInfo& info);
+  Napi::Value endNativePainting(const Napi::CallbackInfo& info);
   Napi::Value rotate(const Napi::CallbackInfo& info);
   Napi::Value setPen(const Napi::CallbackInfo& info);
   Napi::Value setRenderHint(const Napi::CallbackInfo& info);

--- a/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
@@ -12,6 +12,7 @@ Napi::Object QMouseEventWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::Function func =
       DefineClass(env, CLASSNAME,
                   {InstanceMethod("button", &QMouseEventWrap::button),
+                   InstanceMethod("buttons", &QMouseEventWrap::buttons),
                    InstanceMethod("x", &QMouseEventWrap::x),
                    InstanceMethod("y", &QMouseEventWrap::y),
                    InstanceMethod("globalX", &QMouseEventWrap::globalX),
@@ -48,6 +49,12 @@ Napi::Value QMouseEventWrap::button(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   int button = static_cast<int>(this->instance->button());
   return Napi::Number::From(env, button);
+}
+
+Napi::Value QMouseEventWrap::buttons(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  int buttons = static_cast<int>(this->instance->buttons());
+  return Napi::Number::From(env, buttons);
 }
 
 Napi::Value QMouseEventWrap::x(const Napi::CallbackInfo& info) {

--- a/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
@@ -32,6 +32,9 @@ Napi::Object QPainterWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("drawConvexPolygon", &QPainterWrap::drawConvexPolygon),
        InstanceMethod("save", &QPainterWrap::save),
        InstanceMethod("restore", &QPainterWrap::restore),
+       InstanceMethod("beginNativePainting",
+                      &QPainterWrap::beginNativePainting),
+       InstanceMethod("endNativePainting", &QPainterWrap::endNativePainting),
        COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QPainterWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -242,5 +245,17 @@ Napi::Value QPainterWrap::setRenderHint(const Napi::CallbackInfo& info) {
       (QPainter::RenderHint)info[0].As<Napi::Number>().Int32Value();
 
   this->instance->setRenderHint(hint, true);
+  return env.Null();
+}
+Napi::Value QPainterWrap::beginNativePainting(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  this->instance->beginNativePainting();
+  return env.Null();
+}
+Napi::Value QPainterWrap::endNativePainting(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  this->instance->endNativePainting();
   return env.Null();
 }

--- a/src/lib/QtGui/QEvent/QMouseEvent.ts
+++ b/src/lib/QtGui/QEvent/QMouseEvent.ts
@@ -9,6 +9,9 @@ export class QMouseEvent {
     button(): number {
         return this.native.button();
     }
+    buttons(): number {
+        return this.native.buttons();
+    }
     x(): number {
         return this.native.x();
     }

--- a/src/lib/QtWidgets/QPainter.ts
+++ b/src/lib/QtWidgets/QPainter.ts
@@ -7,7 +7,7 @@ import { QPoint } from '../QtCore/QPoint';
 import { QPen } from '../QtGui/QPen';
 
 /**
- 
+
 > Lets you paint on widgets.
 
 * **This class is a JS wrapper around Qt's [QPainter class](https://doc.qt.io/qt-5/qpainter.html)**
@@ -71,8 +71,16 @@ export class QPainter extends Component {
         return this.native.begin(device.native);
     }
 
+    beginNativePainting(): void {
+        this.native.beginNativePainting();
+    }
+
     end(): boolean {
         return this.native.end();
+    }
+
+    endNativePainting(): void {
+        this.native.endNativePainting();
     }
 
     rotate(angle: number): void {


### PR DESCRIPTION
This adds couple small methods to existing classes:

* `QMouseEvent.buttons()`
* `QPainter.beginNativePainting()`
* `QPainter.endNativePainting()`

These are rather important for the OpenGL nodegui plugin I'm working on.
