### PR TITLE
Add `QBrush` as an argument to `QPainter.setBrush`

### DIFF
--- a/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
@@ -3,6 +3,7 @@
 #include "Extras/Utils/nutils.h"
 #include "QtCore/QPoint/qpoint_wrap.h"
 #include "QtCore/QRect/qrect_wrap.h"
+#include "QtGui/QBrush/qbrush_wrap.h"
 #include "QtGui/QColor/qcolor_wrap.h"
 #include "QtGui/QFont/qfont_wrap.h"
 #include "QtGui/QImage/qimage_wrap.h"
@@ -304,11 +305,21 @@ Napi::Value QPainterWrap::setBrush(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  Napi::Object colorObject = info[0].As<Napi::Object>();
-  QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject);
-  QColor* color = colorWrap->getInternalInstance();
-  QBrush* brush = new QBrush(*color);
-  this->instance->setBrush(*brush);
+  Napi::String napiType = info[1].As<Napi::String>();
+  std::string type = napiType.Utf8Value();
+
+  if (type == "brush") {
+    Napi::Object brushObject = info[0].As<Napi::Object>();
+    QBrushWrap* brushWrap = Napi::ObjectWrap<QBrushWrap>::Unwrap(brushObject);
+    QBrush* brush = brushWrap->getInternalInstance();
+    this->instance->setBrush(*brush);
+  } else if (type == "color") {
+    Napi::Object colorObject = info[0].As<Napi::Object>();
+    QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject);
+    QColor* color = colorWrap->getInternalInstance();
+    QBrush* brush = new QBrush(*color);
+    this->instance->setBrush(*brush);
+  }
   return env.Null();
 }
 Napi::Value QPainterWrap::setRenderHint(const Napi::CallbackInfo& info) {

--- a/src/lib/QtWidgets/QPainter.ts
+++ b/src/lib/QtWidgets/QPainter.ts
@@ -2,6 +2,7 @@ import addon from '../utils/addon';
 import { Component, NativeElement } from '../core/Component';
 import { QPainterPath } from '../QtWidgets/QPainterPath';
 import { PenStyle } from '../QtEnums';
+import { QBrush } from '../QtGui/QBrush';
 import { QColor } from '../QtGui/QColor';
 import { QPoint } from '../QtCore/QPoint';
 import { QPen } from '../QtGui/QPen';
@@ -180,8 +181,12 @@ export class QPainter extends Component {
     }
     // TODO: void 	setBackground(const QBrush &brush)
     // TODO: void 	setBackgroundMode(Qt::BGMode mode)
-    setBrush(color: QColor): void {
-        this.native.setBrush(color.native);
+    setBrush(colorOrBrush: QColor | QBrush): void {
+        if (colorOrBrush instanceof QColor) {
+	    this.native.setBrush(colorOrBrush.native, 'color');
+        } else {
+	    this.native.setBrush(colorOrBrush.native, 'brush');
+	}
     }
     setBrushOrigin(x: number, y: number): void {
         this.native.setBrushOrigin(x, y);


### PR DESCRIPTION
Makes if possible to paint with brushes made out of textures etc.

Here's how to make a round image:
```
  // Texture for use as a brush
  const texture = QPixmap.fromImage(image, ImageConversionFlag.NoFormatConversion);
  const brushTexture = new QBrush();
  brushTexture.setTexture(texture);

  // Completely transparent output image
  const outImg = new QImage(size, size, QImageFormat.ARGB32);
  outImg.fill(GlobalColor.transparent)

  // Paint a circle on the output image with the texture as a brush (.NoPen = fill)
  const painter = new QPainter();
  painter.begin(outImg);
  painter.setPen(PenStyle.NoPen);
  painter.setBrush(brushTexture);

  painter.drawEllipse(0, 0, size, size)

  painter.end()
```