### PR TITLE
Add way for JS to stop event processing in `QObject::event()`

### DIFF
--- a/src/cpp/include/nodegui/core/Events/eventwidget.h
+++ b/src/cpp/include/nodegui/core/Events/eventwidget.h
@@ -15,7 +15,7 @@ class DLL_EXPORT EventWidget {
   void subscribeToQtEvent(std::string evtString);
   void unSubscribeToQtEvent(std::string evtString);
 
-  void event(QEvent* event);
+  bool event(QEvent* event);
 
   void connectSignalsToEventEmitter();
 

--- a/src/cpp/include/nodegui/core/Events/eventwidget_macro.h
+++ b/src/cpp/include/nodegui/core/Events/eventwidget_macro.h
@@ -52,7 +52,9 @@
 #ifndef EVENTWIDGET_IMPLEMENTATIONS
 #define EVENTWIDGET_IMPLEMENTATIONS(BaseWidgetName) \
   bool event(QEvent* event) override {              \
-    EventWidget::event(event);                      \
+    if (EventWidget::event(event)) {                \
+      return true;                                  \
+    }                                               \
     return BaseWidgetName::event(event);            \
   }
 

--- a/src/cpp/lib/core/Events/eventwidget.cpp
+++ b/src/cpp/lib/core/Events/eventwidget.cpp
@@ -28,7 +28,7 @@ void EventWidget::unSubscribeToQtEvent(std::string evtString) {
   }
 }
 
-void EventWidget::event(QEvent* event) {
+bool EventWidget::event(QEvent* event) {
   if (this->emitOnNode) {
     try {
       QEvent::Type evtType = event->type();
@@ -40,11 +40,13 @@ void EventWidget::event(QEvent* event) {
       std::vector<napi_value> args = {Napi::String::New(env, eventTypeString),
                                       nativeEvent};
 
-      this->emitOnNode.Call(args);
+      Napi::Value returnCode = this->emitOnNode.Call(args);
+      return returnCode.As<Napi::Boolean>().Value();
     } catch (...) {
       // Do nothing
     }
   }
+  return false;
 }
 
 void EventWidget::connectSignalsToEventEmitter() {


### PR DESCRIPTION
This adds a couple small methods on `QObject` which makes it possible for
JS code to indicate to the currently running `QObject::event()` override
method whether it should allow more processing of an event or to stop
processing and not call super class `event()` method. This is Qt recommended
(C++) way of overriding event behaviour and stopping default behaviour.

This seems to work quite nicely, although it would have been better if the method's themselves could be attached to the event objects, but all the wrapping makes that not practical. If there are better ideas them I'm glad to hear them. Same applies for the naming of this stuff.
