### PR TITLE
Add `QInputEvent` methods

### DIFF
--- a/src/cpp/include/nodegui/QtGui/QEvent/QInputEvent/qinputevent_macro.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QInputEvent/qinputevent_macro.h
@@ -1,0 +1,19 @@
+#ifndef QINPUTEVENT_WRAPPED_METHODS_DECLARATION
+#define QINPUTEVENT_WRAPPED_METHODS_DECLARATION              \
+  Napi::Value modifiers(const Napi::CallbackInfo& info) {    \
+    Napi::Env env = info.Env();                              \
+    uint v = static_cast<uint>(this->instance->modifiers()); \
+    return Napi::Number::From(env, v);                       \
+  }                                                          \
+  Napi::Value timestamp(const Napi::CallbackInfo& info) {    \
+    Napi::Env env = info.Env();                              \
+    ulong timestamp = this->instance->timestamp();           \
+    return Napi::Number::From(env, timestamp);               \
+  }
+#endif
+
+#ifndef QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE
+#define QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE(WidgetWrapName) \
+  InstanceMethod("modifiers", &WidgetWrapName::modifiers),        \
+      InstanceMethod("timestamp", &WidgetWrapName::timestamp),
+#endif

--- a/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.h
@@ -6,11 +6,13 @@
 
 #include "Extras/Export/export.h"
 #include "QtGui/QEvent/QEvent/qevent_macro.h"
