### PR TITLE
Extra drawing related methods

### DIFF
--- a/src/cpp/include/nodegui/QtGui/QFont/qfont_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QFont/qfont_wrap.h
@@ -22,7 +22,9 @@ class DLL_EXPORT QFontWrap : public Napi::ObjectWrap<QFontWrap> {
   Napi::Value capitalization(const Napi::CallbackInfo& info);
   Napi::Value setFamily(const Napi::CallbackInfo& info);
   Napi::Value family(const Napi::CallbackInfo& info);
+  Napi::Value setPixelSize(const Napi::CallbackInfo& info);
   Napi::Value setPointSize(const Napi::CallbackInfo& info);
+  Napi::Value pixelSize(const Napi::CallbackInfo& info);
   Napi::Value pointSize(const Napi::CallbackInfo& info);
   Napi::Value setStretch(const Napi::CallbackInfo& info);
   Napi::Value stretch(const Napi::CallbackInfo& info);

--- a/src/cpp/include/nodegui/QtGui/QFontMetrics/qfontmetrics_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QFontMetrics/qfontmetrics_wrap.h
@@ -37,4 +37,5 @@ class DLL_EXPORT QFontMetricsWrap : public Napi::ObjectWrap<QFontMetricsWrap> {
   Napi::Value strikeOutPos(const Napi::CallbackInfo& info);
   Napi::Value swap(const Napi::CallbackInfo& info);
   Napi::Value underlinePos(const Napi::CallbackInfo& info);
+  Napi::Value xHeight(const Napi::CallbackInfo& info);
 };

--- a/src/cpp/include/nodegui/QtWidgets/QPainter/qpainter_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QPainter/qpainter_wrap.h
@@ -20,6 +20,7 @@ class DLL_EXPORT QPainterWrap : public Napi::ObjectWrap<QPainterWrap> {
   // class constructor
   static Napi::FunctionReference constructor;
   // wrapped methods
+  Napi::Value drawArc(const Napi::CallbackInfo& info);
   Napi::Value drawText(const Napi::CallbackInfo& info);
   Napi::Value drawPath(const Napi::CallbackInfo& info);
   Napi::Value strokePath(const Napi::CallbackInfo& info);
@@ -28,8 +29,10 @@ class DLL_EXPORT QPainterWrap : public Napi::ObjectWrap<QPainterWrap> {
   Napi::Value end(const Napi::CallbackInfo& info);
   Napi::Value endNativePainting(const Napi::CallbackInfo& info);
   Napi::Value rotate(const Napi::CallbackInfo& info);
+  Napi::Value setFont(const Napi::CallbackInfo& info);
   Napi::Value setPen(const Napi::CallbackInfo& info);
   Napi::Value setRenderHint(const Napi::CallbackInfo& info);
+  Napi::Value setTransform(const Napi::CallbackInfo& info);
   Napi::Value setBrush(const Napi::CallbackInfo& info);
   Napi::Value drawLine(const Napi::CallbackInfo& info);
   Napi::Value drawEllipse(const Napi::CallbackInfo& info);
@@ -39,4 +42,5 @@ class DLL_EXPORT QPainterWrap : public Napi::ObjectWrap<QPainterWrap> {
   Napi::Value drawConvexPolygon(const Napi::CallbackInfo& info);
   Napi::Value save(const Napi::CallbackInfo& info);
   Napi::Value restore(const Napi::CallbackInfo& info);
+  Napi::Value fillRect(const Napi::CallbackInfo& info);
 };

--- a/src/cpp/lib/QtGui/QFont/qfont_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFont/qfont_wrap.cpp
@@ -15,7 +15,9 @@ Napi::Object QFontWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("capitalization", &QFontWrap::capitalization),
        InstanceMethod("setFamily", &QFontWrap::setFamily),
        InstanceMethod("family", &QFontWrap::family),
+       InstanceMethod("setPixelSize", &QFontWrap::setPixelSize),
        InstanceMethod("setPointSize", &QFontWrap::setPointSize),
+       InstanceMethod("pixelSize", &QFontWrap::pixelSize),
        InstanceMethod("pointSize", &QFontWrap::pointSize),
        InstanceMethod("setStretch", &QFontWrap::setStretch),
        InstanceMethod("stretch", &QFontWrap::stretch),
@@ -91,12 +93,26 @@ Napi::Value QFontWrap::family(const Napi::CallbackInfo& info) {
   return Napi::String::New(env, family.toStdString());
 }
 
+Napi::Value QFontWrap::setPixelSize(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  int pointSize = info[0].As<Napi::Number>().Int32Value();
+  this->instance->setPixelSize(pointSize);
+  return env.Null();
+}
+
 Napi::Value QFontWrap::setPointSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
   int pointSize = info[0].As<Napi::Number>().Int32Value();
   this->instance->setPointSize(pointSize);
   return env.Null();
+}
+
+Napi::Value QFontWrap::pixelSize(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  return Napi::Value::From(env, this->instance->pixelSize());
 }
 
 Napi::Value QFontWrap::pointSize(const Napi::CallbackInfo& info) {

--- a/src/cpp/lib/QtGui/QFontMetrics/qfontmetrics_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFontMetrics/qfontmetrics_wrap.cpp
@@ -30,6 +30,7 @@ Napi::Object QFontMetricsWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("strikeOutPos", &QFontMetricsWrap::strikeOutPos),
        InstanceMethod("swap", &QFontMetricsWrap::swap),
        InstanceMethod("underlinePos", &QFontMetricsWrap::underlinePos),
+       InstanceMethod("xHeight", &QFontMetricsWrap::xHeight),
        COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QFontMetricsWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
@@ -218,4 +219,11 @@ Napi::Value QFontMetricsWrap::underlinePos(const Napi::CallbackInfo& info) {
   Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->underlinePos());
+}
+
+Napi::Value QFontMetricsWrap::xHeight(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  return Napi::Value::From(env, this->instance->xHeight());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { QKeySequence } from './lib/QtGui/QKeySequence';
 export { QPicture } from './lib/QtGui/QPicture';
 export { QPixmap, ImageFormats } from './lib/QtGui/QPixmap';
 export { QIcon, QIconMode, QIconState } from './lib/QtGui/QIcon';
-export { QImage } from './lib/QtGui/QImage';
+export { QImage, QImageFormat } from './lib/QtGui/QImage';
 export { QFont, QFontCapitalization, QFontStretch, QFontWeight } from './lib/QtGui/QFont';
 export { QMovie, CacheMode, MovieState } from './lib/QtGui/QMovie';
 export { QCursor } from './lib/QtGui/QCursor';

--- a/src/lib/QtGui/QFont.ts
+++ b/src/lib/QtGui/QFont.ts
@@ -33,8 +33,14 @@ export class QFont extends Component {
     family(): string {
         return this.native.family();
     }
+    setPixelSize(value: number): void {
+        this.native.setPixelSize(value);
+    }
     setPointSize(value: number): void {
         this.native.setPointSize(value);
+    }
+    pixelSize(): number {
+        return this.native.pixelSize();
     }
     pointSize(): number {
         return this.native.pointSize();

--- a/src/lib/QtGui/QFontMetrics.ts
+++ b/src/lib/QtGui/QFontMetrics.ts
@@ -115,4 +115,9 @@ export class QFontMetrics extends Component {
     underlinePos(): number {
         return this.native.underlinePos();
     }
+
+    /** Returns the 'x' height of the font. This is often but not always the same as the height of the character 'x'. */
+    xHeight(): number {
+        return this.native.xHeight();
+    }
 }

--- a/src/lib/QtWidgets/QPainter.ts
+++ b/src/lib/QtWidgets/QPainter.ts
@@ -116,9 +116,19 @@ export class QPainter extends Component {
         this.native.setRenderHint(hint, on);
     }
 
+    /**
+     * Sets the world transformation matrix.
+     *
+     * @param matrix2x3 An array of length 6 representing a 2x3 transformation
+     *                  matrix. The order of elements corresponds to the
+     *                  convention used in QTransform, i.e. m11, m12, m21, m22,
+     *                  dx, and dy.
+     * @param combine   If set then this transform will be combining with the
+     *                  curent one. Otherwise it replaces it completely.
+     */
     setTransform(matrix2x3: number[] | Float32Array, combine = false): void {
         if (matrix2x3.length !== 6) {
-            throw new Error('matrix to QPainter.setTransform() mush have length 6.');
+            throw new Error('Parameter "matrix2x3" to QPainter.setTransform() must have length 6.');
         }
 
         this.native.setTransform(

--- a/src/lib/QtWidgets/QPainter.ts
+++ b/src/lib/QtWidgets/QPainter.ts
@@ -5,6 +5,9 @@ import { PenStyle } from '../QtEnums';
 import { QColor } from '../QtGui/QColor';
 import { QPoint } from '../QtCore/QPoint';
 import { QPen } from '../QtGui/QPen';
+import { QWidget } from './QWidget';
+import { QImage } from '../QtGui/QImage';
+import { QFont } from '../QtGui/QFont';
 
 /**
 
@@ -55,6 +58,10 @@ export class QPainter extends Component {
         this.native = native;
     }
 
+    drawArc(x: number, y: number, width: number, height: number, startAngle: number, spanAngle: number): void {
+        this.native.drawArc(x, y, width, height, startAngle, spanAngle);
+    }
+
     drawText(x: number, y: number, text: string): void {
         return this.native.drawText(x, y, text);
     }
@@ -67,8 +74,12 @@ export class QPainter extends Component {
         return this.native.strokePath(path.native, pen.native);
     }
 
-    begin(device: Component): boolean {
-        return this.native.begin(device.native);
+    begin(device: QWidget | QImage): boolean {
+        if (device instanceof QWidget) {
+            return this.native.begin(device.native, 'widget');
+        } else {
+            return this.native.begin(device.native, 'image');
+        }
     }
 
     beginNativePainting(): void {
@@ -87,6 +98,10 @@ export class QPainter extends Component {
         this.native.rotate(angle);
     }
 
+    setFont(font: QFont): void {
+        this.native.setFont(font.native);
+    }
+
     setPen(arg: PenStyle | QColor | QPen): void {
         if (typeof arg == 'number') {
             this.native.setPen(arg, 'style');
@@ -99,6 +114,23 @@ export class QPainter extends Component {
 
     setRenderHint(hint: RenderHint, on = true): void {
         this.native.setRenderHint(hint, on);
+    }
+
+    setTransform(matrix2x3: number[] | Float32Array, combine = false): void {
+        if (matrix2x3.length !== 6) {
+            throw new Error('matrix to QPainter.setTransform() mush have length 6.');
+        }
+
+        this.native.setTransform(
+            'matrix2x3',
+            combine,
+            matrix2x3[0],
+            matrix2x3[1],
+            matrix2x3[2],
+            matrix2x3[3],
+            matrix2x3[4],
+            matrix2x3[5],
+        );
     }
 
     drawEllipse(x: number, y: number, width: number, height: number): void {
@@ -136,6 +168,10 @@ export class QPainter extends Component {
 
     setBrush(color: QColor): void {
         this.native.setBrush(color.native);
+    }
+
+    fillRect(x: number, y: number, width: number, height: number, color: QColor): void {
+        this.native.fillRect(x, y, width, height, color.native);
     }
 }
 


### PR DESCRIPTION
Extra methods for `QFont`, `QFontMetrics` and `QPainter`. See the commit messages.

Note: Unlike C++, I've made `QPainter.setTransform()` accept an array to represent a matrix. `QTransform` could be added later, but the JS world already has modules like `gl-matrix` which are more native JS friendly IMO. My nodegui-plugin-opengl trades in JS data types for matrices too.
