### PR TITLE
Fix QWidgetTableItem Wrapper #832

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.h
@@ -12,6 +12,7 @@ class DLL_EXPORT QTableWidgetItemWrap
   COMPONENT_WRAPPED_METHODS_DECLARATION
  private:
   QTableWidgetItem* instance;
+  bool disableDeletion;
 
  public:
   static Napi::Object init(Napi::Env env, Napi::Object exports);

--- a/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
@@ -56,22 +56,35 @@ Napi::Object QTableWidgetItemWrap::init(Napi::Env env, Napi::Object exports) {
 QTableWidgetItem* QTableWidgetItemWrap::getInternalInstance() {
   return this->instance;
 }
-QTableWidgetItemWrap::~QTableWidgetItemWrap() { delete this->instance; }
+QTableWidgetItemWrap::~QTableWidgetItemWrap() {
+    if (!this->disableDeletion) {
+	delete this->instance;
+    }
+}
 
 QTableWidgetItemWrap::QTableWidgetItemWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTableWidgetItemWrap>(info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  if (info.Length() == 1) {
-    QString text =
-        QString::fromUtf8(info[0].As<Napi::String>().Utf8Value().c_str());
-    this->instance = new QTableWidgetItem(text);
-  } else if (info.Length() == 0) {
-    this->instance = new QTableWidgetItem();
+    
+  if (info.Length() > 0 && info[0].IsExternal()) {
+    // --- if external ---
+    this->instance = info[0].As<Napi::External<QTableWidgetItem>>().Data();
+    if (info.Length() == 2) {
+      this->disableDeletion = info[1].As<Napi::Boolean>().Value();
+    }
   } else {
-    Napi::TypeError::New(env, "Wrong number of arguments")
-        .ThrowAsJavaScriptException();
+    if (info.Length() == 1) {
+      QString text =
+          QString::fromUtf8(info[0].As<Napi::String>().Utf8Value().c_str());
+      this->instance = new QTableWidgetItem(text);
+    } else if (info.Length() == 0) {
+      this->instance = new QTableWidgetItem();
+    } else {
+      Napi::TypeError::New(env, "QTableWidgetItemWrap: Wrong number of arguments")
+          .ThrowAsJavaScriptException();
+    }
   }
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
 }


### PR DESCRIPTION
This should fix #832 - (At least it does locally for me.  :grinning: )   

Based on reading other parts of the source code, I believe this wrapper should have both the added `external` check and the no delete flag ability, and it was missing it both.   @sedwards2009