+#include "QtGui/QEvent/QInputEvent/qinputevent_macro.h"
 #include "core/Component/component_macro.h"
 
 class DLL_EXPORT QKeyEventWrap : public Napi::ObjectWrap<QKeyEventWrap> {
   COMPONENT_WRAPPED_METHODS_DECLARATION
   QEVENT_WRAPPED_METHODS_DECLARATION
+  QINPUTEVENT_WRAPPED_METHODS_DECLARATION
 
  private:
   QKeyEvent* instance;
@@ -25,7 +27,6 @@ class DLL_EXPORT QKeyEventWrap : public Napi::ObjectWrap<QKeyEventWrap> {
   // wrapped methods
   Napi::Value text(const Napi::CallbackInfo& info);
   Napi::Value key(const Napi::CallbackInfo& info);
-  Napi::Value modifiers(const Napi::CallbackInfo& info);
   Napi::Value count(const Napi::CallbackInfo& info);
   Napi::Value isAutoRepeat(const Napi::CallbackInfo& info);
 };

--- a/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.h
@@ -6,11 +6,13 @@
 
 #include "Extras/Export/export.h"
 #include "QtGui/QEvent/QEvent/qevent_macro.h"
+#include "QtGui/QEvent/QInputEvent/qinputevent_macro.h"
 #include "core/Component/component_macro.h"
 
 class DLL_EXPORT QMouseEventWrap : public Napi::ObjectWrap<QMouseEventWrap> {
   COMPONENT_WRAPPED_METHODS_DECLARATION
   QEVENT_WRAPPED_METHODS_DECLARATION
+  QINPUTEVENT_WRAPPED_METHODS_DECLARATION
 
  private:
   QMouseEvent* instance;

--- a/src/cpp/include/nodegui/QtGui/QEvent/QNativeGestureEvent/qnativegestureevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QNativeGestureEvent/qnativegestureevent_wrap.h
@@ -5,11 +5,15 @@
 #include <QNativeGestureEvent>
 
 #include "Extras/Export/export.h"
+#include "QtGui/QEvent/QEvent/qevent_macro.h"
+#include "QtGui/QEvent/QInputEvent/qinputevent_macro.h"
 #include "core/Component/component_macro.h"
 
 class DLL_EXPORT QNativeGestureEventWrap
     : public Napi::ObjectWrap<QNativeGestureEventWrap> {
   COMPONENT_WRAPPED_METHODS_DECLARATION
+  QEVENT_WRAPPED_METHODS_DECLARATION
+  QINPUTEVENT_WRAPPED_METHODS_DECLARATION
 
  private:
   QNativeGestureEvent* instance;

--- a/src/cpp/include/nodegui/QtGui/QEvent/QTabletEvent/qtabletevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QTabletEvent/qtabletevent_wrap.h
@@ -6,11 +6,13 @@
 
 #include "Extras/Export/export.h"
 #include "QtGui/QEvent/QEvent/qevent_macro.h"
+#include "QtGui/QEvent/QInputEvent/qinputevent_macro.h"
 #include "core/Component/component_macro.h"
 
 class DLL_EXPORT QTabletEventWrap : public Napi::ObjectWrap<QTabletEventWrap> {
   COMPONENT_WRAPPED_METHODS_DECLARATION
   QEVENT_WRAPPED_METHODS_DECLARATION
+  QINPUTEVENT_WRAPPED_METHODS_DECLARATION
 
  private:
   QTabletEvent* instance;

--- a/src/cpp/include/nodegui/QtGui/QEvent/QWheelEvent/qwheelevent_wrap.h
+++ b/src/cpp/include/nodegui/QtGui/QEvent/QWheelEvent/qwheelevent_wrap.h
@@ -5,10 +5,14 @@
 #include <QWheelEvent>
 
 #include "Extras/Export/export.h"
+#include "QtGui/QEvent/QEvent/qevent_macro.h"
+#include "QtGui/QEvent/QInputEvent/qinputevent_macro.h"
 #include "core/Component/component_macro.h"
 
 class DLL_EXPORT QWheelEventWrap : public Napi::ObjectWrap<QWheelEventWrap> {
   COMPONENT_WRAPPED_METHODS_DECLARATION
+  QEVENT_WRAPPED_METHODS_DECLARATION
+  QINPUTEVENT_WRAPPED_METHODS_DECLARATION
 
  private:
   QWheelEvent* instance;

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -9,15 +9,16 @@ Napi::FunctionReference QKeyEventWrap::constructor;
 Napi::Object QKeyEventWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QKeyEvent";
-  Napi::Function func =
-      DefineClass(env, CLASSNAME,
-                  {InstanceMethod("text", &QKeyEventWrap::text),
-                   InstanceMethod("key", &QKeyEventWrap::key),
-                   InstanceMethod("modifiers", &QKeyEventWrap::modifiers),
-                   InstanceMethod("count", &QKeyEventWrap::count),
-                   InstanceMethod("isAutoRepeat", &QKeyEventWrap::isAutoRepeat),
-                   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QKeyEventWrap)
-                       QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QKeyEventWrap)});
+  Napi::Function func = DefineClass(
+      env, CLASSNAME,
+      {InstanceMethod("text", &QKeyEventWrap::text),
+       InstanceMethod("key", &QKeyEventWrap::key),
+       InstanceMethod("modifiers", &QKeyEventWrap::modifiers),
+       InstanceMethod("count", &QKeyEventWrap::count),
+       InstanceMethod("isAutoRepeat", &QKeyEventWrap::isAutoRepeat),
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QKeyEventWrap)
+           QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QKeyEventWrap)
+               QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QKeyEventWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;
@@ -54,12 +55,6 @@ Napi::Value QKeyEventWrap::text(const Napi::CallbackInfo& info) {
 Napi::Value QKeyEventWrap::key(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   int key = static_cast<int>(this->instance->key());
-  return Napi::Number::From(env, key);
-}
-
-Napi::Value QKeyEventWrap::modifiers(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  int key = static_cast<int>(this->instance->modifiers());
   return Napi::Number::From(env, key);
 }
 

--- a/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
@@ -9,17 +9,18 @@ Napi::FunctionReference QMouseEventWrap::constructor;
 Napi::Object QMouseEventWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QMouseEvent";
-  Napi::Function func =
-      DefineClass(env, CLASSNAME,
-                  {InstanceMethod("button", &QMouseEventWrap::button),
-                   InstanceMethod("buttons", &QMouseEventWrap::buttons),
-                   InstanceMethod("x", &QMouseEventWrap::x),
-                   InstanceMethod("y", &QMouseEventWrap::y),
-                   InstanceMethod("globalX", &QMouseEventWrap::globalX),
-                   InstanceMethod("globalY", &QMouseEventWrap::globalY),
+  Napi::Function func = DefineClass(
+      env, CLASSNAME,
+      {InstanceMethod("button", &QMouseEventWrap::button),
+       InstanceMethod("buttons", &QMouseEventWrap::buttons),
+       InstanceMethod("x", &QMouseEventWrap::x),
+       InstanceMethod("y", &QMouseEventWrap::y),
+       InstanceMethod("globalX", &QMouseEventWrap::globalX),
+       InstanceMethod("globalY", &QMouseEventWrap::globalY),
 
-                   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QMouseEventWrap)
-                       QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QMouseEventWrap)});
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QMouseEventWrap)
+           QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QMouseEventWrap)
+               QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QMouseEventWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;

--- a/src/cpp/lib/QtGui/QEvent/QNativeGestureEvent/qnativegestureevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QNativeGestureEvent/qnativegestureevent_wrap.cpp
@@ -21,8 +21,10 @@ Napi::Object QNativeGestureEventWrap::init(Napi::Env env,
        InstanceMethod("screenPos", &QNativeGestureEventWrap::screenPos),
        InstanceMethod("windowPos", &QNativeGestureEventWrap::windowPos),
        InstanceMethod("value", &QNativeGestureEventWrap::value),
-
-       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QNativeGestureEventWrap)});
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QNativeGestureEventWrap)
+           QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QNativeGestureEventWrap)
+               QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE(
+                   QNativeGestureEventWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;

--- a/src/cpp/lib/QtGui/QEvent/QTabletEvent/qtabletevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QTabletEvent/qtabletevent_wrap.cpp
@@ -35,7 +35,8 @@ Napi::Object QTabletEventWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("z", &QTabletEventWrap::z),
 
        COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QTabletEventWrap)
