### PR TITLE
add postcss to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "eslint-plugin-prettier": "^3.4.0",
         "husky": "^7.0.1",
         "jest": "^27.0.6",
+        "postcss": "^7.0.17",
         "prettier": "^2.3.2",
         "ts-jest": "^27.0.4",
         "typescript": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "manage-path": "^2.0.0",
         "memoize-one": "^5.2.1",
         "node-addon-api": "^4.0.0",
+        "postcss": "^7.0.17",
         "postcss-nodegui-autoprefixer": "0.0.7"
     },
     "devDependencies": {
@@ -55,7 +56,6 @@
         "eslint-plugin-prettier": "^3.4.0",
         "husky": "^7.0.1",
         "jest": "^27.0.6",
-        "postcss": "^7.0.17",
         "prettier": "^2.3.2",
         "ts-jest": "^27.0.4",
         "typescript": "^4.3.5"


### PR DESCRIPTION
fix build with deep node_modules (pnpm, [etc](https://github.com/milahu/npm-install-mini))

error was

```
> @nodegui/nodegui@0.37.3 build /tmp/nodegui
> cross-env tsc && npm run build:addon

src/lib/core/Style/StyleSheet.ts:1:21 - error TS2307: Cannot find module 'postcss' or its corresponding type declarations.

1 import postcss from 'postcss';
                      ~~~~~~~~~
```
