### PR TITLE
Re-use existing JS event emitters when creating JS side wrappers

### DIFF
--- a/src/cpp/include/nodegui/core/Events/eventwidget_macro.h
+++ b/src/cpp/include/nodegui/core/Events/eventwidget_macro.h
@@ -22,6 +22,14 @@
     return env.Null();                                               \
   }                                                                  \
                                                                      \
+  Napi::Value getNodeEventEmitter(const Napi::CallbackInfo& info) {  \
+    Napi::Env env = info.Env();                                      \
+    if (this->instance->emitOnNode) {                                \
+      return this->instance->emitOnNode.Value();                     \
+    } else {                                                         \
+      return env.Null();                                             \
+    }                                                                \
+  }                                                                  \
   Napi::Value subscribeToQtEvent(const Napi::CallbackInfo& info) {   \
     Napi::Env env = info.Env();                                      \
     Napi::String eventString = info[0].As<Napi::String>();           \
@@ -42,6 +50,8 @@
   COMPONENT_WRAPPED_METHODS_EXPORT_DEFINE(WidgetWrapName)         \
   InstanceMethod("initNodeEventEmitter",                          \
                  &WidgetWrapName::initNodeEventEmitter),          \
+      InstanceMethod("getNodeEventEmitter",                       \
+                     &WidgetWrapName::getNodeEventEmitter),       \
       InstanceMethod("subscribeToQtEvent",                        \
                      &WidgetWrapName::subscribeToQtEvent),        \
       InstanceMethod("unSubscribeToQtEvent",                      \


### PR DESCRIPTION
This bug fix may need a second opinion.

Consider this little program:

```typescript
import { QApplication, QMainWindow } from "@nodegui/nodegui";

const win = new QMainWindow();

QApplication.instance().addEventListener('focusWindowChanged', () => {
  console.log("focusWindowChanged handler 1");
});

QApplication.instance().addEventListener('focusWindowChanged', () => {
  console.log("focusWindowChanged handler 2");
});

win.show();

(global as any).win = win;
```
I expect both event handlers to be called when the window focus changes. But only the last one is, which is a bug.

When the JS `QApplication` instance is created and set up the event emitter function is set on the C++ instance. But creating a wrapper more than once for the same underlying C++ object will overwrite the previous emitter function and any event handlers which were registered on it.

This PR makes it possible to detect and re-use any previous emitter function and JS `EventEmitter` object if a 2nd JS wrapper is created.

So far re-creating JS wrappers doesn't actually happen very often in most applications, but it is worth applying a more structural solution to the problem.