-           QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QTabletEventWrap)});
+           QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QTabletEventWrap)
+               QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QTabletEventWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;

--- a/src/cpp/lib/QtGui/QEvent/QWheelEvent/qwheelevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QWheelEvent/qwheelevent_wrap.cpp
@@ -21,7 +21,9 @@ Napi::Object QWheelEventWrap::init(Napi::Env env, Napi::Object exports) {
        InstanceMethod("pixelDelta", &QWheelEventWrap::pixelDelta),
        InstanceMethod("position", &QWheelEventWrap::position),
 
-       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QWheelEventWrap)});
+       COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(QWheelEventWrap)
+           QEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QWheelEventWrap)
+               QINPUTEVENT_WRAPPED_METHODS_EXPORT_DEFINE(QWheelEventWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   return exports;

--- a/src/lib/QtGui/QEvent/QInputEvent.ts
+++ b/src/lib/QtGui/QEvent/QInputEvent.ts
@@ -1,0 +1,11 @@
+import { KeyboardModifier } from '../../QtEnums';
+import { QEvent } from './QEvent';
+
+export abstract class QInputEvent extends QEvent {
+    modifiers(): KeyboardModifier {
+        return this.native.modifiers();
+    }
+    timestamp(): number {
+        return this.native.timestamp();
+    }
+}

--- a/src/lib/QtGui/QEvent/QKeyEvent.ts
+++ b/src/lib/QtGui/QEvent/QKeyEvent.ts
@@ -1,8 +1,8 @@
 import addon from '../../utils/addon';
 import { NativeRawPointer } from '../../core/Component';
-import { QEvent } from './QEvent';
+import { QInputEvent } from './QInputEvent';
 
-export class QKeyEvent extends QEvent {
+export class QKeyEvent extends QInputEvent {
     constructor(event: NativeRawPointer<'QEvent'>) {
         super(new addon.QKeyEvent(event));
     }

--- a/src/lib/QtGui/QEvent/QMouseEvent.ts
+++ b/src/lib/QtGui/QEvent/QMouseEvent.ts
@@ -1,8 +1,8 @@
 import addon from '../../utils/addon';
 import { NativeRawPointer } from '../../core/Component';
-import { QEvent } from './QEvent';
+import { QInputEvent } from './QInputEvent';
 
-export class QMouseEvent extends QEvent {
+export class QMouseEvent extends QInputEvent {
     constructor(event: NativeRawPointer<'QEvent'>) {
         super(new addon.QMouseEvent(event));
     }

--- a/src/lib/QtGui/QEvent/QNativeGestureEvent.ts
+++ b/src/lib/QtGui/QEvent/QNativeGestureEvent.ts
@@ -1,9 +1,9 @@
 import addon from '../../utils/addon';
 import { NativeRawPointer } from '../../core/Component';
 import { NativeGestureType } from '../../QtEnums';
-import { QEvent } from './QEvent';
+import { QInputEvent } from './QInputEvent';
 
-export class QNativeGestureEvent extends QEvent {
+export class QNativeGestureEvent extends QInputEvent {
     constructor(event: NativeRawPointer<'QEvent'>) {
         super(new addon.QNativeGestureEvent(event));
     }

--- a/src/lib/QtGui/QEvent/QTabletEvent.ts
+++ b/src/lib/QtGui/QEvent/QTabletEvent.ts
@@ -1,6 +1,6 @@
 import addon from '../../utils/addon';
 import { NativeRawPointer } from '../../core/Component';
-import { QEvent } from './QEvent';
+import { QInputEvent } from './QInputEvent';
 
 enum PointerType {
     /** An unknown device */
@@ -29,7 +29,7 @@ enum TabletDevice {
 /**
  * The QTabletEvent class contains parameters that describe a Tablet event
  */
-export class QTabletEvent extends QEvent {
+export class QTabletEvent extends QInputEvent {
     static readonly PointerType = PointerType;
     static readonly TabletDevice = TabletDevice;
     readonly PointerType = PointerType;

--- a/src/lib/QtGui/QEvent/QWheelEvent.ts
+++ b/src/lib/QtGui/QEvent/QWheelEvent.ts
@@ -1,9 +1,9 @@
 import addon from '../../utils/addon';
 import { NativeRawPointer } from '../../core/Component';
 import { ScrollPhase } from '../../QtEnums';
-import { QEvent } from './QEvent';
+import { QInputEvent } from './QInputEvent';
 
-export class QWheelEvent extends QEvent {
+export class QWheelEvent extends QInputEvent {
     constructor(event: NativeRawPointer<'QEvent'>) {
         super(new addon.QWheelEvent(event));
     }

--- a/src/lib/core/EventWidget.ts
+++ b/src/lib/core/EventWidget.ts
@@ -8,7 +8,7 @@ function addDefaultErrorHandler(native: NativeElement, emitter: EventEmitter): v
 }
 
 /**
- 
+
 > Abstract class that adds event handling support to all widgets.
 
 **This class implements an event emitter and merges it with Qt's event and signal system. It allows us to register and unregister event and signal listener at will from javascript**
@@ -110,10 +110,10 @@ export abstract class EventWidget<Signals extends unknown> extends Component {
     addEventListener<SignalType extends keyof Signals>(signalType: SignalType, callback: Signals[SignalType]): void;
 
     /**
-    
+
      @param eventType
      @param callback
-    
+
      For example in the case of QPushButton:
      ```js
      const button = new QPushButton();


### PR DESCRIPTION
The `QInputEvent` methods are added to all related subclasses by inserting `QInputEvent` into the hierarchy plus some C++ macro work.
