### PR TITLE
Update Process.md

### DIFF
--- a/website/docs/api/manual/process.md
+++ b/website/docs/api/manual/process.md
@@ -15,10 +15,3 @@ It adds the following properties :
 
 A `String` representing Qode's version string. Qode is a lightly modified version of NodeJs that allows running Qt and NodeJs under a single process.
 
-### `process.versions.qt(compiled)` _Readonly_
-
-A `String` representing Qt version used when compile Qode binary. This can be useful to know which version of Qt is binary compatible with the version of Qode you are running. This is useful when running qode with a different version of Qt than what it was compiled with.
-
-### `process.versions.qt(runtime)` _Readonly_
-
-A `String` representing Qt version of the Qt library loaded during runtime. This can be useful to know which version of Qt you are using at runtime as compared to the version of Qt used when Qode was compiled.This is possible since Qt is dynamically linked to Qode and you could replace the Qt dynamic libraries with any binary compatible library. Hence, this is useful when running qode with a different version of Qt than what it was compiled with.


### PR DESCRIPTION
Delete invalid documentation, as these two values are no longer valid in the later versions of Qode.    There does NOT appear to be a current way to get the currently running QT.