### PR TITLE
Remove most unneeded or buggy `Napi:HandleScope` uses

### DIFF
--- a/src/cpp/include/nodegui/QtCore/QObject/qobject_macro.h
+++ b/src/cpp/include/nodegui/QtCore/QObject/qobject_macro.h
@@ -19,20 +19,17 @@
                                                                              \
   Napi::Value __id__(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     return Napi::Value::From(                                                \
         env, extrautils::hashPointerTo53bit(this->instance.data()));         \
   }                                                                          \
   Napi::Value inherits(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     Napi::String className = info[0].As<Napi::String>();                     \
     bool doesIt = this->instance->inherits(className.Utf8Value().c_str());   \
     return Napi::Value::From(env, doesIt);                                   \
   }                                                                          \
   Napi::Value setProperty(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     Napi::String name = info[0].As<Napi::String>();                          \
     Napi::Value value = info[1];                                             \
     auto variant =                                                           \
@@ -43,7 +40,6 @@
   }                                                                          \
   Napi::Value property(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     Napi::String name = info[0].As<Napi::String>();                          \
     Napi::Value value = info[1];                                             \
     QVariant* variant =                                                      \
@@ -54,7 +50,6 @@
   }                                                                          \
   Napi::Value setObjectName(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     Napi::String objectName = info[0].As<Napi::String>();                    \
     this->instance->setObjectName(                                           \
         QString::fromStdString(objectName.Utf8Value()));                     \
@@ -62,19 +57,16 @@
   }                                                                          \
   Napi::Value objectName(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     QString objectName = this->instance->objectName();                       \
     return Napi::String::New(env, objectName.toStdString());                 \
   }                                                                          \
   Napi::Value dumpObjectTree(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     this->instance->dumpObjectTree();                                        \
     return env.Null();                                                       \
   }                                                                          \
   Napi::Value dumpObjectInfo(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     this->instance->dumpObjectInfo();                                        \
     return env.Null();                                                       \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QAbstractButton/qabstractbutton_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QAbstractButton/qabstractbutton_macro.h
@@ -16,20 +16,17 @@
   QWIDGET_WRAPPED_METHODS_DECLARATION                        \
   Napi::Value animateClick(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                              \
-    Napi::HandleScope scope(env);                            \
     int msec = info[0].As<Napi::Number>().Int32Value();      \
     this->instance->animateClick(msec);                      \
     return env.Null();                                       \
   }                                                          \
   Napi::Value click(const Napi::CallbackInfo& info) {        \
     Napi::Env env = info.Env();                              \
-    Napi::HandleScope scope(env);                            \
     this->instance->click();                                 \
     return env.Null();                                       \
   }                                                          \
   Napi::Value toggle(const Napi::CallbackInfo& info) {       \
     Napi::Env env = info.Env();                              \
-    Napi::HandleScope scope(env);                            \
     this->instance->toggle();                                \
     return env.Null();                                       \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QAbstractItemView/qabstractitemview_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QAbstractItemView/qabstractitemview_macro.h
@@ -22,7 +22,6 @@
   QABSTRACTSCROLLAREA_WRAPPED_METHODS_DECLARATION                              \
   Napi::Value setCurrentIndex(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object indexObject = info[0].As<Napi::Object>();                     \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(indexObject);                \
@@ -31,7 +30,6 @@
   }                                                                            \
   Napi::Value currentIndex(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndex current = this->instance->currentIndex();                      \
     auto instance = QModelIndexWrap::constructor.New(                          \
         {Napi::External<QModelIndex>::New(env, new QModelIndex(current))});    \
@@ -39,7 +37,6 @@
   }                                                                            \
   Napi::Value setIndexWidget(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object indexObject = info[0].As<Napi::Object>();                     \
     Napi::Object widgetObject = info[1].As<Napi::Object>();                    \
     QModelIndexWrap* indexWrap =                                               \
@@ -52,7 +49,6 @@
   }                                                                            \
   Napi::Value indexWidget(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object indexObject = info[0].As<Napi::Object>();                     \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(indexObject);                \
@@ -65,19 +61,16 @@
   }                                                                            \
   Napi::Value resetHorizontalScrollMode(const Napi::CallbackInfo& info) {      \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->resetHorizontalScrollMode();                               \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value resetVerticalScrollMode(const Napi::CallbackInfo& info) {        \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->resetVerticalScrollMode();                                 \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value rootIndex(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndex root = this->instance->rootIndex();                            \
     auto instance = QModelIndexWrap::constructor.New(                          \
         {Napi::External<QModelIndex>::New(env, new QModelIndex(root))});       \
@@ -85,19 +78,16 @@
   }                                                                            \
   Napi::Value scrollToBottom(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->scrollToBottom();                                          \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value scrollToTop(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->scrollToTop();                                             \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value setModel(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object modelObject = info[0].As<Napi::Object>();                     \
     QAbstractItemModelWrap* modelWrap =                                        \
         Napi::ObjectWrap<QAbstractItemModelWrap>::Unwrap(modelObject);         \
@@ -107,7 +97,6 @@
   }                                                                            \
   Napi::Value closePersistentEditor(const Napi::CallbackInfo& info) {          \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \
@@ -116,13 +105,11 @@
   }                                                                            \
   Napi::Value clearSelection(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->clearSelection();                                          \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value edit(const Napi::CallbackInfo& info) {                           \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \
@@ -131,19 +118,16 @@
   }                                                                            \
   Napi::Value reset(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->reset();                                                   \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value selectAll(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->selectAll();                                               \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value setRootIndex(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \
@@ -152,7 +136,6 @@
   }                                                                            \
   Napi::Value update_QModelIndex(const Napi::CallbackInfo& info) {             \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \
@@ -161,7 +144,6 @@
   }                                                                            \
   Napi::Value selectionModel(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QItemSelectionModel* model = this->instance->selectionModel();             \
     auto modelExt = Napi::External<QItemSelectionModel>::New(env, model);      \
     auto instance = QItemSelectionModelWrap::constructor.New({modelExt});      \
@@ -169,7 +151,6 @@
   }                                                                            \
   Napi::Value isPersistentEditorOpen(const Napi::CallbackInfo& info) {         \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \
@@ -178,7 +159,6 @@
   }                                                                            \
   Napi::Value openPersistentEditor(const Napi::CallbackInfo& info) {           \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \
@@ -187,7 +167,6 @@
   }                                                                            \
   Napi::Value keyboardSearch(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string searchNapiText = info[0].As<Napi::String>().Utf8Value();       \
     QString search = QString::fromUtf8(searchNapiText.c_str());                \
     this->instance->keyboardSearch(search);                                    \
@@ -198,7 +177,6 @@
   QABSTRACTITEMVIEW_WRAPPED_METHODS_DECLARATION_NO_QHEADERVIEW_PROTECTED       \
   Napi::Value indexAt(const Napi::CallbackInfo& info) {                        \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QPointWrap* pointWrap =                                                    \
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>());      \
     QPoint* point = pointWrap->getInternalInstance();                          \
@@ -209,7 +187,6 @@
   }                                                                            \
   Napi::Value scrollTo(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QModelIndexWrap* indexWrap =                                               \
         Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>()); \
     QModelIndex* index = indexWrap->getInternalInstance();                     \

--- a/src/cpp/include/nodegui/QtWidgets/QAbstractScrollArea/qabstractscrollarea_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QAbstractScrollArea/qabstractscrollarea_macro.h
@@ -19,7 +19,6 @@
                                                                        \
   Napi::Value maximumViewportSize(const Napi::CallbackInfo& info) {    \
     Napi::Env env = info.Env();                                        \
-    Napi::HandleScope scope(env);                                      \
     QSize size = this->instance->maximumViewportSize();                \
     auto instance = QSizeWrap::constructor.New(                        \
         {Napi::External<QSize>::New(env, new QSize(size))});           \
@@ -28,7 +27,6 @@
                                                                        \
   Napi::Value setHorizontalScrollBar(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                                        \
-    Napi::HandleScope scope(env);                                      \
     Napi::Object scrollBarObject = info[0].As<Napi::Object>();         \
     QScrollBarWrap* scrollBarWrap =                                    \
         Napi::ObjectWrap<QScrollBarWrap>::Unwrap(scrollBarObject);     \
@@ -39,7 +37,6 @@
                                                                        \
   Napi::Value setVerticalScrollBar(const Napi::CallbackInfo& info) {   \
     Napi::Env env = info.Env();                                        \
-    Napi::HandleScope scope(env);                                      \
     Napi::Object scrollBarObject = info[0].As<Napi::Object>();         \
     QScrollBarWrap* scrollBarWrap =                                    \
         Napi::ObjectWrap<QScrollBarWrap>::Unwrap(scrollBarObject);     \
@@ -50,7 +47,6 @@
                                                                        \
   Napi::Value setViewport(const Napi::CallbackInfo& info) {            \
     Napi::Env env = info.Env();                                        \
-    Napi::HandleScope scope(env);                                      \
     Napi::Object viewPortObject = info[0].As<Napi::Object>();          \
     NodeWidgetWrap* viewPortWidgetWrap =                               \
         Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(viewPortObject);      \
@@ -61,7 +57,6 @@
                                                                        \
   Napi::Value viewport(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                        \
-    Napi::HandleScope scope(env);                                      \
     QWidget* viewPort = this->instance->viewport();                    \
     NWidget* nviewPort = reinterpret_cast<NWidget*>(viewPort);         \
     auto instance = QWidgetWrap::constructor.New(                      \

--- a/src/cpp/include/nodegui/QtWidgets/QAbstractSlider/qabstractslider_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QAbstractSlider/qabstractslider_macro.h
@@ -14,7 +14,6 @@
   QWIDGET_WRAPPED_METHODS_DECLARATION                         \
   Napi::Value triggerAction(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                               \
-    Napi::HandleScope scope(env);                             \
     int action = info[0].As<Napi::Number>().Int32Value();     \
     this->instance->triggerAction(                            \
         static_cast<QAbstractSlider::SliderAction>(action));  \
@@ -22,7 +21,6 @@
   }                                                           \
   Napi::Value setRange(const Napi::CallbackInfo& info) {      \
     Napi::Env env = info.Env();                               \
-    Napi::HandleScope scope(env);                             \
     int min = info[0].As<Napi::Number>().Int32Value();        \
     int max = info[1].As<Napi::Number>().Int32Value();        \
     this->instance->setRange(min, max);                       \

--- a/src/cpp/include/nodegui/QtWidgets/QAbstractSpinBox/qabstractspinbox_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QAbstractSpinBox/qabstractspinbox_macro.h
@@ -15,19 +15,16 @@
   QWIDGET_WRAPPED_METHODS_DECLARATION                     \
   Napi::Value selectAll(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     this->instance->selectAll();                          \
     return env.Null();                                    \
   }                                                       \
   Napi::Value stepDown(const Napi::CallbackInfo& info) {  \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     this->instance->stepDown();                           \
     return env.Null();                                    \
   }                                                       \
   Napi::Value stepUp(const Napi::CallbackInfo& info) {    \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     this->instance->stepUp();                             \
     return env.Null();                                    \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QDateTimeEdit/qdatetimeedit_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QDateTimeEdit/qdatetimeedit_macro.h
@@ -18,7 +18,6 @@
   QABSTRACTSPINBOX_WRAPPED_METHODS_DECLARATION                               \
   Napi::Value setCalendarWidget(const Napi::CallbackInfo &info) {            \
     Napi::Env env = info.Env();                                              \
-    Napi::HandleScope scope(env);                                            \
     Napi::Object calendarWidgetObject = info[0].As<Napi::Object>();          \
     QCalendarWidgetWrap *calendarWidgetWrap =                                \
         Napi::ObjectWrap<QCalendarWidgetWrap>::Unwrap(calendarWidgetObject); \

--- a/src/cpp/include/nodegui/QtWidgets/QDialog/qdialog_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QDialog/qdialog_macro.h
@@ -20,32 +20,27 @@
                                                           \
   Napi::Value setResult(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     Napi::Number result = info[0].As<Napi::Number>();     \
     this->instance->setResult(result.Int32Value());       \
     return env.Null();                                    \
   }                                                       \
   Napi::Value result(const Napi::CallbackInfo& info) {    \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     int value = this->instance->result();                 \
     return Napi::Value::From(env, value);                 \
   }                                                       \
   Napi::Value exec(const Napi::CallbackInfo& info) {      \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     int value = static_cast<int>(this->instance->exec()); \
     return Napi::Number::From(env, value);                \
   }                                                       \
   Napi::Value open(const Napi::CallbackInfo& info) {      \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     this->instance->open();                               \
     return env.Null();                                    \
   }                                                       \
   Napi::Value reject(const Napi::CallbackInfo& info) {    \
     Napi::Env env = info.Env();                           \
-    Napi::HandleScope scope(env);                         \
     this->instance->reject();                             \
     return env.Null();                                    \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QFrame/qframe_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QFrame/qframe_macro.h
@@ -17,12 +17,10 @@
                                                                  \
   Napi::Value frameStyle(const Napi::CallbackInfo& info) {       \
     Napi::Env env = info.Env();                                  \
-    Napi::HandleScope scope(env);                                \
     return Napi::Number::New(env, this->instance->frameStyle()); \
   }                                                              \
   Napi::Value setFrameStyle(const Napi::CallbackInfo& info) {    \
     Napi::Env env = info.Env();                                  \
-    Napi::HandleScope scope(env);                                \
     int style = info[0].As<Napi::Number>().Int32Value();         \
     this->instance->setFrameStyle(style);                        \
     return env.Null();                                           \

--- a/src/cpp/include/nodegui/QtWidgets/QGraphicsEffect/qgraphicseffect_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QGraphicsEffect/qgraphicseffect_macro.h
@@ -16,7 +16,6 @@
                                                        \
   Napi::Value update(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                        \
-    Napi::HandleScope scope(env);                      \
     this->instance->update();                          \
     return env.Null();                                 \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QHeaderView/qheaderview_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QHeaderView/qheaderview_wrap.h
@@ -13,7 +13,6 @@ class DLL_EXPORT QHeaderViewWrap : public Napi::ObjectWrap<QHeaderViewWrap> {
 
   Napi::Value indexAt(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    Napi::HandleScope scope(env);
     QPointWrap* pointWrap =
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>());
     QPoint* point = pointWrap->getInternalInstance();
@@ -31,8 +30,6 @@ class DLL_EXPORT QHeaderViewWrap : public Napi::ObjectWrap<QHeaderViewWrap> {
 
   Napi::Value scrollTo(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    Napi::HandleScope scope(env);
-
     NHeaderView* wrapper = dynamic_cast<NHeaderView*>(this->instance.data());
     if (wrapper) {
       QModelIndexWrap* indexWrap =

--- a/src/cpp/include/nodegui/QtWidgets/QLayout/qlayout_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QLayout/qlayout_macro.h
@@ -17,26 +17,22 @@
                                                                    \
   Napi::Value activate(const Napi::CallbackInfo& info) {           \
     Napi::Env env = info.Env();                                    \
-    Napi::HandleScope scope(env);                                  \
     bool wasRedone = this->instance->activate();                   \
     return Napi::Boolean::New(env, wasRedone);                     \
   }                                                                \
   Napi::Value setEnabled(const Napi::CallbackInfo& info) {         \
     Napi::Env env = info.Env();                                    \
-    Napi::HandleScope scope(env);                                  \
     bool enable = info[0].As<Napi::Boolean>().Value();             \
     this->instance->setEnabled(enable);                            \
     return env.Null();                                             \
   }                                                                \
   Napi::Value isEnabled(const Napi::CallbackInfo& info) {          \
     Napi::Env env = info.Env();                                    \
-    Napi::HandleScope scope(env);                                  \
     bool enabled = this->instance->isEnabled();                    \
     return Napi::Boolean::New(env, enabled);                       \
   }                                                                \
   Napi::Value setContentsMargins(const Napi::CallbackInfo& info) { \
     Napi::Env env = info.Env();                                    \
-    Napi::HandleScope scope(env);                                  \
     int left = info[0].As<Napi::Number>().Int32Value();            \
     int top = info[1].As<Napi::Number>().Int32Value();             \
     int right = info[2].As<Napi::Number>().Int32Value();           \
@@ -46,13 +42,11 @@
   }                                                                \
   Napi::Value invalidate(const Napi::CallbackInfo& info) {         \
     Napi::Env env = info.Env();                                    \
-    Napi::HandleScope scope(env);                                  \
     this->instance->invalidate();                                  \
     return env.Null();                                             \
   }                                                                \
   Napi::Value update(const Napi::CallbackInfo& info) {             \
     Napi::Env env = info.Env();                                    \
-    Napi::HandleScope scope(env);                                  \
     this->instance->update();                                      \
     return env.Null();                                             \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QListView/qlistview_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QListView/qlistview_macro.h
@@ -17,13 +17,11 @@
   QABSTRACTITEMVIEW_WRAPPED_METHODS_DECLARATION                       \
   Napi::Value clearPropertyFlags(const Napi::CallbackInfo& info) {    \
     Napi::Env env = info.Env();                                       \
-    Napi::HandleScope scope(env);                                     \
     this->instance->clearPropertyFlags();                             \
     return env.Null();                                                \
   }                                                                   \
   Napi::Value setRowHidden(const Napi::CallbackInfo& info) {          \
     Napi::Env env = info.Env();                                       \
-    Napi::HandleScope scope(env);                                     \
     int row = info[0].As<Napi::Number>().Int32Value();                \
     int hide = info[1].As<Napi::Boolean>().Value();                   \
     this->instance->setRowHidden(row, hide);                          \
@@ -31,7 +29,6 @@
   }                                                                   \
   Napi::Value isRowHidden(const Napi::CallbackInfo& info) {           \
     Napi::Env env = info.Env();                                       \
-    Napi::HandleScope scope(env);                                     \
     int row = info[0].As<Napi::Number>().Int32Value();                \
     return Napi::Boolean::New(env, this->instance->isRowHidden(row)); \
   }

--- a/src/cpp/include/nodegui/QtWidgets/QTableView/qtableview_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTableView/qtableview_macro.h
@@ -19,76 +19,64 @@
                                                                               \
   Napi::Value clearSpans(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->clearSpans();                                             \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value columnAt(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int x = info[0].As<Napi::Number>().Int32Value();                          \
     return Napi::Number::New(env, this->instance->columnAt(x));               \
   }                                                                           \
   Napi::Value columnSpan(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     return Napi::Number::New(env, this->instance->columnSpan(row, column));   \
   }                                                                           \
   Napi::Value columnViewportPosition(const Napi::CallbackInfo& info) {        \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     return Napi::Number::New(env,                                             \
                              this->instance->columnViewportPosition(column)); \
   }                                                                           \
   Napi::Value columnWidth(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     return Napi::Number::New(env, this->instance->columnWidth(column));       \
   }                                                                           \
   Napi::Value isColumnHidden(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     return Napi::Boolean::New(env, this->instance->isColumnHidden(column));   \
   }                                                                           \
   Napi::Value isRowHidden(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     return Napi::Boolean::New(env, this->instance->isRowHidden(row));         \
   }                                                                           \
   Napi::Value rowAt(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int y = info[0].As<Napi::Number>().Int32Value();                          \
     return Napi::Number::New(env, this->instance->rowAt(y));                  \
   }                                                                           \
   Napi::Value rowHeight(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     return Napi::Number::New(env, this->instance->rowHeight(row));            \
   }                                                                           \
   Napi::Value rowSpan(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     return Napi::Number::New(env, this->instance->rowSpan(row, column));      \
   }                                                                           \
   Napi::Value rowViewportPosition(const Napi::CallbackInfo& info) {           \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     return Napi::Number::New(env, this->instance->rowViewportPosition(row));  \
   }                                                                           \
   Napi::Value setColumnHidden(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     bool hide = info[1].As<Napi::Boolean>().Value();                          \
     this->instance->setColumnHidden(column, hide);                            \
@@ -96,7 +84,6 @@
   }                                                                           \
   Napi::Value setColumnWidth(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     int width = info[1].As<Napi::Number>().Int32Value();                      \
     this->instance->setColumnWidth(column, width);                            \
@@ -104,7 +91,6 @@
   }                                                                           \
   Napi::Value setRowHeight(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     int height = info[1].As<Napi::Number>().Int32Value();                     \
     this->instance->setRowHeight(row, height);                                \
@@ -112,7 +98,6 @@
   }                                                                           \
   Napi::Value setRowHidden(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     bool hide = info[1].As<Napi::Boolean>().Value();                          \
     this->instance->setRowHidden(row, hide);                                  \
@@ -120,7 +105,6 @@
   }                                                                           \
   Napi::Value setSpan(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     int column = info[1].As<Napi::Number>().Int32Value();                     \
     int rowSpanCount = info[2].As<Napi::Number>().Int32Value();               \
@@ -130,75 +114,64 @@
   }                                                                           \
   Napi::Value hideColumn(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     this->instance->hideColumn(column);                                       \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value hideRow(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     this->instance->hideRow(row);                                             \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value resizeColumnToContents(const Napi::CallbackInfo& info) {        \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     this->instance->resizeColumnToContents(column);                           \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value resizeColumnsToContents(const Napi::CallbackInfo& info) {       \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->resizeColumnsToContents();                                \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value resizeRowToContents(const Napi::CallbackInfo& info) {           \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     this->instance->resizeRowToContents(row);                                 \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value resizeRowsToContents(const Napi::CallbackInfo& info) {          \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->resizeRowsToContents();                                   \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value selectColumn(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     this->instance->selectColumn(column);                                     \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value selectRow(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     this->instance->selectRow(row);                                           \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value showColumn(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     this->instance->showColumn(column);                                       \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value showRow(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int row = info[0].As<Napi::Number>().Int32Value();                        \
     this->instance->showRow(row);                                             \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value sortByColumn(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int column = info[0].As<Napi::Number>().Int32Value();                     \
     int orderInt = info[1].As<Napi::Number>().Int32Value();                   \
     Qt::SortOrder order = static_cast<Qt::SortOrder>(orderInt);               \
@@ -207,7 +180,6 @@
   }                                                                           \
   Napi::Value horizontalHeader(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     auto header = this->instance->horizontalHeader();                         \
     auto instance = QHeaderViewWrap::constructor.New(                         \
         {Napi::External<QHeaderView>::New(env, header)});                     \
@@ -215,7 +187,6 @@
   }                                                                           \
   Napi::Value verticalHeader(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     auto header = this->instance->verticalHeader();                           \
     auto instance = QHeaderViewWrap::constructor.New(                         \
         {Napi::External<QHeaderView>::New(env, header)});                     \

--- a/src/cpp/include/nodegui/QtWidgets/QTextEdit/qtextedit_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QTextEdit/qtextedit_macro.h
@@ -20,156 +20,131 @@
                                                                                \
   Napi::Value setAlignment(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     int alignment = info[0].As<Napi::Number>().Int32Value();                   \
     this->instance->setAlignment(static_cast<Qt::Alignment>(alignment));       \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value alignment(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Qt::Alignment alignment = this->instance->alignment();                     \
     return Napi::Number::New(env, static_cast<int>(alignment));                \
   }                                                                            \
   Napi::Value canPaste(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     return Napi::Boolean::New(env, this->instance->canPaste());                \
   }                                                                            \
   Napi::Value ensureCursorVisible(const Napi::CallbackInfo& info) {            \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->ensureCursorVisible();                                     \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value setFontFamily(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string family = info[0].As<Napi::String>().Utf8Value();               \
     this->instance->setFontFamily(QString::fromUtf8(family.c_str()));          \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value fontFamily(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QString family = this->instance->fontFamily();                             \
     return Napi::String::New(env, family.toStdString());                       \
   }                                                                            \
   Napi::Value setFontItalic(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     bool italic = info[0].As<Napi::Boolean>().Value();                         \
     this->instance->setFontItalic(italic);                                     \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value fontItalic(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     return Napi::Boolean::New(env, this->instance->fontItalic());              \
   }                                                                            \
   Napi::Value setFontPointSize(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     double s = info[0].As<Napi::Number>().DoubleValue();                       \
     this->instance->setFontPointSize(s);                                       \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value fontPointSize(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     return Napi::Number::New(env, this->instance->fontPointSize());            \
   }                                                                            \
   Napi::Value setFontUnderline(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     bool underline = info[0].As<Napi::Boolean>().Value();                      \
     this->instance->setFontUnderline(underline);                               \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value fontUnderline(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     return Napi::Boolean::New(env, this->instance->fontUnderline());           \
   }                                                                            \
   Napi::Value setFontWeight(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     int weight = info[0].As<Napi::Number>().Int32Value();                      \
     this->instance->setFontWeight(weight);                                     \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value fontWeight(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     return Napi::Number::New(env, this->instance->fontWeight());               \
   }                                                                            \
   Napi::Value append(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string text = info[0].As<Napi::String>().Utf8Value();                 \
     this->instance->append(QString::fromUtf8(text.c_str()));                   \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value clear(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->clear();                                                   \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value copy(const Napi::CallbackInfo& info) {                           \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->copy();                                                    \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value cut(const Napi::CallbackInfo& info) {                            \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->cut();                                                     \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value insertHtml(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string text = info[0].As<Napi::String>().Utf8Value();                 \
     this->instance->insertHtml(QString::fromUtf8(text.c_str()));               \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value insertPlainText(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string text = info[0].As<Napi::String>().Utf8Value();                 \
     this->instance->insertPlainText(QString::fromUtf8(text.c_str()));          \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value paste(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->paste();                                                   \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value redo(const Napi::CallbackInfo& info) {                           \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->redo();                                                    \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value scrollToAnchor(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string name = info[0].As<Napi::String>().Utf8Value();                 \
     this->instance->scrollToAnchor(QString::fromUtf8(name.c_str()));           \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value selectAll(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->selectAll();                                               \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value setCurrentFont(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object fontObject = info[0].As<Napi::Object>();                      \
     QFontWrap* fontWrap = Napi::ObjectWrap<QFontWrap>::Unwrap(fontObject);     \
     this->instance->setCurrentFont(*fontWrap->getInternalInstance());          \
@@ -177,7 +152,6 @@
   }                                                                            \
   Napi::Value currentFont(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     QFont font = this->instance->currentFont();                                \
     auto instance = QFontWrap::constructor.New(                                \
         {Napi::External<QFont>::New(env, new QFont(font))});                   \
@@ -185,14 +159,12 @@
   }                                                                            \
   Napi::Value setText(const Napi::CallbackInfo& info) {                        \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     std::string text = info[0].As<Napi::String>().Utf8Value();                 \
     this->instance->setText(QString::fromUtf8(text.c_str()));                  \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value setTextBackgroundColor(const Napi::CallbackInfo& info) {         \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object colorObject = info[0].As<Napi::Object>();                     \
     QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject); \
     this->instance->setTextBackgroundColor(*colorWrap->getInternalInstance()); \
@@ -200,7 +172,6 @@
   }                                                                            \
   Napi::Value setTextColor(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     Napi::Object colorObject = info[0].As<Napi::Object>();                     \
     QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject); \
     this->instance->setTextColor(*colorWrap->getInternalInstance());           \
@@ -208,20 +179,17 @@
   }                                                                            \
   Napi::Value undo(const Napi::CallbackInfo& info) {                           \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     this->instance->undo();                                                    \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value zoomIn(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     int range = info[0].As<Napi::Number>().Int32Value();                       \
     this->instance->zoomIn(range);                                             \
     return env.Null();                                                         \
   }                                                                            \
   Napi::Value zoomOut(const Napi::CallbackInfo& info) {                        \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     int range = info[0].As<Napi::Number>().Int32Value();                       \
     this->instance->zoomOut(range);                                            \
     return env.Null();                                                         \

--- a/src/cpp/include/nodegui/QtWidgets/QWidget/qwidget_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QWidget/qwidget_macro.h
@@ -30,13 +30,11 @@
                                                                               \
   Napi::Value show(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->show();                                                   \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value resize(const Napi::CallbackInfo& info) {                        \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Number width = info[0].As<Napi::Number>();                          \
     Napi::Number height = info[1].As<Napi::Number>();                         \
     this->instance->resize(width.Int32Value(), height.Int32Value());          \
@@ -44,13 +42,11 @@
   }                                                                           \
   Napi::Value close(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool hasClosed = this->instance->close();                                 \
     return Napi::Boolean::New(env, hasClosed);                                \
   }                                                                           \
   Napi::Value mapFromGlobal(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object posObject = info[0].As<Napi::Object>();                      \
     QPointWrap* posWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(posObject);    \
     QPoint pt =                                                               \
@@ -61,7 +57,6 @@
   }                                                                           \
   Napi::Value mapFromParent(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object posObject = info[0].As<Napi::Object>();                      \
     QPointWrap* posWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(posObject);    \
     QPoint pt =                                                               \
@@ -72,7 +67,6 @@
   }                                                                           \
   Napi::Value mapToGlobal(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object posObject = info[0].As<Napi::Object>();                      \
     QPointWrap* posWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(posObject);    \
     QPoint pt = this->instance->mapToGlobal(*posWrap->getInternalInstance()); \
@@ -82,7 +76,6 @@
   }                                                                           \
   Napi::Value mapToParent(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object posObject = info[0].As<Napi::Object>();                      \
     QPointWrap* posWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(posObject);    \
     QPoint pt = this->instance->mapToParent(*posWrap->getInternalInstance()); \
@@ -92,14 +85,12 @@
   }                                                                           \
   Napi::Value isVisible(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool isVisible = this->instance->isVisible();                             \
     return Napi::Boolean::New(env, isVisible);                                \
   }                                                                           \
                                                                               \
   Napi::Value setLayout(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object layoutObject = info[0].As<Napi::Object>();                   \
     QLayoutWrap* layoutWrap =                                                 \
         Napi::ObjectWrap<QLayoutWrap>::Unwrap(layoutObject);                  \
@@ -109,7 +100,6 @@
                                                                               \
   Napi::Value setStyleSheet(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::String text = info[0].As<Napi::String>();                           \
     std::string style = text.Utf8Value();                                     \
     QString newStyle = QString::fromStdString(style);                         \
@@ -121,7 +111,6 @@
   }                                                                           \
   Napi::Value setCursor(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     if (info[0].IsNumber()) {                                                 \
       Napi::Number cursor = info[0].As<Napi::Number>();                       \
       this->instance->setCursor(                                              \
@@ -135,7 +124,6 @@
   }                                                                           \
   Napi::Value setWindowIcon(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object iconObject = info[0].As<Napi::Object>();                     \
     QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);    \
     this->instance->setWindowIcon(*iconWrap->getInternalInstance());          \
@@ -143,7 +131,6 @@
   }                                                                           \
   Napi::Value setWindowState(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Number state = info[0].As<Napi::Number>();                          \
     this->instance->setWindowState(                                           \
         static_cast<Qt::WindowState>(state.Int32Value()));                    \
@@ -151,13 +138,11 @@
   }                                                                           \
   Napi::Value windowState(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int state = static_cast<int>(this->instance->windowState());              \
     return Napi::Value::From(env, state);                                     \
   }                                                                           \
   Napi::Value setWindowTitle(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::String napiTitle = info[0].As<Napi::String>();                      \
     std::string title = napiTitle.Utf8Value();                                \
     this->instance->setWindowTitle(title.c_str());                            \
@@ -165,25 +150,21 @@
   }                                                                           \
   Napi::Value windowTitle(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QString title = this->instance->windowTitle();                            \
     return Napi::String::New(env, title.toStdString());                       \
   }                                                                           \
   Napi::Value styleSheet(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QString stylesheet = this->instance->styleSheet();                        \
     return Napi::String::New(env, stylesheet.toStdString());                  \
   }                                                                           \
   Napi::Value hide(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->hide();                                                   \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value move(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int x = info[0].As<Napi::Number>().Int32Value();                          \
     int y = info[1].As<Napi::Number>().Int32Value();                          \
     this->instance->move(x, y);                                               \
@@ -192,33 +173,28 @@
                                                                               \
   Napi::Value setMouseTracking(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Boolean isMouseTracked = info[0].As<Napi::Boolean>();               \
     this->instance->setMouseTracking(isMouseTracked.Value());                 \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value hasMouseTracking(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool isMouseTracked = this->instance->hasMouseTracking();                 \
     return Napi::Value::From(env, isMouseTracked);                            \
   }                                                                           \
   Napi::Value setEnabled(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Boolean enabled = info[0].As<Napi::Boolean>();                      \
     this->instance->setEnabled(enabled.Value());                              \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value isEnabled(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool enabled = this->instance->isEnabled();                               \
     return Napi::Value::From(env, enabled);                                   \
   }                                                                           \
   Napi::Value setFixedSize(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int width = info[0].As<Napi::Number>().Int32Value();                      \
     int height = info[1].As<Napi::Number>().Int32Value();                     \
     this->instance->setFixedSize(width, height);                              \
@@ -226,7 +202,6 @@
   }                                                                           \
   Napi::Value setGeometry(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int x = info[0].As<Napi::Number>().Int32Value();                          \
     int y = info[1].As<Napi::Number>().Int32Value();                          \
     int width = info[2].As<Napi::Number>().Int32Value();                      \
@@ -236,7 +211,6 @@
   }                                                                           \
   Napi::Value setMaximumSize(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int width = info[0].As<Napi::Number>().Int32Value();                      \
     int height = info[1].As<Napi::Number>().Int32Value();                     \
     this->instance->setMaximumSize(width, height);                            \
@@ -244,7 +218,6 @@
   }                                                                           \
   Napi::Value maximumSize(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QSize size = this->instance->maximumSize();                               \
     auto sizeWrap = QSizeWrap::constructor.New({Napi::External<QSize>::New(   \
         env, new QSize(size.width(), size.height()))});                       \
@@ -252,7 +225,6 @@
   }                                                                           \
   Napi::Value setMinimumSize(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int width = info[0].As<Napi::Number>().Int32Value();                      \
     int height = info[1].As<Napi::Number>().Int32Value();                     \
     this->instance->setMinimumSize(width, height);                            \
@@ -260,7 +232,6 @@
   }                                                                           \
   Napi::Value minimumSize(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QSize size = this->instance->minimumSize();                               \
     auto sizeWrap = QSizeWrap::constructor.New({Napi::External<QSize>::New(   \
         env, new QSize(size.width(), size.height()))});                       \
@@ -268,25 +239,21 @@
   }                                                                           \
   Napi::Value repaint(const Napi::CallbackInfo& info) {                       \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->repaint();                                                \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value update(const Napi::CallbackInfo& info) {                        \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->update();                                                 \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value updateGeometry(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->updateGeometry();                                         \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value pos(const Napi::CallbackInfo& info) {                           \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QPoint pos = this->instance->pos();                                       \
     Napi::Object posObj = Napi::Object::New(env);                             \
     posObj.Set("x", pos.x());                                                 \
@@ -295,7 +262,6 @@
   }                                                                           \
   Napi::Value size(const Napi::CallbackInfo& info) {                          \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QSize size = this->instance->size();                                      \
     auto sizeWrap = QSizeWrap::constructor.New({Napi::External<QSize>::New(   \
         env, new QSize(size.width(), size.height()))});                       \
@@ -303,7 +269,6 @@
   }                                                                           \
   Napi::Value setAttribute(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int attributeId = info[0].As<Napi::Number>().Int32Value();                \
     bool switchOn = info[1].As<Napi::Boolean>().Value();                      \
     this->instance->setAttribute(                                             \
@@ -312,7 +277,6 @@
   }                                                                           \
   Napi::Value testAttribute(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int attributeId = info[0].As<Napi::Number>().Int32Value();                \
     bool isOn = this->instance->testAttribute(                                \
         static_cast<Qt::WidgetAttribute>(attributeId));                       \
@@ -320,20 +284,17 @@
   }                                                                           \
   Napi::Value setWindowOpacity(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     float opacity = info[0].As<Napi::Number>().FloatValue();                  \
     this->instance->setWindowOpacity(opacity);                                \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value windowOpacity(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     float opacity = this->instance->windowOpacity();                          \
     return Napi::Value::From(env, opacity);                                   \
   }                                                                           \
   Napi::Value setWindowFlag(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int windowType = info[0].As<Napi::Number>().Int32Value();                 \
     bool switchOn = info[1].As<Napi::Boolean>().Value();                      \
     this->instance->setWindowFlag(static_cast<Qt::WindowType>(windowType),    \
@@ -342,55 +303,46 @@
   }                                                                           \
   Napi::Value adjustSize(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->adjustSize();                                             \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value activateWindow(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->activateWindow();                                         \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value raise(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->raise();                                                  \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value lower(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->lower();                                                  \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value showFullScreen(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->showFullScreen();                                         \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value showMaximized(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->showMaximized();                                          \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value showMinimized(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->showMinimized();                                          \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value showNormal(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->showNormal();                                             \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value addAction(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object actionObject = info[0].As<Napi::Object>();                   \
     QActionWrap* actionWrap =                                                 \
         Napi::ObjectWrap<QActionWrap>::Unwrap(actionObject);                  \
@@ -399,7 +351,6 @@
   }                                                                           \
   Napi::Value removeAction(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object actionObject = info[0].As<Napi::Object>();                   \
     QActionWrap* actionWrap =                                                 \
         Napi::ObjectWrap<QActionWrap>::Unwrap(actionObject);                  \
@@ -408,14 +359,12 @@
   }                                                                           \
   Napi::Value repolish(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->style()->unpolish(this->instance);                        \
     this->instance->style()->polish(this->instance);                          \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setGraphicsEffect(const Napi::CallbackInfo& info) {             \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     Napi::Object effectObject = info[0].As<Napi::Object>();                   \
     QObjectWrap* effectWrap =                                                 \
         Napi::ObjectWrap<QObjectWrap>::Unwrap(effectObject);                  \
@@ -426,32 +375,27 @@
   }                                                                           \
   Napi::Value acceptDrops(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     return Napi::Boolean::From(env, this->instance->acceptDrops());           \
   }                                                                           \
   Napi::Value setAcceptDrops(const Napi::CallbackInfo& info) {                \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool v = info[0].As<Napi::Boolean>().Value();                             \
     this->instance->setAcceptDrops(v);                                        \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setFocus(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int reason = info[0].As<Napi::Number>().Int32Value();                     \
     this->instance->setFocus(static_cast<Qt::FocusReason>(reason));           \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value clearFocus(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     this->instance->clearFocus();                                             \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setSizePolicy(const Napi::CallbackInfo& info) {                 \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QSizePolicy::Policy horizontal = static_cast<QSizePolicy::Policy>(        \
         info[0].As<Napi::Number>().Int32Value());                             \
     QSizePolicy::Policy vertical = static_cast<QSizePolicy::Policy>(          \
@@ -461,88 +405,75 @@
   }                                                                           \
   Napi::Value setMaximumHeight(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int maxh = info[0].As<Napi::Number>().Int32Value();                       \
     this->instance->setMaximumHeight(maxh);                                   \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setMinimumWidth(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int minw = info[0].As<Napi::Number>().Int32Value();                       \
     this->instance->setMinimumWidth(minw);                                    \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setMaximumWidth(const Napi::CallbackInfo& info) {               \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int maxw = info[0].As<Napi::Number>().Int32Value();                       \
     this->instance->setMaximumWidth(maxw);                                    \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setMinimumHeight(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     int minh = info[0].As<Napi::Number>().Int32Value();                       \
     this->instance->setMinimumHeight(minh);                                   \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value style(const Napi::CallbackInfo& info) {                         \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QStyle* style = this->instance->style();                                  \
     return QStyleWrap::constructor.New(                                       \
         {Napi::External<QStyle>::New(env, style)});                           \
   }                                                                           \
   Napi::Value isWindow(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool result = this->instance->isWindow();                                 \
     return Napi::Boolean::New(env, result);                                   \
   }                                                                           \
   Napi::Value isWindowModified(const Napi::CallbackInfo& info) {              \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool result = this->instance->isWindowModified();                         \
     return Napi::Boolean::New(env, result);                                   \
   }                                                                           \
   Napi::Value isHidden(const Napi::CallbackInfo& info) {                      \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool result = this->instance->isHidden();                                 \
     return Napi::Boolean::New(env, result);                                   \
   }                                                                           \
   Napi::Value setDisabled(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool disable = info[0].As<Napi::Boolean>().Value();                       \
     this->instance->setDisabled(disable);                                     \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setHidden(const Napi::CallbackInfo& info) {                     \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool hidden = info[0].As<Napi::Boolean>().Value();                        \
     this->instance->setHidden(hidden);                                        \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setVisible(const Napi::CallbackInfo& info) {                    \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool visible = info[0].As<Napi::Boolean>().Value();                       \
     this->instance->setVisible(visible);                                      \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value setWindowModified(const Napi::CallbackInfo& info) {             \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     bool modified = info[0].As<Napi::Boolean>().Value();                      \
     this->instance->setWindowModified(modified);                              \
     return env.Null();                                                        \
   }                                                                           \
   Napi::Value windowHandle(const Napi::CallbackInfo& info) {                  \
     Napi::Env env = info.Env();                                               \
-    Napi::HandleScope scope(env);                                             \
     QWindow* window = this->instance->windowHandle();                         \
     if (window) {                                                             \
       return WrapperCache::instance.get<QWindow, QWindowWrap>(env, window);   \

--- a/src/cpp/include/nodegui/core/YogaWidget/yogawidget_macro.h
+++ b/src/cpp/include/nodegui/core/YogaWidget/yogawidget_macro.h
@@ -23,7 +23,6 @@
   }                                                                            \
   Napi::Value setFlexNodeSizeControlled(const Napi::CallbackInfo& info) {      \
     Napi::Env env = info.Env();                                                \
-    Napi::HandleScope scope(env);                                              \
     FlexItem* item = dynamic_cast<FlexItem*>(this->instance.data());           \
     if (item) {                                                                \
       Napi::Boolean isSizeControlled = info[0].As<Napi::Boolean>();            \

--- a/src/cpp/lib/Extras/Utils/nutils.cpp
+++ b/src/cpp/lib/Extras/Utils/nutils.cpp
@@ -146,7 +146,6 @@ NUtilsWrap::NUtilsWrap(const Napi::CallbackInfo& info)
 Napi::Value StaticNUtilsWrapMethods::isNapiExternal(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() > 0 && info[0].IsExternal()) {
     return Napi::Boolean::New(env, true);
   }

--- a/src/cpp/lib/QtCore/QAbstractItemModel/qabstractitemmodel_wrap.cpp
+++ b/src/cpp/lib/QtCore/QAbstractItemModel/qabstractitemmodel_wrap.cpp
@@ -58,8 +58,6 @@ QAbstractItemModelWrap::~QAbstractItemModelWrap() {
 QAbstractItemModelWrap::QAbstractItemModelWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QAbstractItemModelWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance = new NAbstractItemModel();
 }
 
@@ -73,8 +71,6 @@ Napi::Value QAbstractItemModelWrap::initNodeDispatcher(
 
 Napi::Value QAbstractItemModelWrap::hasIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   QModelIndexWrap* modelIndexWrap =
@@ -89,8 +85,6 @@ Napi::Value QAbstractItemModelWrap::hasIndex(const Napi::CallbackInfo& info) {
 Napi::Value QAbstractItemModelWrap::createIndex(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
 
@@ -104,8 +98,6 @@ Napi::Value QAbstractItemModelWrap::createIndex(
 Napi::Value QAbstractItemModelWrap::_super_flags(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QModelIndexWrap* modelIndexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = modelIndexWrap->getInternalInstance();
@@ -119,8 +111,6 @@ Napi::Value QAbstractItemModelWrap::_super_flags(
 Napi::Value QAbstractItemModelWrap::emitDataChanged(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QModelIndexWrap* topLeftModelIndexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* topLeftIndex = topLeftModelIndexWrap->getInternalInstance();
@@ -144,8 +134,6 @@ Napi::Value QAbstractItemModelWrap::emitDataChanged(
 
 Napi::Value QAbstractItemModelWrap::checkIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QModelIndexWrap* modelIndexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = modelIndexWrap->getInternalInstance();
@@ -158,8 +146,6 @@ Napi::Value QAbstractItemModelWrap::checkIndex(const Napi::CallbackInfo& info) {
 Napi::Value QAbstractItemModelWrap::_super_buddy(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QModelIndexWrap* modelIndexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = modelIndexWrap->getInternalInstance();
@@ -174,7 +160,6 @@ Napi::Value QAbstractItemModelWrap::_super_buddy(
 Napi::Value QAbstractItemModelWrap::beginInsertColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* parent = parentWrap->getInternalInstance();
@@ -187,7 +172,6 @@ Napi::Value QAbstractItemModelWrap::beginInsertColumns(
 Napi::Value QAbstractItemModelWrap::beginInsertRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* parent = parentWrap->getInternalInstance();
@@ -200,7 +184,6 @@ Napi::Value QAbstractItemModelWrap::beginInsertRows(
 Napi::Value QAbstractItemModelWrap::beginMoveColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* sourceParentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* sourceParent = sourceParentWrap->getInternalInstance();
@@ -219,7 +202,6 @@ Napi::Value QAbstractItemModelWrap::beginMoveColumns(
 Napi::Value QAbstractItemModelWrap::beginMoveRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* sourceParentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* sourceParent = sourceParentWrap->getInternalInstance();
@@ -238,7 +220,6 @@ Napi::Value QAbstractItemModelWrap::beginMoveRows(
 Napi::Value QAbstractItemModelWrap::beginRemoveColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* parent = parentWrap->getInternalInstance();
@@ -251,7 +232,6 @@ Napi::Value QAbstractItemModelWrap::beginRemoveColumns(
 Napi::Value QAbstractItemModelWrap::beginRemoveRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* parent = parentWrap->getInternalInstance();
@@ -264,7 +244,6 @@ Napi::Value QAbstractItemModelWrap::beginRemoveRows(
 Napi::Value QAbstractItemModelWrap::beginResetModel(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_beginResetModel();
   return env.Null();
 }
@@ -272,7 +251,6 @@ Napi::Value QAbstractItemModelWrap::beginResetModel(
 Napi::Value QAbstractItemModelWrap::endInsertColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endInsertColumns();
   return env.Null();
 }
@@ -280,7 +258,6 @@ Napi::Value QAbstractItemModelWrap::endInsertColumns(
 Napi::Value QAbstractItemModelWrap::endInsertRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endInsertRows();
   return env.Null();
 }
@@ -288,7 +265,6 @@ Napi::Value QAbstractItemModelWrap::endInsertRows(
 Napi::Value QAbstractItemModelWrap::endMoveColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endMoveColumns();
   return env.Null();
 }
@@ -296,7 +272,6 @@ Napi::Value QAbstractItemModelWrap::endMoveColumns(
 Napi::Value QAbstractItemModelWrap::endMoveRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endMoveRows();
   return env.Null();
 }
@@ -304,7 +279,6 @@ Napi::Value QAbstractItemModelWrap::endMoveRows(
 Napi::Value QAbstractItemModelWrap::endRemoveColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endRemoveColumns();
   return env.Null();
 }
@@ -312,7 +286,6 @@ Napi::Value QAbstractItemModelWrap::endRemoveColumns(
 Napi::Value QAbstractItemModelWrap::endRemoveRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endRemoveRows();
   return env.Null();
 }
@@ -320,7 +293,6 @@ Napi::Value QAbstractItemModelWrap::endRemoveRows(
 Napi::Value QAbstractItemModelWrap::endResetModel(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->_protected_endResetModel();
   return env.Null();
 }

--- a/src/cpp/lib/QtCore/QDate/qdate_wrap.cpp
+++ b/src/cpp/lib/QtCore/QDate/qdate_wrap.cpp
@@ -43,8 +43,6 @@ Napi::Object QDateWrap::init(Napi::Env env, Napi::Object exports) {
 QDateWrap::QDateWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDateWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 3) {
     int y = info[0].As<Napi::Number>().Int32Value();
     int m = info[1].As<Napi::Number>().Int32Value();
@@ -68,8 +66,6 @@ QDate* QDateWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QDateWrap::addDays(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 ndays = info[0].As<Napi::Number>().Int64Value();
   QDate date = this->instance->addDays(ndays);
   auto instance = QDateWrap::constructor.New({Napi::External<QDate>::New(
@@ -79,7 +75,6 @@ Napi::Value QDateWrap::addDays(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateWrap::addMonths(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   int nmonths = info[0].As<Napi::Number>().Int32Value();
   QDate date = this->instance->addMonths(nmonths);
@@ -90,8 +85,6 @@ Napi::Value QDateWrap::addMonths(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateWrap::addYears(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int nyears = info[0].As<Napi::Number>().Int32Value();
   QDate date = this->instance->addYears(nyears);
   auto instance = QDateWrap::constructor.New({Napi::External<QDate>::New(
@@ -101,37 +94,31 @@ Napi::Value QDateWrap::addYears(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateWrap::day(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->day());
 }
 
 Napi::Value QDateWrap::dayOfWeek(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->dayOfWeek());
 }
 
 Napi::Value QDateWrap::dayOfYear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->dayOfYear());
 }
 
 Napi::Value QDateWrap::daysInMonth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->daysInMonth());
 }
 
 Napi::Value QDateWrap::daysInYear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->daysInYear());
 }
 
 Napi::Value QDateWrap::daysTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   Napi::Object dObject = info[0].As<Napi::Object>();
   QDateWrap* dWrap = Napi::ObjectWrap<QDateWrap>::Unwrap(dObject);
@@ -141,26 +128,21 @@ Napi::Value QDateWrap::daysTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->isNull());
 }
 
 Napi::Value QDateWrap::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->isValid());
 }
 
 Napi::Value QDateWrap::month(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->month());
 }
 
 Napi::Value QDateWrap::setDate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int year = info[0].As<Napi::Number>().Int32Value();
   int month = info[1].As<Napi::Number>().Int32Value();
   int day = info[2].As<Napi::Number>().Int32Value();
@@ -170,14 +152,11 @@ Napi::Value QDateWrap::setDate(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateWrap::toJulianDay(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->toJulianDay());
 }
 
 Napi::Value QDateWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString result;
   if (info[0].IsString()) {
     std::string format = info[0].As<Napi::String>().Utf8Value();
@@ -192,14 +171,11 @@ Napi::Value QDateWrap::toString(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateWrap::year(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->year());
 }
 
 Napi::Value StaticDateWrapMethods::currentDate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDate date = QDate::currentDate();
   auto instance = QDateWrap::constructor.New({Napi::External<QDate>::New(
       env, new QDate(date.year(), date.month(), date.day()))});
@@ -209,8 +185,6 @@ Napi::Value StaticDateWrapMethods::currentDate(const Napi::CallbackInfo& info) {
 Napi::Value StaticDateWrapMethods::fromJulianDay(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 jd = info[0].As<Napi::Number>().Int64Value();
   QDate date = QDate::fromJulianDay(jd);
   auto instance = QDateWrap::constructor.New({Napi::External<QDate>::New(
@@ -220,16 +194,12 @@ Napi::Value StaticDateWrapMethods::fromJulianDay(
 
 Napi::Value StaticDateWrapMethods::isLeapYear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int year = info[0].As<Napi::Number>().Int32Value();
   return Napi::Value::From(env, QDate::isLeapYear(year));
 }
 
 Napi::Value StaticDateWrapMethods::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int year = info[0].As<Napi::Number>().Int32Value();
   int month = info[1].As<Napi::Number>().Int32Value();
   int day = info[2].As<Napi::Number>().Int32Value();
@@ -238,8 +208,6 @@ Napi::Value StaticDateWrapMethods::isValid(const Napi::CallbackInfo& info) {
 }
 Napi::Value StaticDateWrapMethods::fromString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string dateString = info[0].As<Napi::String>().Utf8Value();
 
   QDate date;
@@ -260,7 +228,6 @@ Napi::Value StaticDateWrapMethods::fromString(const Napi::CallbackInfo& info) {
 Napi::Value StaticDateWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QDateTime/qdatetime_wrap.cpp
+++ b/src/cpp/lib/QtCore/QDateTime/qdatetime_wrap.cpp
@@ -59,8 +59,6 @@ Napi::Object QDateTimeWrap::init(Napi::Env env, Napi::Object exports) {
 QDateTimeWrap::QDateTimeWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDateTimeWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     Napi::Object dateObject = info[0].As<Napi::Object>();
     Napi::Object timeObject = info[1].As<Napi::Object>();
@@ -86,8 +84,6 @@ QDateTime* QDateTimeWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QDateTimeWrap::addDays(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 ndays = info[0].As<Napi::Number>().Int64Value();
   QDateTime result = this->instance->addDays(ndays);
   auto instance = QDateTimeWrap::constructor.New(
@@ -97,8 +93,6 @@ Napi::Value QDateTimeWrap::addDays(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::addMSecs(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 msecs = info[0].As<Napi::Number>().Int64Value();
   QDateTime result = this->instance->addMSecs(msecs);
   auto instance = QDateTimeWrap::constructor.New(
@@ -108,8 +102,6 @@ Napi::Value QDateTimeWrap::addMSecs(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::addMonths(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int nmonths = info[0].As<Napi::Number>().Int32Value();
   QDateTime result = this->instance->addMonths(nmonths);
   auto instance = QDateTimeWrap::constructor.New(
@@ -119,8 +111,6 @@ Napi::Value QDateTimeWrap::addMonths(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::addSecs(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 s = info[0].As<Napi::Number>().Int64Value();
   QDateTime result = this->instance->addSecs(s);
   auto instance = QDateTimeWrap::constructor.New(
@@ -130,8 +120,6 @@ Napi::Value QDateTimeWrap::addSecs(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::addYears(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int nyears = info[0].As<Napi::Number>().Int32Value();
   QDateTime result = this->instance->addYears(nyears);
   auto instance = QDateTimeWrap::constructor.New(
@@ -141,8 +129,6 @@ Napi::Value QDateTimeWrap::addYears(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::date(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDate date = this->instance->date();
   auto instance = QDateWrap::constructor.New({Napi::External<QDate>::New(
       env, new QDate(date.year(), date.month(), date.day()))});
@@ -151,8 +137,6 @@ Napi::Value QDateTimeWrap::date(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::daysTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object otherObject = info[0].As<Napi::Object>();
   QDateTimeWrap* otherWrap =
       Napi::ObjectWrap<QDateTimeWrap>::Unwrap(otherObject);
@@ -162,26 +146,21 @@ Napi::Value QDateTimeWrap::daysTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::isDaylightTime(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  return Napi::Value::From(env, this->instance->isDaylightTime());
+ return Napi::Value::From(env, this->instance->isDaylightTime());
 }
 
 Napi::Value QDateTimeWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  return Napi::Value::From(env, this->instance->isNull());
+ return Napi::Value::From(env, this->instance->isNull());
 }
 
 Napi::Value QDateTimeWrap::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  return Napi::Value::From(env, this->instance->isValid());
+ return Napi::Value::From(env, this->instance->isValid());
 }
 
 Napi::Value QDateTimeWrap::msecsTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object otherObject = info[0].As<Napi::Object>();
   QDateTimeWrap* otherWrap =
       Napi::ObjectWrap<QDateTimeWrap>::Unwrap(otherObject);
@@ -191,14 +170,11 @@ Napi::Value QDateTimeWrap::msecsTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::offsetFromUtc(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  return Napi::Value::From(env, this->instance->offsetFromUtc());
+ return Napi::Value::From(env, this->instance->offsetFromUtc());
 }
 
 Napi::Value QDateTimeWrap::secsTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object otherObject = info[0].As<Napi::Object>();
   QDateTimeWrap* otherWrap =
       Napi::ObjectWrap<QDateTimeWrap>::Unwrap(otherObject);
@@ -208,8 +184,6 @@ Napi::Value QDateTimeWrap::secsTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::setDate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object dateObject = info[0].As<Napi::Object>();
   QDateWrap* dateWrap = Napi::ObjectWrap<QDateWrap>::Unwrap(dateObject);
   this->instance->setDate(*dateWrap->getInternalInstance());
@@ -218,8 +192,6 @@ Napi::Value QDateTimeWrap::setDate(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::setMSecsSinceEpoch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 msecs = info[0].As<Napi::Number>().Int64Value();
   this->instance->setMSecsSinceEpoch(msecs);
   return env.Null();
@@ -227,8 +199,6 @@ Napi::Value QDateTimeWrap::setMSecsSinceEpoch(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::setOffsetFromUtc(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int offsetSeconds = info[0].As<Napi::Number>().Int32Value();
   this->instance->setOffsetFromUtc(offsetSeconds);
   return env.Null();
@@ -236,8 +206,6 @@ Napi::Value QDateTimeWrap::setOffsetFromUtc(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::setSecsSinceEpoch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qint64 secs = info[0].As<Napi::Number>().Int64Value();
   this->instance->setSecsSinceEpoch(secs);
   return env.Null();
@@ -245,8 +213,6 @@ Napi::Value QDateTimeWrap::setSecsSinceEpoch(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::setTime(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object timeObject = info[0].As<Napi::Object>();
   QTimeWrap* timeWrap = Napi::ObjectWrap<QTimeWrap>::Unwrap(timeObject);
   this->instance->setTime(*timeWrap->getInternalInstance());
@@ -255,8 +221,6 @@ Napi::Value QDateTimeWrap::setTime(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::setTimeSpec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int spec = info[0].As<Napi::Number>().Int32Value();
   this->instance->setTimeSpec(static_cast<Qt::TimeSpec>(spec));
   return env.Null();
@@ -264,8 +228,6 @@ Napi::Value QDateTimeWrap::setTimeSpec(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::time(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QTime time = this->instance->time();
   auto instance = QTimeWrap::constructor.New({Napi::External<QTime>::New(
       env, new QTime(time.hour(), time.minute(), time.second(), time.msec()))});
@@ -274,16 +236,12 @@ Napi::Value QDateTimeWrap::time(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::timeSpec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::TimeSpec spec = this->instance->timeSpec();
   return Napi::Value::From(env, static_cast<int>(spec));
 }
 
 Napi::Value QDateTimeWrap::toLocalTime(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDateTime local = this->instance->toLocalTime();
   auto instance = QDateTimeWrap::constructor.New(
       {Napi::External<QDateTime>::New(env, new QDateTime(local))});
@@ -292,14 +250,11 @@ Napi::Value QDateTimeWrap::toLocalTime(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::toMSecsSinceEpoch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->toMSecsSinceEpoch());
 }
 
 Napi::Value QDateTimeWrap::toOffsetFromUtc(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int offsetSeconds = info[0].As<Napi::Number>().Int32Value();
   QDateTime result = this->instance->toOffsetFromUtc(offsetSeconds);
   auto instance = QDateTimeWrap::constructor.New(
@@ -309,14 +264,11 @@ Napi::Value QDateTimeWrap::toOffsetFromUtc(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::toSecsSinceEpoch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->toSecsSinceEpoch());
 }
 
 Napi::Value QDateTimeWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString result;
   if (info[0].IsString()) {
     std::string format = info[0].As<Napi::String>().Utf8Value();
@@ -331,8 +283,6 @@ Napi::Value QDateTimeWrap::toString(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::toTimeSpec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int spec = info[0].As<Napi::Number>().Int32Value();
   QDateTime result =
       this->instance->toTimeSpec(static_cast<Qt::TimeSpec>(spec));
@@ -343,8 +293,6 @@ Napi::Value QDateTimeWrap::toTimeSpec(const Napi::CallbackInfo& info) {
 
 Napi::Value QDateTimeWrap::toUTC(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDateTime result = this->instance->toUTC();
   auto instance = QDateTimeWrap::constructor.New(
       {Napi::External<QDateTime>::New(env, new QDateTime(result))});
@@ -354,8 +302,6 @@ Napi::Value QDateTimeWrap::toUTC(const Napi::CallbackInfo& info) {
 Napi::Value StaticDateTimeWrapMethods::currentDateTime(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDateTime result = QDateTime::currentDateTime();
   auto instance = QDateTimeWrap::constructor.New(
       {Napi::External<QDateTime>::New(env, new QDateTime(result))});
@@ -365,8 +311,6 @@ Napi::Value StaticDateTimeWrapMethods::currentDateTime(
 Napi::Value StaticDateTimeWrapMethods::currentDateTimeUtc(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDateTime result = QDateTime::currentDateTimeUtc();
   auto instance = QDateTimeWrap::constructor.New(
       {Napi::External<QDateTime>::New(env, new QDateTime(result))});
@@ -376,22 +320,18 @@ Napi::Value StaticDateTimeWrapMethods::currentDateTimeUtc(
 Napi::Value StaticDateTimeWrapMethods::currentMSecsSinceEpoch(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, QDateTime::currentMSecsSinceEpoch());
 }
 
 Napi::Value StaticDateTimeWrapMethods::currentSecsSinceEpoch(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, QDateTime::currentSecsSinceEpoch());
 }
 
 Napi::Value StaticDateTimeWrapMethods::fromString(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string dateTimeString = info[0].As<Napi::String>().Utf8Value();
 
   QDateTime dateTime;
@@ -412,7 +352,6 @@ Napi::Value StaticDateTimeWrapMethods::fromString(
 Napi::Value StaticDateTimeWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QItemSelectionModel/qitemselectionmodel_wrap.cpp
+++ b/src/cpp/lib/QtCore/QItemSelectionModel/qitemselectionmodel_wrap.cpp
@@ -53,8 +53,6 @@ QItemSelectionModelWrap::~QItemSelectionModelWrap() {
 QItemSelectionModelWrap::QItemSelectionModelWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QItemSelectionModelWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 0) {
     this->instance = new NItemSelectionModel();
     this->disableDeletion = false;
@@ -66,7 +64,6 @@ QItemSelectionModelWrap::QItemSelectionModelWrap(const Napi::CallbackInfo& info)
 Napi::Value QItemSelectionModelWrap::columnIntersectsSelection(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int column = info[0].As<Napi::Number>().Int32Value();
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[1].As<Napi::Object>());
@@ -78,7 +75,6 @@ Napi::Value QItemSelectionModelWrap::columnIntersectsSelection(
 Napi::Value QItemSelectionModelWrap::currentIndex(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndex result = this->instance->currentIndex();
   auto resultInstance = QModelIndexWrap::constructor.New(
       {Napi::External<QModelIndex>::New(env, new QModelIndex(result))});
@@ -88,7 +84,6 @@ Napi::Value QItemSelectionModelWrap::currentIndex(
 Napi::Value QItemSelectionModelWrap::hasSelection(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->hasSelection();
   return Napi::Boolean::New(env, result);
 }
@@ -96,7 +91,6 @@ Napi::Value QItemSelectionModelWrap::hasSelection(
 Napi::Value QItemSelectionModelWrap::isColumnSelected(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int column = info[0].As<Napi::Number>().Int32Value();
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[1].As<Napi::Object>());
@@ -108,7 +102,6 @@ Napi::Value QItemSelectionModelWrap::isColumnSelected(
 Napi::Value QItemSelectionModelWrap::isRowSelected(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int row = info[0].As<Napi::Number>().Int32Value();
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[1].As<Napi::Object>());
@@ -120,7 +113,6 @@ Napi::Value QItemSelectionModelWrap::isRowSelected(
 Napi::Value QItemSelectionModelWrap::isSelected(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* indexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = indexWrap->getInternalInstance();
@@ -131,7 +123,6 @@ Napi::Value QItemSelectionModelWrap::isSelected(
 Napi::Value QItemSelectionModelWrap::rowIntersectsSelection(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int row = info[0].As<Napi::Number>().Int32Value();
   QModelIndexWrap* parentWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[1].As<Napi::Object>());
@@ -142,7 +133,6 @@ Napi::Value QItemSelectionModelWrap::rowIntersectsSelection(
 
 Napi::Value QItemSelectionModelWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clear();
   return env.Null();
 }
@@ -150,7 +140,6 @@ Napi::Value QItemSelectionModelWrap::clear(const Napi::CallbackInfo& info) {
 Napi::Value QItemSelectionModelWrap::clearCurrentIndex(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clearCurrentIndex();
   return env.Null();
 }
@@ -158,21 +147,18 @@ Napi::Value QItemSelectionModelWrap::clearCurrentIndex(
 Napi::Value QItemSelectionModelWrap::clearSelection(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clearSelection();
   return env.Null();
 }
 
 Napi::Value QItemSelectionModelWrap::reset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->reset();
   return env.Null();
 }
 
 Napi::Value QItemSelectionModelWrap::select(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* indexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = indexWrap->getInternalInstance();
@@ -186,7 +172,6 @@ Napi::Value QItemSelectionModelWrap::select(const Napi::CallbackInfo& info) {
 Napi::Value QItemSelectionModelWrap::setCurrentIndex(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* indexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = indexWrap->getInternalInstance();
@@ -199,7 +184,6 @@ Napi::Value QItemSelectionModelWrap::setCurrentIndex(
 Napi::Value QItemSelectionModelWrap::selectedColumns(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int row = info[0].As<Napi::Number>().Int32Value();
   QModelIndexList result = this->instance->selectedColumns(row);
   Napi::Array resultArrayNapi = Napi::Array::New(env, result.size());
@@ -213,7 +197,6 @@ Napi::Value QItemSelectionModelWrap::selectedColumns(
 Napi::Value QItemSelectionModelWrap::selectedIndexes(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexList result = this->instance->selectedIndexes();
   Napi::Array resultArrayNapi = Napi::Array::New(env, result.size());
   for (int i = 0; i < result.size(); i++) {
@@ -226,7 +209,6 @@ Napi::Value QItemSelectionModelWrap::selectedIndexes(
 Napi::Value QItemSelectionModelWrap::selectedRows(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int column = info[0].As<Napi::Number>().Int32Value();
   QModelIndexList result = this->instance->selectedRows(column);
   Napi::Array resultArrayNapi = Napi::Array::New(env, result.size());

--- a/src/cpp/lib/QtCore/QMimeData/qmimedata_wrap.cpp
+++ b/src/cpp/lib/QtCore/QMimeData/qmimedata_wrap.cpp
@@ -39,7 +39,6 @@ QMimeDataWrap::~QMimeDataWrap() { this->instance.reset(); }
 QMimeDataWrap::QMimeDataWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMimeDataWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QMimeData> eventObject =
         info[0].As<Napi::External<QMimeData>>();
@@ -102,23 +101,17 @@ void QMimeDataWrap::cloneFromMimeData(QMimeData* mimeReference) {
 
 Napi::Value QMimeDataWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QMimeDataWrap::hasColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasColor());
 }
 
 Napi::Value QMimeDataWrap::hasHtml(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasHtml());
 }
 
@@ -130,29 +123,21 @@ Napi::Value QMimeDataWrap::hasImage(const Napi::CallbackInfo& info) {
 
 Napi::Value QMimeDataWrap::hasText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasText());
 }
 
 Napi::Value QMimeDataWrap::hasUrls(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasUrls());
 }
 
 Napi::Value QMimeDataWrap::html(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::String::New(env, this->instance->html().toStdString());
 }
 
 Napi::Value QMimeDataWrap::removeFormat(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   this->instance->removeFormat(input0);
@@ -162,9 +147,7 @@ Napi::Value QMimeDataWrap::removeFormat(const Napi::CallbackInfo& info) {
 // TODO: Maybe implement a Buffer or UInt8Array
 // Napi::Value QMimeDataWrap::setData(const Napi::CallbackInfo& info) {
 //   Napi::Env env = info.Env();
-//   Napi::HandleScope scope(env);
-
-//   QString input0 =
+// //   QString input0 =
 //   QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
 //   Napi::Object wrap1_0 = info[1].As<Napi::Object>();
 //   constWrap* wrap1_1 = Napi::ObjectWrap<constWrap>::Unwrap(wrap1_0);
@@ -175,8 +158,6 @@ Napi::Value QMimeDataWrap::removeFormat(const Napi::CallbackInfo& info) {
 
 Napi::Value QMimeDataWrap::setHtml(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   this->instance->setHtml(input0);
@@ -185,8 +166,6 @@ Napi::Value QMimeDataWrap::setHtml(const Napi::CallbackInfo& info) {
 
 Napi::Value QMimeDataWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   this->instance->setText(input0);
@@ -195,8 +174,6 @@ Napi::Value QMimeDataWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QMimeDataWrap::setUrls(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array urls = info[0].As<Napi::Array>();
   QList<QUrl> list;
   for (int i = 0; i < urls.Length(); i++) {
@@ -211,15 +188,11 @@ Napi::Value QMimeDataWrap::setUrls(const Napi::CallbackInfo& info) {
 
 Napi::Value QMimeDataWrap::text(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::String::New(env, this->instance->text().toStdString());
 }
 
 Napi::Value QMimeDataWrap::urls(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QList<QUrl> urls = this->instance->urls();
   int length = urls.length();
   Napi::Array retval = Napi::Array::New(env, length);

--- a/src/cpp/lib/QtCore/QModelIndex/qmodelindex_wrap.cpp
+++ b/src/cpp/lib/QtCore/QModelIndex/qmodelindex_wrap.cpp
@@ -31,8 +31,6 @@ Napi::Object QModelIndexWrap::init(Napi::Env env, Napi::Object exports) {
 QModelIndexWrap::QModelIndexWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QModelIndexWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = std::unique_ptr<QModelIndex>(
@@ -56,13 +54,11 @@ QModelIndex* QModelIndexWrap::getInternalInstance() {
 
 Napi::Value QModelIndexWrap::column(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->column());
 }
 
 Napi::Value QModelIndexWrap::data(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int role = info[0].As<Napi::Number>().Int32Value();
   QVariant data = this->instance->data(role);
   auto instance = QVariantWrap::constructor.New(
@@ -72,20 +68,17 @@ Napi::Value QModelIndexWrap::data(const Napi::CallbackInfo& info) {
 
 Napi::Value QModelIndexWrap::flags(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Qt::ItemFlags flags = this->instance->flags();
   return Napi::Value::From(env, static_cast<int>(flags));
 }
 
 Napi::Value QModelIndexWrap::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->isValid());
 }
 
 Napi::Value QModelIndexWrap::parent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndex parent = this->instance->parent();
   auto instance = QModelIndexWrap::constructor.New(
       {Napi::External<QModelIndex>::New(env, new QModelIndex(parent))});
@@ -94,13 +87,11 @@ Napi::Value QModelIndexWrap::parent(const Napi::CallbackInfo& info) {
 
 Napi::Value QModelIndexWrap::row(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->row());
 }
 
 Napi::Value QModelIndexWrap::sibling(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   QModelIndex sibling = this->instance->sibling(row, column);
@@ -111,7 +102,6 @@ Napi::Value QModelIndexWrap::sibling(const Napi::CallbackInfo& info) {
 
 Napi::Value QModelIndexWrap::siblingAtColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int column = info[0].As<Napi::Number>().Int32Value();
   QModelIndex index = this->instance->siblingAtColumn(column);
   auto instance = QModelIndexWrap::constructor.New(
@@ -121,7 +111,6 @@ Napi::Value QModelIndexWrap::siblingAtColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QModelIndexWrap::siblingAtRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int row = info[0].As<Napi::Number>().Int32Value();
   QModelIndex index = this->instance->siblingAtRow(row);
   auto instance = QModelIndexWrap::constructor.New(
@@ -132,7 +121,6 @@ Napi::Value QModelIndexWrap::siblingAtRow(const Napi::CallbackInfo& info) {
 Napi::Value StaticQModelIndexWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QObject/qobject_wrap.cpp
+++ b/src/cpp/lib/QtCore/QObject/qobject_wrap.cpp
@@ -21,7 +21,6 @@ QObjectWrap::~QObjectWrap() { extrautils::safeDelete(this->instance); }
 QObjectWrap::QObjectWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QObjectWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance = info[0].As<Napi::External<NObject>>().Data();

--- a/src/cpp/lib/QtCore/QPoint/qpoint_wrap.cpp
+++ b/src/cpp/lib/QtCore/QPoint/qpoint_wrap.cpp
@@ -27,8 +27,6 @@ Napi::Object QPointWrap::init(Napi::Env env, Napi::Object exports) {
 QPointWrap::QPointWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPointWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     int xpos = info[0].As<Napi::Number>().Int32Value();
     int ypos = info[1].As<Napi::Number>().Int32Value();
@@ -51,34 +49,29 @@ QPoint* QPointWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QPointWrap::setX(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  int x = info[0].As<Napi::Number>().Int32Value();
+ int x = info[0].As<Napi::Number>().Int32Value();
   this->instance->setX(x);
   return env.Null();
 }
 Napi::Value QPointWrap::setY(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  int y = info[0].As<Napi::Number>().Int32Value();
+ int y = info[0].As<Napi::Number>().Int32Value();
   this->instance->setY(y);
   return env.Null();
 }
 Napi::Value QPointWrap::x(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  return Napi::Value::From(env, this->instance->x());
+ return Napi::Value::From(env, this->instance->x());
 }
 Napi::Value QPointWrap::y(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  return Napi::Value::From(env, this->instance->y());
+ return Napi::Value::From(env, this->instance->y());
 }
 
 Napi::Value StaticQPointWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  Napi::Object variantObject = info[0].As<Napi::Object>();
+ Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);
   QVariant* variant = variantWrap->getInternalInstance();
@@ -90,22 +83,17 @@ Napi::Value StaticQPointWrapMethods::fromQVariant(
 
 Napi::Value QPointWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isNull());
 }
 
 Napi::Value QPointWrap::manhattanLength(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->manhattanLength());
 }
 
 Napi::Value QPointWrap::transposed(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  QPoint ret = this->instance->transposed();
+ QPoint ret = this->instance->transposed();
   auto instance = QPointWrap::constructor.New(
       {Napi::External<QPoint>::New(env, new QPoint(ret))});
   return instance;

--- a/src/cpp/lib/QtCore/QPointF/qpointf_wrap.cpp
+++ b/src/cpp/lib/QtCore/QPointF/qpointf_wrap.cpp
@@ -34,8 +34,6 @@ QPointF* QPointFWrap::getInternalInstance() { return this->instance.get(); }
 QPointFWrap::QPointFWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPointFWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     qreal xpos = info[0].As<Napi::Number>().DoubleValue();
     qreal ypos = info[1].As<Napi::Number>().DoubleValue();
@@ -57,8 +55,6 @@ QPointFWrap::QPointFWrap(const Napi::CallbackInfo& info)
 Napi::Value StaticQPointFWrapMethods::dotProduct(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -70,22 +66,16 @@ Napi::Value StaticQPointFWrapMethods::dotProduct(
 
 Napi::Value QPointFWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isNull());
 }
 
 Napi::Value QPointFWrap::manhattanLength(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->manhattanLength());
 }
 
 Napi::Value QPointFWrap::setX(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setX(input0);
   return env.Null();
@@ -93,8 +83,6 @@ Napi::Value QPointFWrap::setX(const Napi::CallbackInfo& info) {
 
 Napi::Value QPointFWrap::setY(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setY(input0);
   return env.Null();
@@ -120,8 +108,6 @@ Napi::Value QPointFWrap::transposed(const Napi::CallbackInfo& info) {
 
 Napi::Value QPointFWrap::x(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->x());
 }
 

--- a/src/cpp/lib/QtCore/QRect/qrect_wrap.cpp
+++ b/src/cpp/lib/QtCore/QRect/qrect_wrap.cpp
@@ -28,8 +28,6 @@ Napi::Object QRectWrap::init(Napi::Env env, Napi::Object exports) {
 QRectWrap::QRectWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QRectWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 4) {
     int x = info[0].As<Napi::Number>().Int32Value();
     int y = info[1].As<Napi::Number>().Int32Value();
@@ -54,14 +52,12 @@ QRect* QRectWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QRectWrap::setHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int height = info[0].As<Napi::Number>().Int32Value();
   this->instance->setHeight(height);
   return env.Null();
 }
 Napi::Value QRectWrap::setWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int width = info[0].As<Napi::Number>().Int32Value();
   this->instance->setWidth(width);
   return env.Null();
@@ -69,43 +65,36 @@ Napi::Value QRectWrap::setWidth(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectWrap::setLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setLeft(value);
   return env.Null();
 }
 Napi::Value QRectWrap::setTop(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setTop(value);
   return env.Null();
 }
 Napi::Value QRectWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->height());
 }
 Napi::Value QRectWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->width());
 }
 Napi::Value QRectWrap::left(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->left());
 }
 Napi::Value QRectWrap::top(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->top());
 }
 
 Napi::Value StaticQRectWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QRectF/qrectf_wrap.cpp
+++ b/src/cpp/lib/QtCore/QRectF/qrectf_wrap.cpp
@@ -83,7 +83,6 @@ QRectFWrap::~QRectFWrap() { this->instance.reset(); }
 QRectFWrap::QRectFWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QRectFWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 4) {
     qreal x = info[0].As<Napi::Number>().DoubleValue();
     qreal y = info[1].As<Napi::Number>().DoubleValue();
@@ -106,8 +105,6 @@ QRectFWrap::QRectFWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QRectFWrap::adjust(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   qreal input2 = info[2].As<Napi::Number>().DoubleValue();
@@ -118,8 +115,6 @@ Napi::Value QRectFWrap::adjust(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::adjusted(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   qreal input2 = info[2].As<Napi::Number>().DoubleValue();
@@ -133,15 +128,11 @@ Napi::Value QRectFWrap::adjusted(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::bottom(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->bottom());
 }
 
 Napi::Value QRectFWrap::bottomLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPointF ret = this->instance->bottomLeft();
   auto instance = QPointFWrap::constructor.New(
       {Napi::External<QPointF>::New(env, new QPointF(ret))});
@@ -150,8 +141,6 @@ Napi::Value QRectFWrap::bottomLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::bottomRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPointF ret = this->instance->bottomRight();
   auto instance = QPointFWrap::constructor.New(
       {Napi::External<QPointF>::New(env, new QPointF(ret))});
@@ -160,8 +149,6 @@ Napi::Value QRectFWrap::bottomRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::center(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPointF ret = this->instance->center();
   auto instance = QPointFWrap::constructor.New(
       {Napi::External<QPointF>::New(env, new QPointF(ret))});
@@ -170,8 +157,6 @@ Napi::Value QRectFWrap::center(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::contains_QPoint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -180,8 +165,6 @@ Napi::Value QRectFWrap::contains_QPoint(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::contains_QRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QRectFWrap* wrap0_1 = Napi::ObjectWrap<QRectFWrap>::Unwrap(wrap0_0);
   QRectF* input0 = wrap0_1->getInternalInstance();
@@ -190,8 +173,6 @@ Napi::Value QRectFWrap::contains_QRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::contains(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   return Napi::Boolean::New(env, this->instance->contains(input0, input1));
@@ -199,15 +180,11 @@ Napi::Value QRectFWrap::contains(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->height());
 }
 
 Napi::Value QRectFWrap::intersected(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QRectFWrap* wrap0_1 = Napi::ObjectWrap<QRectFWrap>::Unwrap(wrap0_0);
   QRectF* input0 = wrap0_1->getInternalInstance();
@@ -220,8 +197,6 @@ Napi::Value QRectFWrap::intersected(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::intersects(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QRectFWrap* wrap0_1 = Napi::ObjectWrap<QRectFWrap>::Unwrap(wrap0_0);
   QRectF* input0 = wrap0_1->getInternalInstance();
@@ -230,36 +205,26 @@ Napi::Value QRectFWrap::intersects(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::isEmpty(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isEmpty());
 }
 
 Napi::Value QRectFWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isNull());
 }
 
 Napi::Value QRectFWrap::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isValid());
 }
 
 Napi::Value QRectFWrap::left(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->left());
 }
 
 Napi::Value QRectFWrap::moveBottom(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->moveBottom(input0);
   return env.Null();
@@ -267,8 +232,6 @@ Napi::Value QRectFWrap::moveBottom(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveBottomLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -278,8 +241,6 @@ Napi::Value QRectFWrap::moveBottomLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveBottomRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -289,8 +250,6 @@ Napi::Value QRectFWrap::moveBottomRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveCenter(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -300,8 +259,6 @@ Napi::Value QRectFWrap::moveCenter(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->moveLeft(input0);
   return env.Null();
@@ -309,8 +266,6 @@ Napi::Value QRectFWrap::moveLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->moveRight(input0);
   return env.Null();
@@ -318,8 +273,6 @@ Napi::Value QRectFWrap::moveRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   this->instance->moveTo(input0, input1);
@@ -328,8 +281,6 @@ Napi::Value QRectFWrap::moveTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveTo_QPoint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -339,8 +290,6 @@ Napi::Value QRectFWrap::moveTo_QPoint(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveTop(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->moveTop(input0);
   return env.Null();
@@ -348,8 +297,6 @@ Napi::Value QRectFWrap::moveTop(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveTopLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -359,8 +306,6 @@ Napi::Value QRectFWrap::moveTopLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::moveTopRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -370,8 +315,6 @@ Napi::Value QRectFWrap::moveTopRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::normalized(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QRectF ret = this->instance->normalized();
   auto instance = QRectFWrap::constructor.New(
       {Napi::External<QRectF>::New(env, new QRectF(ret))});
@@ -380,15 +323,11 @@ Napi::Value QRectFWrap::normalized(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::right(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->right());
 }
 
 Napi::Value QRectFWrap::setBottom(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setBottom(input0);
   return env.Null();
@@ -396,8 +335,6 @@ Napi::Value QRectFWrap::setBottom(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setBottomLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -407,8 +344,6 @@ Napi::Value QRectFWrap::setBottomLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setBottomRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -418,8 +353,6 @@ Napi::Value QRectFWrap::setBottomRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setCoords(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   qreal input2 = info[2].As<Napi::Number>().DoubleValue();
@@ -430,8 +363,6 @@ Napi::Value QRectFWrap::setCoords(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setHeight(input0);
   return env.Null();
@@ -439,8 +370,6 @@ Napi::Value QRectFWrap::setHeight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setLeft(input0);
   return env.Null();
@@ -448,8 +377,6 @@ Napi::Value QRectFWrap::setLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   qreal input2 = info[2].As<Napi::Number>().DoubleValue();
@@ -460,8 +387,6 @@ Napi::Value QRectFWrap::setRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setRight(input0);
   return env.Null();
@@ -469,8 +394,6 @@ Napi::Value QRectFWrap::setRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setTop(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setTop(input0);
   return env.Null();
@@ -478,8 +401,6 @@ Napi::Value QRectFWrap::setTop(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setTopLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -489,8 +410,6 @@ Napi::Value QRectFWrap::setTopLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setTopRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -500,8 +419,6 @@ Napi::Value QRectFWrap::setTopRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setWidth(input0);
   return env.Null();
@@ -509,8 +426,6 @@ Napi::Value QRectFWrap::setWidth(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setX(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setX(input0);
   return env.Null();
@@ -518,8 +433,6 @@ Napi::Value QRectFWrap::setX(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::setY(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setY(input0);
   return env.Null();
@@ -527,8 +440,6 @@ Napi::Value QRectFWrap::setY(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::toAlignedRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QRect ret = this->instance->toAlignedRect();
   auto instance = QRectWrap::constructor.New(
       {Napi::External<QRect>::New(env, new QRect(ret))});
@@ -537,8 +448,6 @@ Napi::Value QRectFWrap::toAlignedRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::toRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QRect ret = this->instance->toRect();
   auto instance = QRectWrap::constructor.New(
       {Napi::External<QRect>::New(env, new QRect(ret))});
@@ -547,15 +456,11 @@ Napi::Value QRectFWrap::toRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::top(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->top());
 }
 
 Napi::Value QRectFWrap::topLeft(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPointF ret = this->instance->topLeft();
   auto instance = QPointFWrap::constructor.New(
       {Napi::External<QPointF>::New(env, new QPointF(ret))});
@@ -564,8 +469,6 @@ Napi::Value QRectFWrap::topLeft(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::topRight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPointF ret = this->instance->topRight();
   auto instance = QPointFWrap::constructor.New(
       {Napi::External<QPointF>::New(env, new QPointF(ret))});
@@ -574,8 +477,6 @@ Napi::Value QRectFWrap::topRight(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::translate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
   this->instance->translate(input0, input1);
@@ -584,8 +485,6 @@ Napi::Value QRectFWrap::translate(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::translate_QPoint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -595,8 +494,6 @@ Napi::Value QRectFWrap::translate_QPoint(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::translated(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal input0 = info[0].As<Napi::Number>().DoubleValue();
   qreal input1 = info[1].As<Napi::Number>().DoubleValue();
 
@@ -608,8 +505,6 @@ Napi::Value QRectFWrap::translated(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::translated_QPoint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointFWrap* wrap0_1 = Napi::ObjectWrap<QPointFWrap>::Unwrap(wrap0_0);
   QPointF* input0 = wrap0_1->getInternalInstance();
@@ -622,8 +517,6 @@ Napi::Value QRectFWrap::translated_QPoint(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::transposed(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QRectF ret = this->instance->transposed();
   auto instance = QRectFWrap::constructor.New(
       {Napi::External<QRectF>::New(env, new QRectF(ret))});
@@ -632,8 +525,6 @@ Napi::Value QRectFWrap::transposed(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::united(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QRectFWrap* wrap0_1 = Napi::ObjectWrap<QRectFWrap>::Unwrap(wrap0_0);
   QRectF* input0 = wrap0_1->getInternalInstance();
@@ -646,21 +537,15 @@ Napi::Value QRectFWrap::united(const Napi::CallbackInfo& info) {
 
 Napi::Value QRectFWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->width());
 }
 
 Napi::Value QRectFWrap::x(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->x());
 }
 
 Napi::Value QRectFWrap::y(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->y());
 }

--- a/src/cpp/lib/QtCore/QSize/qsize_wrap.cpp
+++ b/src/cpp/lib/QtCore/QSize/qsize_wrap.cpp
@@ -24,8 +24,6 @@ Napi::Object QSizeWrap::init(Napi::Env env, Napi::Object exports) {
 QSizeWrap::QSizeWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSizeWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     int width = info[0].As<Napi::Number>().Int32Value();
     int height = info[1].As<Napi::Number>().Int32Value();
@@ -48,33 +46,28 @@ QSize* QSizeWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QSizeWrap::setHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int height = info[0].As<Napi::Number>().Int32Value();
   this->instance->setHeight(height);
   return env.Null();
 }
 Napi::Value QSizeWrap::setWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int width = info[0].As<Napi::Number>().Int32Value();
   this->instance->setWidth(width);
   return env.Null();
 }
 Napi::Value QSizeWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->height());
 }
 Napi::Value QSizeWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->width());
 }
 
 Napi::Value StaticQSizeWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QSizeF/qsizef_wrap.cpp
+++ b/src/cpp/lib/QtCore/QSizeF/qsizef_wrap.cpp
@@ -24,8 +24,6 @@ Napi::Object QSizeFWrap::init(Napi::Env env, Napi::Object exports) {
 QSizeFWrap::QSizeFWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSizeFWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     int width = info[0].As<Napi::Number>().Int32Value();
     int height = info[1].As<Napi::Number>().Int32Value();
@@ -48,33 +46,28 @@ QSizeF* QSizeFWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QSizeFWrap::setHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal height = info[0].As<Napi::Number>().FloatValue();
   this->instance->setHeight(height);
   return env.Null();
 }
 Napi::Value QSizeFWrap::setWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal width = info[0].As<Napi::Number>().FloatValue();
   this->instance->setWidth(width);
   return env.Null();
 }
 Napi::Value QSizeFWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->height());
 }
 Napi::Value QSizeFWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->width());
 }
 
 Napi::Value StaticQSizeFWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QTime/qtime_wrap.cpp
+++ b/src/cpp/lib/QtCore/QTime/qtime_wrap.cpp
@@ -41,8 +41,6 @@ Napi::Object QTimeWrap::init(Napi::Env env, Napi::Object exports) {
 QTimeWrap::QTimeWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTimeWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 4) {
     int h = info[0].As<Napi::Number>().Int32Value();
     int m = info[1].As<Napi::Number>().Int32Value();
@@ -67,8 +65,6 @@ QTime* QTimeWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QTimeWrap::addMSecs(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int ms = info[0].As<Napi::Number>().Int32Value();
   QTime time = this->instance->addMSecs(ms);
   auto instance = QTimeWrap::constructor.New({Napi::External<QTime>::New(
@@ -78,8 +74,6 @@ Napi::Value QTimeWrap::addMSecs(const Napi::CallbackInfo& info) {
 
 Napi::Value QTimeWrap::addSecs(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int s = info[0].As<Napi::Number>().Int32Value();
   QTime time = this->instance->addSecs(s);
   auto instance = QTimeWrap::constructor.New({Napi::External<QTime>::New(
@@ -89,50 +83,41 @@ Napi::Value QTimeWrap::addSecs(const Napi::CallbackInfo& info) {
 
 Napi::Value QTimeWrap::elapsed(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->elapsed());
 }
 
 Napi::Value QTimeWrap::hour(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->hour());
 }
 
 Napi::Value QTimeWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->isNull());
 }
 
 Napi::Value QTimeWrap::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->isValid());
 }
 
 Napi::Value QTimeWrap::minute(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->minute());
 }
 
 Napi::Value QTimeWrap::msec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->msec());
 }
 
 Napi::Value QTimeWrap::msecsSinceStartOfDay(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->msecsSinceStartOfDay());
 }
 
 Napi::Value QTimeWrap::msecsTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object tObject = info[0].As<Napi::Object>();
   QTimeWrap* tWrap = Napi::ObjectWrap<QTimeWrap>::Unwrap(tObject);
   int result = this->instance->msecsTo(*tWrap->getInternalInstance());
@@ -141,21 +126,17 @@ Napi::Value QTimeWrap::msecsTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QTimeWrap::restart(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->restart();
   return Napi::Value::From(env, result);
 }
 
 Napi::Value QTimeWrap::second(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->second());
 }
 
 Napi::Value QTimeWrap::secsTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object tObject = info[0].As<Napi::Object>();
   QTimeWrap* tWrap = Napi::ObjectWrap<QTimeWrap>::Unwrap(tObject);
   int result = this->instance->secsTo(*tWrap->getInternalInstance());
@@ -164,8 +145,6 @@ Napi::Value QTimeWrap::secsTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QTimeWrap::setHMS(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int h = info[0].As<Napi::Number>().Int32Value();
   int m = info[1].As<Napi::Number>().Int32Value();
   int s = info[2].As<Napi::Number>().Int32Value();
@@ -176,15 +155,12 @@ Napi::Value QTimeWrap::setHMS(const Napi::CallbackInfo& info) {
 
 Napi::Value QTimeWrap::start(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->start();
   return env.Null();
 }
 
 Napi::Value QTimeWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString result;
   if (info[0].IsString()) {
     std::string format = info[0].As<Napi::String>().Utf8Value();
@@ -199,8 +175,6 @@ Napi::Value QTimeWrap::toString(const Napi::CallbackInfo& info) {
 
 Napi::Value StaticTimeWrapMethods::currentTime(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QTime time = QTime::currentTime();
   auto instance = QTimeWrap::constructor.New({Napi::External<QTime>::New(
       env, new QTime(time.hour(), time.minute(), time.second(), time.msec()))});
@@ -210,8 +184,6 @@ Napi::Value StaticTimeWrapMethods::currentTime(const Napi::CallbackInfo& info) {
 Napi::Value StaticTimeWrapMethods::fromMSecsSinceStartOfDay(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int msecs = info[0].As<Napi::Number>().Int32Value();
   QTime time = QTime::fromMSecsSinceStartOfDay(msecs);
   auto instance = QTimeWrap::constructor.New({Napi::External<QTime>::New(
@@ -221,8 +193,6 @@ Napi::Value StaticTimeWrapMethods::fromMSecsSinceStartOfDay(
 
 Napi::Value StaticTimeWrapMethods::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int h = info[0].As<Napi::Number>().Int32Value();
   int m = info[1].As<Napi::Number>().Int32Value();
   int s = info[2].As<Napi::Number>().Int32Value();
@@ -233,8 +203,6 @@ Napi::Value StaticTimeWrapMethods::isValid(const Napi::CallbackInfo& info) {
 
 Napi::Value StaticTimeWrapMethods::fromString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string timeString = info[0].As<Napi::String>().Utf8Value();
 
   QTime time;
@@ -255,7 +223,6 @@ Napi::Value StaticTimeWrapMethods::fromString(const Napi::CallbackInfo& info) {
 Napi::Value StaticTimeWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtCore/QUrl/qurl_wrap.cpp
+++ b/src/cpp/lib/QtCore/QUrl/qurl_wrap.cpp
@@ -65,7 +65,6 @@ Napi::Object QUrlWrap::init(Napi::Env env, Napi::Object exports) {
 QUrlWrap::QUrlWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QUrlWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   if (info.Length() == 2) {
     std::string url = info[0].As<Napi::String>().Utf8Value();
@@ -95,7 +94,6 @@ QUrl* QUrlWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QUrlWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString url = this->instance->toString();
   return Napi::Value::From(env, url.toStdString());
 }
@@ -103,7 +101,6 @@ Napi::Value QUrlWrap::toString(const Napi::CallbackInfo& info) {
 Napi::Value StaticQUrlWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);
@@ -118,8 +115,6 @@ Napi::Value StaticQUrlWrapMethods::fromQVariant(
 
 Napi::Value QUrlWrap::adjusted(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::FormattingOptions input0 =
       (QUrl::FormattingOptions)info[0].As<Napi::Number>().Int32Value();
 
@@ -131,7 +126,6 @@ Napi::Value QUrlWrap::adjusted(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::authority(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
@@ -141,23 +135,17 @@ Napi::Value QUrlWrap::authority(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QUrlWrap::errorString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::String::New(env, this->instance->errorString().toStdString());
 }
 
 Napi::Value QUrlWrap::fileName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->fileName(input0).toStdString());
@@ -165,8 +153,6 @@ Napi::Value QUrlWrap::fileName(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::fragment(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->fragment(input0).toStdString());
@@ -174,22 +160,16 @@ Napi::Value QUrlWrap::fragment(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::hasFragment(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasFragment());
 }
 
 Napi::Value QUrlWrap::hasQuery(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasQuery());
 }
 
 Napi::Value QUrlWrap::host(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->host(input0).toStdString());
@@ -197,21 +177,16 @@ Napi::Value QUrlWrap::host(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::isEmpty(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isEmpty());
 }
 
 Napi::Value QUrlWrap::isLocalFile(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isLocalFile());
 }
 
 Napi::Value QUrlWrap::isParentOf(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QUrlWrap* wrap0_1 = Napi::ObjectWrap<QUrlWrap>::Unwrap(wrap0_0);
@@ -221,22 +196,16 @@ Napi::Value QUrlWrap::isParentOf(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::isRelative(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isRelative());
 }
 
 Napi::Value QUrlWrap::isValid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isValid());
 }
 
 Napi::Value QUrlWrap::matches(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QUrlWrap* wrap0_1 = Napi::ObjectWrap<QUrlWrap>::Unwrap(wrap0_0);
   QUrl* input0 = wrap0_1->getInternalInstance();
@@ -247,8 +216,6 @@ Napi::Value QUrlWrap::matches(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::password(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->password(input0).toStdString());
@@ -256,8 +223,6 @@ Napi::Value QUrlWrap::password(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::path(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->path(input0).toStdString());
@@ -265,16 +230,12 @@ Napi::Value QUrlWrap::path(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::port(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int input0 = info[0].As<Napi::Number>().Int32Value();
   return Napi::Number::New(env, this->instance->port(input0));
 }
 
 Napi::Value QUrlWrap::query(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->query(input0).toStdString());
@@ -282,8 +243,6 @@ Napi::Value QUrlWrap::query(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::resolved(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QUrlWrap* wrap0_1 = Napi::ObjectWrap<QUrlWrap>::Unwrap(wrap0_0);
   QUrl* input0 = wrap0_1->getInternalInstance();
@@ -296,15 +255,11 @@ Napi::Value QUrlWrap::resolved(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::scheme(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::String::New(env, this->instance->scheme().toStdString());
 }
 
 Napi::Value QUrlWrap::setAuthority(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -315,8 +270,6 @@ Napi::Value QUrlWrap::setAuthority(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setFragment(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -327,8 +280,6 @@ Napi::Value QUrlWrap::setFragment(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setHost(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -339,8 +290,6 @@ Napi::Value QUrlWrap::setHost(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setPassword(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -351,8 +300,6 @@ Napi::Value QUrlWrap::setPassword(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setPath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -363,8 +310,6 @@ Napi::Value QUrlWrap::setPath(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setPort(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int input0 = info[0].As<Napi::Number>().Int32Value();
   this->instance->setPort(input0);
   return env.Null();
@@ -372,8 +317,6 @@ Napi::Value QUrlWrap::setPort(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setQuery(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -384,8 +327,6 @@ Napi::Value QUrlWrap::setQuery(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setScheme(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   this->instance->setScheme(input0);
@@ -394,8 +335,6 @@ Napi::Value QUrlWrap::setScheme(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setUrl(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -406,8 +345,6 @@ Napi::Value QUrlWrap::setUrl(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setUserInfo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -418,8 +355,6 @@ Napi::Value QUrlWrap::setUserInfo(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::setUserName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
   QUrl::ParsingMode input1 =
@@ -430,8 +365,6 @@ Napi::Value QUrlWrap::setUserName(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::swap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QUrlWrap* wrap0_1 = Napi::ObjectWrap<QUrlWrap>::Unwrap(wrap0_0);
   QUrl* input0 = wrap0_1->getInternalInstance();
@@ -441,8 +374,6 @@ Napi::Value QUrlWrap::swap(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::toDisplayString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::FormattingOptions input0 =
       (QUrl::FormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(
@@ -451,15 +382,11 @@ Napi::Value QUrlWrap::toDisplayString(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::toLocalFile(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::String::New(env, this->instance->toLocalFile().toStdString());
 }
 
 Napi::Value QUrlWrap::toString_withOpts(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::FormattingOptions input0 =
       (QUrl::FormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->toString(input0).toStdString());
@@ -467,8 +394,6 @@ Napi::Value QUrlWrap::toString_withOpts(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::url(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::FormattingOptions input0 =
       (QUrl::FormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->url(input0).toStdString());
@@ -476,8 +401,6 @@ Napi::Value QUrlWrap::url(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::userInfo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->userInfo(input0).toStdString());
@@ -485,8 +408,6 @@ Napi::Value QUrlWrap::userInfo(const Napi::CallbackInfo& info) {
 
 Napi::Value QUrlWrap::userName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QUrl::ComponentFormattingOptions input0 =
       (QUrl::ComponentFormattingOptions)info[0].As<Napi::Number>().Int32Value();
   return Napi::String::New(env, this->instance->userName(input0).toStdString());
@@ -496,7 +417,6 @@ Napi::Value QUrlWrap::userName(const Napi::CallbackInfo& info) {
 Napi::Value StaticQUrlWrapMethods::fromLocalFile(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString input0 =
       QString::fromStdString(info[0].As<Napi::String>().Utf8Value());
 
@@ -509,7 +429,6 @@ Napi::Value StaticQUrlWrapMethods::fromLocalFile(
 Napi::Value StaticQUrlWrapMethods::fromUserInput(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     QString input0 =
         QString::fromStdString(info[0].As<Napi::String>().Utf8Value());

--- a/src/cpp/lib/QtCore/QVariant/qvariant_wrap.cpp
+++ b/src/cpp/lib/QtCore/QVariant/qvariant_wrap.cpp
@@ -27,7 +27,6 @@ QVariant* QVariantWrap::getInternalInstance() { return this->instance.data(); }
 QVariantWrap::QVariantWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QVariantWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     this->instance =
         QSharedPointer<QVariant>(info[0].As<Napi::External<QVariant>>().Data());
@@ -39,31 +38,26 @@ QVariantWrap::QVariantWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QVariantWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString value = this->instance->value<QString>();
   return Napi::Value::From(env, value.toStdString());
 }
 Napi::Value QVariantWrap::toInt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = this->instance->value<int>();
   return Napi::Value::From(env, value);
 }
 Napi::Value QVariantWrap::toDouble(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   double value = this->instance->value<double>();
   return Napi::Value::From(env, value);
 }
 Napi::Value QVariantWrap::toBool(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool value = this->instance->value<bool>();
   return Napi::Value::From(env, value);
 }
 Napi::Value QVariantWrap::toStringList(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QStringList value = this->instance->toStringList();
   Napi::Array result = Napi::Array::New(env, value.size());
   for (int i = 0; i < value.size(); i++) {
@@ -75,7 +69,6 @@ Napi::Value QVariantWrap::toStringList(const Napi::CallbackInfo& info) {
 Napi::Value StaticQVariantWrapMethods::convertToQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Value value = info[0];
   QVariant* variant = extrautils::convertToQVariant(env, value);
   // Use the variant from extrautils::convertToQVariant function as is and do

--- a/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp
+++ b/src/cpp/lib/QtGui/QApplication/qapplication_wrap.cpp
@@ -41,7 +41,6 @@ Napi::Object QApplicationWrap::init(Napi::Env env, Napi::Object exports) {
 QApplicationWrap::QApplicationWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QApplicationWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     this->instance = info[0].As<Napi::External<NApplication>>().Data();
   } else if (info.Length() == 0) {
@@ -63,28 +62,24 @@ NApplication* QApplicationWrap::getInternalInstance() { return this->instance; }
 
 Napi::Value QApplicationWrap::processEvents(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->processEvents();
   return env.Null();
 }
 
 Napi::Value QApplicationWrap::exec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int exitCode = this->instance->exec();
   return Napi::Number::New(env, exitCode);
 }
 
 Napi::Value QApplicationWrap::quit(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->quit();
   return env.Null();
 }
 
 Napi::Value QApplicationWrap::exit(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number exitCode = info[0].As<Napi::Number>();
   this->instance->exit(exitCode.Int32Value());
   return env.Null();
@@ -92,8 +87,6 @@ Napi::Value QApplicationWrap::exit(const Napi::CallbackInfo& info) {
 
 Napi::Value QApplicationWrap::palette(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPalette* palette = new QPalette(this->instance->palette());
   return QPaletteWrap::constructor.New(
       {Napi::External<QPalette>::New(env, palette)});
@@ -101,7 +94,6 @@ Napi::Value QApplicationWrap::palette(const Napi::CallbackInfo& info) {
 
 Napi::Value QApplicationWrap::setStyleSheet(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String text = info[0].As<Napi::String>();
   std::string style = text.Utf8Value();
   QString newStyle = QString::fromStdString(style);
@@ -115,7 +107,6 @@ Napi::Value QApplicationWrap::setStyleSheet(const Napi::CallbackInfo& info) {
 Napi::Value StaticQApplicationWrapMethods::instance(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   NApplication* app = static_cast<NApplication*>(QCoreApplication::instance());
   Napi::Object instance = QApplicationWrap::constructor.New(
       {Napi::External<NApplication>::New(env, app)});
@@ -137,8 +128,6 @@ Napi::Value StaticQApplicationWrapMethods::clipboard(
 Napi::Value StaticQApplicationWrapMethods::setStyle(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QStyleWrap* styleWrap =
       Napi::ObjectWrap<QStyleWrap>::Unwrap(info[0].As<Napi::Object>());
   QStyle* style = styleWrap->getInternalInstance();
@@ -150,7 +139,6 @@ Napi::Value StaticQApplicationWrapMethods::setStyle(
 Napi::Value StaticQApplicationWrapMethods::style(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QStyle* style = QApplication::style();
   return QStyleWrap::constructor.New({Napi::External<QStyle>::New(env, style)});
 }
@@ -158,8 +146,6 @@ Napi::Value StaticQApplicationWrapMethods::style(
 Napi::Value QApplicationWrap::setQuitOnLastWindowClosed(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Boolean quit = info[0].As<Napi::Boolean>();
   this->instance->setQuitOnLastWindowClosed(quit.Value());
   return env.Null();
@@ -168,7 +154,6 @@ Napi::Value QApplicationWrap::setQuitOnLastWindowClosed(
 Napi::Value QApplicationWrap::quitOnLastWindowClosed(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool quit = this->instance->quitOnLastWindowClosed();
   return Napi::Value::From(env, quit);
 }
@@ -176,7 +161,6 @@ Napi::Value QApplicationWrap::quitOnLastWindowClosed(
 Napi::Value StaticQApplicationWrapMethods::primaryScreen(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto screen = QApplication::primaryScreen();
   if (screen) {
     return WrapperCache::instance.get<QScreen, QScreenWrap>(env, screen);
@@ -188,8 +172,6 @@ Napi::Value StaticQApplicationWrapMethods::primaryScreen(
 Napi::Value StaticQApplicationWrapMethods::screens(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   auto screens = QApplication::screens();
   Napi::Array jsArray = Napi::Array::New(env, screens.size());
   for (int i = 0; i < screens.size(); i++) {
@@ -203,8 +185,6 @@ Napi::Value StaticQApplicationWrapMethods::screens(
 
 Napi::Value QApplicationWrap::devicePixelRatio(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   qreal result = this->instance->devicePixelRatio();
   return Napi::Value::From(env, result);
 }

--- a/src/cpp/lib/QtGui/QBrush/qbrush_wrap.cpp
+++ b/src/cpp/lib/QtGui/QBrush/qbrush_wrap.cpp
@@ -29,8 +29,6 @@ Napi::Object QBrushWrap::init(Napi::Env env, Napi::Object exports) {
 QBrushWrap::QBrushWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QBrushWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     if (info[0].IsNumber()) {
       Qt::GlobalColor color =
@@ -64,15 +62,11 @@ QBrush* QBrushWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QBrushWrap::isOpaque(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isOpaque());
 }
 
 Napi::Value QBrushWrap::setColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info[0].IsNumber()) {
     Qt::GlobalColor color =
         (Qt::GlobalColor)info[0].As<Napi::Number>().Int32Value();
@@ -87,8 +81,6 @@ Napi::Value QBrushWrap::setColor(const Napi::CallbackInfo& info) {
 
 Napi::Value QBrushWrap::color(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QColor color = this->instance->color();
   auto instance = QColorWrap::constructor.New(
       {Napi::External<QColor>::New(env, new QColor(color))});
@@ -97,8 +89,6 @@ Napi::Value QBrushWrap::color(const Napi::CallbackInfo& info) {
 
 Napi::Value QBrushWrap::setStyle(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::BrushStyle style =
       (Qt::BrushStyle)info[0].As<Napi::Number>().Int32Value();
   this->instance->setStyle(style);
@@ -107,16 +97,12 @@ Napi::Value QBrushWrap::setStyle(const Napi::CallbackInfo& info) {
 
 Napi::Value QBrushWrap::style(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::BrushStyle style = this->instance->style();
   return Napi::Number::New(env, static_cast<int>(style));
 }
 
 Napi::Value QBrushWrap::setTexture(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object pixmapObject = info[0].As<Napi::Object>();
   QPixmapWrap* pixmapWrap = Napi::ObjectWrap<QPixmapWrap>::Unwrap(pixmapObject);
   this->instance->setTexture(*pixmapWrap->getInternalInstance());
@@ -125,8 +111,6 @@ Napi::Value QBrushWrap::setTexture(const Napi::CallbackInfo& info) {
 
 Napi::Value QBrushWrap::texture(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPixmap pixmap = this->instance->texture();
   auto instance = QPixmapWrap::constructor.New(
       {Napi::External<QPixmap>::New(env, new QPixmap(pixmap))});
@@ -136,8 +120,6 @@ Napi::Value QBrushWrap::texture(const Napi::CallbackInfo& info) {
 Napi::Value StaticQBrushWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp
+++ b/src/cpp/lib/QtGui/QClipboard/qclipboard_wrap.cpp
@@ -25,7 +25,6 @@ Napi::Object QClipboardWrap::init(Napi::Env env, Napi::Object exports) {
 QClipboardWrap::QClipboardWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QClipboardWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info[0].IsExternal()) {
     this->instance = info[0].As<Napi::External<QClipboard>>().Data();
   } else {
@@ -72,7 +71,6 @@ void QClipboardWrap::connectSignalsToEventEmitter() {
 
 Napi::Value QClipboardWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number mode = info[0].As<Napi::Number>();
   this->instance->clear(static_cast<QClipboard::Mode>(mode.Int32Value()));
   return env.Null();
@@ -80,7 +78,6 @@ Napi::Value QClipboardWrap::clear(const Napi::CallbackInfo& info) {
 
 Napi::Value QClipboardWrap::setPixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   Napi::Object pixmapObject = info[0].As<Napi::Object>();
   QPixmapWrap* pixmapWrap = Napi::ObjectWrap<QPixmapWrap>::Unwrap(pixmapObject);
@@ -92,7 +89,6 @@ Napi::Value QClipboardWrap::setPixmap(const Napi::CallbackInfo& info) {
 
 Napi::Value QClipboardWrap::pixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number mode = info[0].As<Napi::Number>();
   QPixmap pixmap =
       this->instance->pixmap(static_cast<QClipboard::Mode>(mode.Int32Value()));
@@ -103,7 +99,6 @@ Napi::Value QClipboardWrap::pixmap(const Napi::CallbackInfo& info) {
 
 Napi::Value QClipboardWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String text = info[0].As<Napi::String>();
   Napi::Number mode = info[1].As<Napi::Number>();
   QString clipboardText = text.Utf8Value().c_str();
@@ -114,7 +109,6 @@ Napi::Value QClipboardWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QClipboardWrap::text(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number mode = info[0].As<Napi::Number>();
   QString text =
       this->instance->text(static_cast<QClipboard::Mode>(mode.Int32Value()));

--- a/src/cpp/lib/QtGui/QColor/qcolor_wrap.cpp
+++ b/src/cpp/lib/QtGui/QColor/qcolor_wrap.cpp
@@ -30,8 +30,6 @@ Napi::Object QColorWrap::init(Napi::Env env, Napi::Object exports) {
 QColorWrap::QColorWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QColorWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 4) {
     int r = info[0].As<Napi::Number>().Int32Value();
     int g = info[1].As<Napi::Number>().Int32Value();
@@ -71,67 +69,56 @@ QColor* QColorWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QColorWrap::setRed(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int red = info[0].As<Napi::Number>().Int32Value();
   this->instance->setRed(red);
   return env.Null();
 }
 Napi::Value QColorWrap::red(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->red());
 }
 Napi::Value QColorWrap::setGreen(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setGreen(value);
   return env.Null();
 }
 Napi::Value QColorWrap::green(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->green());
 }
 Napi::Value QColorWrap::setBlue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setBlue(value);
   return env.Null();
 }
 Napi::Value QColorWrap::blue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->blue());
 }
 Napi::Value QColorWrap::setAlpha(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setAlpha(value);
   return env.Null();
 }
 Napi::Value QColorWrap::alpha(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->alpha());
 }
 Napi::Value QColorWrap::rgb(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->rgb());
 }
 Napi::Value QColorWrap::rgba(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->rgba());
 }
 
 Napi::Value StaticQColorWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp
+++ b/src/cpp/lib/QtGui/QCursor/qcursor_wrap.cpp
@@ -21,7 +21,6 @@ Napi::Object QCursorWrap::init(Napi::Env env, Napi::Object exports) {
 QCursorWrap::QCursorWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QCursorWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::Number cursor = info[0].As<Napi::Number>();
     this->instance = std::make_unique<QCursor>(
@@ -41,7 +40,6 @@ QCursor* QCursorWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QCursorWrap::pos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QPoint pos = this->instance->pos();
   Napi::Object posObj = Napi::Object::New(env);
   posObj.Set("x", pos.x());
@@ -51,7 +49,6 @@ Napi::Value QCursorWrap::pos(const Napi::CallbackInfo& info) {
 
 Napi::Value QCursorWrap::setPos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number x = info[0].As<Napi::Number>();
   Napi::Number y = info[1].As<Napi::Number>();
   this->instance->setPos(x.Int32Value(), y.Int32Value());

--- a/src/cpp/lib/QtGui/QDrag/qdrag_wrap.cpp
+++ b/src/cpp/lib/QtGui/QDrag/qdrag_wrap.cpp
@@ -40,7 +40,6 @@ NDrag* QDragWrap::getInternalInstance() { return this->instance; }
 QDragWrap::QDragWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDragWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::Object wrap0_0 = info[0].As<Napi::Object>();
     QObjectWrap* wrap0_1 = Napi::ObjectWrap<QObjectWrap>::Unwrap(wrap0_0);
@@ -62,14 +61,11 @@ QDragWrap::~QDragWrap() {
 
 Napi::Value QDragWrap::defaultAction(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, this->instance->defaultAction());
 }
 
 Napi::Value QDragWrap::dragCursor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::DropAction input0 =
       (Qt::DropAction)info[0].As<Napi::Number>().Int32Value();
 
@@ -81,8 +77,6 @@ Napi::Value QDragWrap::dragCursor(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::exec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() < 2) {
     Qt::DropActions input0 =
         (Qt::DropActions)info[0].As<Napi::Number>().Int32Value();
@@ -97,8 +91,6 @@ Napi::Value QDragWrap::exec(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::hotSpot(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPoint ret = this->instance->hotSpot();
   auto instance = QPointWrap::constructor.New(
       {Napi::External<QPoint>::New(env, new QPoint(ret))});
@@ -107,7 +99,6 @@ Napi::Value QDragWrap::hotSpot(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::pixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QPixmap ret = this->instance->pixmap();
   auto instance = QPixmapWrap::constructor.New(
       {Napi::External<QPixmap>::New(env, new QPixmap(ret))});
@@ -116,8 +107,6 @@ Napi::Value QDragWrap::pixmap(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::setDragCursor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPixmapWrap* wrap0_1 = Napi::ObjectWrap<QPixmapWrap>::Unwrap(wrap0_0);
   QPixmap* input0 = wrap0_1->getInternalInstance();
@@ -129,8 +118,6 @@ Napi::Value QDragWrap::setDragCursor(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::setHotSpot(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPointWrap* wrap0_1 = Napi::ObjectWrap<QPointWrap>::Unwrap(wrap0_0);
   QPoint* input0 = wrap0_1->getInternalInstance();
@@ -140,8 +127,6 @@ Napi::Value QDragWrap::setHotSpot(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::setPixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QPixmapWrap* wrap0_1 = Napi::ObjectWrap<QPixmapWrap>::Unwrap(wrap0_0);
   QPixmap* input0 = wrap0_1->getInternalInstance();
@@ -151,22 +136,18 @@ Napi::Value QDragWrap::setPixmap(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::supportedActions(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, this->instance->supportedActions());
 }
 
 // Static Methods here
 Napi::Value StaticQDragWrapMethods::cancel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QDrag::cancel();
   return env.Null();
 }
 
 Napi::Value QDragWrap::mimeData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   const QMimeData* ret = this->instance->mimeData();
 
   QMimeData* clone = new QMimeData();
@@ -179,8 +160,6 @@ Napi::Value QDragWrap::mimeData(const Napi::CallbackInfo& info) {
 
 Napi::Value QDragWrap::setMimeData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QMimeDataWrap* wrap0_1 = Napi::ObjectWrap<QMimeDataWrap>::Unwrap(wrap0_0);
   QMimeData* input0 = wrap0_1->getInternalInstance();
@@ -197,8 +176,6 @@ Napi::Value QDragWrap::setMimeData(const Napi::CallbackInfo& info) {
 // This function crashes the application
 Napi::Value QDragWrap::source(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QObject* source = this->instance->source();
   // We can likely call a wrap directly since QObjectWrap is smart and uses
   // QPointer?
@@ -210,8 +187,6 @@ Napi::Value QDragWrap::source(const Napi::CallbackInfo& info) {
 // This function crashes the application
 Napi::Value QDragWrap::target(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QObject* target = this->instance->target();
   // We can likely call a wrap directly since QObjectWrap is smart and uses
   // QPointer?

--- a/src/cpp/lib/QtGui/QEvent/QDragLeaveEvent/qdragleaveevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QDragLeaveEvent/qdragleaveevent_wrap.cpp
@@ -26,7 +26,6 @@ QDragLeaveEvent* QDragLeaveEventWrap::getInternalInstance() {
 QDragLeaveEventWrap::QDragLeaveEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDragLeaveEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QDragLeaveEvent> eventObject =
         info[0].As<Napi::External<QDragLeaveEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QDragMoveEvent/qdragmoveevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QDragMoveEvent/qdragmoveevent_wrap.cpp
@@ -53,7 +53,6 @@ QDragMoveEvent* QDragMoveEventWrap::getInternalInstance() {
 QDragMoveEventWrap::QDragMoveEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDragMoveEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QDragMoveEvent> eventObject =
         info[0].As<Napi::External<QDragMoveEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QDropEvent/qdropevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QDropEvent/qdropevent_wrap.cpp
@@ -37,7 +37,6 @@ QDropEvent* QDropEventWrap::getInternalInstance() { return this->instance; }
 QDropEventWrap::QDropEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDropEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QDropEvent> eventObject =
         info[0].As<Napi::External<QDropEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QKeyEvent/qkeyevent_wrap.cpp
@@ -29,7 +29,6 @@ QKeyEvent* QKeyEventWrap::getInternalInstance() { return this->instance; }
 QKeyEventWrap::QKeyEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QKeyEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QKeyEvent> eventObject =
         info[0].As<Napi::External<QKeyEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QMouseEvent/qmouseevent_wrap.cpp
@@ -31,7 +31,6 @@ QMouseEvent* QMouseEventWrap::getInternalInstance() { return this->instance; }
 QMouseEventWrap::QMouseEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMouseEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QMouseEvent> eventObject =
         info[0].As<Napi::External<QMouseEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QNativeGestureEvent/qnativegestureevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QNativeGestureEvent/qnativegestureevent_wrap.cpp
@@ -37,7 +37,6 @@ QNativeGestureEvent* QNativeGestureEventWrap::getInternalInstance() {
 QNativeGestureEventWrap::QNativeGestureEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QNativeGestureEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QNativeGestureEvent> eventObject =
         info[0].As<Napi::External<QNativeGestureEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QPaintEvent/qpaintevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QPaintEvent/qpaintevent_wrap.cpp
@@ -24,7 +24,6 @@ QPaintEvent* QPaintEventWrap::getInternalInstance() { return this->instance; }
 QPaintEventWrap::QPaintEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPaintEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QPaintEvent> eventObject =
         info[0].As<Napi::External<QPaintEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QTabletEvent/qtabletevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QTabletEvent/qtabletevent_wrap.cpp
@@ -47,7 +47,6 @@ QTabletEvent* QTabletEventWrap::getInternalInstance() { return this->instance; }
 QTabletEventWrap::QTabletEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTabletEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QTabletEvent> eventObject =
         info[0].As<Napi::External<QTabletEvent>>();

--- a/src/cpp/lib/QtGui/QEvent/QWheelEvent/qwheelevent_wrap.cpp
+++ b/src/cpp/lib/QtGui/QEvent/QWheelEvent/qwheelevent_wrap.cpp
@@ -34,7 +34,6 @@ QWheelEvent* QWheelEventWrap::getInternalInstance() { return this->instance; }
 QWheelEventWrap::QWheelEventWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QWheelEventWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::External<QWheelEvent> eventObject =
         info[0].As<Napi::External<QWheelEvent>>();

--- a/src/cpp/lib/QtGui/QFont/qfont_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFont/qfont_wrap.cpp
@@ -39,8 +39,6 @@ Napi::Object QFontWrap::init(Napi::Env env, Napi::Object exports) {
 QFontWrap::QFontWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFontWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 4) {
     std::string family = info[0].As<Napi::String>().Utf8Value();
     int pointSize = info[1].As<Napi::Number>().Int32Value();
@@ -66,7 +64,6 @@ QFont* QFontWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QFontWrap::setBold(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int enable = info[0].As<Napi::Boolean>().Value();
   this->instance->setBold(enable);
   return env.Null();
@@ -74,13 +71,11 @@ Napi::Value QFontWrap::setBold(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::bold(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->bold());
 }
 
 Napi::Value QFontWrap::setCapitalization(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   QFont::Capitalization caps = static_cast<QFont::Capitalization>(
       info[0].As<Napi::Number>().Int32Value());
@@ -90,14 +85,12 @@ Napi::Value QFontWrap::setCapitalization(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::capitalization(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env,
                            static_cast<int>(this->instance->capitalization()));
 }
 
 Napi::Value QFontWrap::setFamily(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string family = info[0].As<Napi::String>().Utf8Value();
   this->instance->setFamily(QString::fromStdString(family.c_str()));
   return env.Null();
@@ -105,14 +98,12 @@ Napi::Value QFontWrap::setFamily(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::family(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString family = this->instance->family();
   return Napi::String::New(env, family.toStdString());
 }
 
 Napi::Value QFontWrap::setPixelSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int pointSize = info[0].As<Napi::Number>().Int32Value();
   this->instance->setPixelSize(pointSize);
   return env.Null();
@@ -120,7 +111,6 @@ Napi::Value QFontWrap::setPixelSize(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::setPointSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int pointSize = info[0].As<Napi::Number>().Int32Value();
   this->instance->setPointSize(pointSize);
   return env.Null();
@@ -128,19 +118,16 @@ Napi::Value QFontWrap::setPointSize(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::pixelSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->pixelSize());
 }
 
 Napi::Value QFontWrap::pointSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->pointSize());
 }
 
 Napi::Value QFontWrap::setStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int factor = info[0].As<Napi::Number>().Int32Value();
   this->instance->setStretch(factor);
   return env.Null();
@@ -148,13 +135,11 @@ Napi::Value QFontWrap::setStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::stretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->stretch());
 }
 
 Napi::Value QFontWrap::setWeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int weight = info[0].As<Napi::Number>().Int32Value();
   this->instance->setWeight(weight);
   return env.Null();
@@ -162,13 +147,11 @@ Napi::Value QFontWrap::setWeight(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::weight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->weight());
 }
 
 Napi::Value QFontWrap::setItalic(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int enable = info[0].As<Napi::Boolean>().Value();
   this->instance->setItalic(enable);
   return env.Null();
@@ -176,13 +159,11 @@ Napi::Value QFontWrap::setItalic(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::italic(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->italic());
 }
 
 Napi::Value QFontWrap::setStyleName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string styleName = info[0].As<Napi::String>().Utf8Value();
   this->instance->setStyleName(QString::fromStdString(styleName.c_str()));
   return env.Null();
@@ -190,7 +171,6 @@ Napi::Value QFontWrap::setStyleName(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString value = this->instance->toString();
   return Napi::String::New(env, value.toStdString());
 }
@@ -198,7 +178,6 @@ Napi::Value QFontWrap::toString(const Napi::CallbackInfo& info) {
 Napi::Value StaticQFontWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QFontDatabase/qfontdatabase_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFontDatabase/qfontdatabase_wrap.cpp
@@ -30,7 +30,6 @@ Napi::Object QFontDatabaseWrap::init(Napi::Env env, Napi::Object exports) {
 QFontDatabaseWrap::QFontDatabaseWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFontDatabaseWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance = std::make_unique<QFontDatabase>();
   this->rawData = extrautils::configureComponent(this->getInternalInstance());
 }
@@ -57,7 +56,6 @@ Napi::Value QFontDatabaseWrap::families(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontDatabaseWrap::bold(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string family = info[0].As<Napi::String>().Utf8Value();
   std::string style = info[1].As<Napi::String>().Utf8Value();
   bool result = this->instance->bold(QString::fromUtf8(family.c_str()),
@@ -67,7 +65,6 @@ Napi::Value QFontDatabaseWrap::bold(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontDatabaseWrap::isFixedPitch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   std::string family = info[0].As<Napi::String>().Utf8Value();
 
@@ -84,7 +81,6 @@ Napi::Value QFontDatabaseWrap::isFixedPitch(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontDatabaseWrap::italic(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string family = info[0].As<Napi::String>().Utf8Value();
   std::string style = info[1].As<Napi::String>().Utf8Value();
   bool result = this->instance->italic(QString::fromUtf8(family.c_str()),
@@ -107,7 +103,6 @@ Napi::Value QFontDatabaseWrap::styles(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontDatabaseWrap::weight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string family = info[0].As<Napi::String>().Utf8Value();
   std::string style = info[1].As<Napi::String>().Utf8Value();
   int result = this->instance->weight(QString::fromUtf8(family.c_str()),
@@ -118,7 +113,6 @@ Napi::Value QFontDatabaseWrap::weight(const Napi::CallbackInfo& info) {
 Napi::Value StaticQFontDatabaseWrapMethods::addApplicationFont(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string fileName = info[0].As<Napi::String>().Utf8Value();
   int id =
       QFontDatabase::addApplicationFont(QString::fromUtf8(fileName.c_str()));
@@ -128,7 +122,6 @@ Napi::Value StaticQFontDatabaseWrapMethods::addApplicationFont(
 Napi::Value StaticQFontDatabaseWrapMethods::applicationFontFamilies(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   int id = info[0].As<Napi::Number>().Int32Value();
   QStringList keys = QFontDatabase::applicationFontFamilies(id);
@@ -145,7 +138,6 @@ Napi::Value StaticQFontDatabaseWrapMethods::applicationFontFamilies(
 Napi::Value StaticQFontDatabaseWrapMethods::removeApplicationFont(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int id = info[0].As<Napi::Number>().Int32Value();
   bool result = QFontDatabase::removeApplicationFont(id);
   return Napi::Value::From(env, result);

--- a/src/cpp/lib/QtGui/QFontMetrics/qfontmetrics_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFontMetrics/qfontmetrics_wrap.cpp
@@ -49,8 +49,6 @@ Napi::Object QFontMetricsWrap::init(Napi::Env env, Napi::Object exports) {
 QFontMetricsWrap::QFontMetricsWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFontMetricsWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance = std::unique_ptr<QFontMetrics>(
@@ -74,51 +72,37 @@ QFontMetrics* QFontMetricsWrap::getInternalInstance() {
 
 Napi::Value QFontMetricsWrap::ascent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->ascent());
 }
 
 Napi::Value QFontMetricsWrap::averageCharWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->averageCharWidth());
 }
 
 Napi::Value QFontMetricsWrap::capHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->capHeight());
 }
 
 Napi::Value QFontMetricsWrap::descent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->descent());
 }
 
 Napi::Value QFontMetricsWrap::fontDpi(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->fontDpi());
 }
 
 Napi::Value QFontMetricsWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->height());
 }
 
 Napi::Value QFontMetricsWrap::horizontalAdvance(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string format = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(format.c_str());
   if (info.Length() <= 2 && text.length() == 1) {
@@ -136,60 +120,44 @@ Napi::Value QFontMetricsWrap::horizontalAdvance(
 
 Napi::Value QFontMetricsWrap::inFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   char ch = info[0].As<Napi::String>().Utf8Value()[0];
   return Napi::Boolean::New(env, this->instance->inFont(ch));
 }
 
 Napi::Value QFontMetricsWrap::leading(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->leading());
 }
 
 Napi::Value QFontMetricsWrap::leftBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   char ch = info[0].As<Napi::String>().Utf8Value()[0];
   return Napi::Boolean::New(env, this->instance->leftBearing(ch));
 }
 
 Napi::Value QFontMetricsWrap::lineSpacing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->lineSpacing());
 }
 
 Napi::Value QFontMetricsWrap::lineWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->lineWidth());
 }
 
 Napi::Value QFontMetricsWrap::overlinePos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->overlinePos());
 }
 
 Napi::Value QFontMetricsWrap::rightBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   char ch = info[0].As<Napi::String>().Utf8Value()[0];
   return Napi::Boolean::New(env, this->instance->rightBearing(ch));
 }
 
 Napi::Value QFontMetricsWrap::size(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() != 2 && info.Length() != 3) {
     Napi::TypeError::New(env, "Invalid number of arguments to size")
         .ThrowAsJavaScriptException();
@@ -207,15 +175,11 @@ Napi::Value QFontMetricsWrap::size(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsWrap::strikeOutPos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->strikeOutPos());
 }
 
 Napi::Value QFontMetricsWrap::swap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QFontMetricsWrap* wrap0_1 =
       Napi::ObjectWrap<QFontMetricsWrap>::Unwrap(wrap0_0);
@@ -225,42 +189,34 @@ Napi::Value QFontMetricsWrap::swap(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsWrap::underlinePos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->underlinePos());
 }
 
 Napi::Value QFontMetricsWrap::xHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->xHeight());
 }
 
 Napi::Value QFontMetricsWrap::maxWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->maxWidth();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QFontMetricsWrap::minLeftBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->minLeftBearing();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QFontMetricsWrap::minRightBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->minRightBearing();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QFontMetricsWrap::inFontUcs4(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   uint ucs4 = info[0].As<Napi::Number>().Uint32Value();
   bool result = this->instance->inFontUcs4(ucs4);
   return Napi::Boolean::New(env, result);
@@ -268,7 +224,6 @@ Napi::Value QFontMetricsWrap::inFontUcs4(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsWrap::boundingRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string textNapiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
   QRect result = this->instance->boundingRect(text);
@@ -280,7 +235,6 @@ Napi::Value QFontMetricsWrap::boundingRect(const Napi::CallbackInfo& info) {
 Napi::Value QFontMetricsWrap::tightBoundingRect(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string textNapiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
   QRect result = this->instance->tightBoundingRect(text);
@@ -291,7 +245,6 @@ Napi::Value QFontMetricsWrap::tightBoundingRect(
 
 Napi::Value QFontMetricsWrap::elidedText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string textNapiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
   Qt::TextElideMode mode =

--- a/src/cpp/lib/QtGui/QFontMetricsF/qfontmetricsf_wrap.cpp
+++ b/src/cpp/lib/QtGui/QFontMetricsF/qfontmetricsf_wrap.cpp
@@ -49,7 +49,6 @@ Napi::Object QFontMetricsFWrap::init(Napi::Env env, Napi::Object exports) {
 QFontMetricsFWrap::QFontMetricsFWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFontMetricsFWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
@@ -74,7 +73,6 @@ QFontMetricsF* QFontMetricsFWrap::getInternalInstance() {
 
 Napi::Value QFontMetricsFWrap::ascent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->ascent());
 }
@@ -82,35 +80,30 @@ Napi::Value QFontMetricsFWrap::ascent(const Napi::CallbackInfo& info) {
 Napi::Value QFontMetricsFWrap::averageCharWidth(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->averageCharWidth());
 }
 
 Napi::Value QFontMetricsFWrap::capHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->capHeight());
 }
 
 Napi::Value QFontMetricsFWrap::descent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->descent());
 }
 
 Napi::Value QFontMetricsFWrap::fontDpi(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->fontDpi());
 }
 
 Napi::Value QFontMetricsFWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->height());
 }
@@ -118,7 +111,6 @@ Napi::Value QFontMetricsFWrap::height(const Napi::CallbackInfo& info) {
 Napi::Value QFontMetricsFWrap::horizontalAdvance(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   std::string format = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(format.c_str());
@@ -137,7 +129,6 @@ Napi::Value QFontMetricsFWrap::horizontalAdvance(
 
 Napi::Value QFontMetricsFWrap::inFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   char ch = info[0].As<Napi::String>().Utf8Value()[0];
   return Napi::Boolean::New(env, this->instance->inFont(ch));
@@ -145,14 +136,12 @@ Napi::Value QFontMetricsFWrap::inFont(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsFWrap::leading(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->leading());
 }
 
 Napi::Value QFontMetricsFWrap::leftBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   char ch = info[0].As<Napi::String>().Utf8Value()[0];
   return Napi::Boolean::New(env, this->instance->leftBearing(ch));
@@ -160,28 +149,24 @@ Napi::Value QFontMetricsFWrap::leftBearing(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsFWrap::lineSpacing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->lineSpacing());
 }
 
 Napi::Value QFontMetricsFWrap::lineWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->lineWidth());
 }
 
 Napi::Value QFontMetricsFWrap::overlinePos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->overlinePos());
 }
 
 Napi::Value QFontMetricsFWrap::rightBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   char ch = info[0].As<Napi::String>().Utf8Value()[0];
   return Napi::Boolean::New(env, this->instance->rightBearing(ch));
@@ -189,7 +174,6 @@ Napi::Value QFontMetricsFWrap::rightBearing(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsFWrap::size(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   if (info.Length() != 2 && info.Length() != 3) {
     Napi::TypeError::New(env, "Invalid number of arguments to size")
@@ -208,14 +192,12 @@ Napi::Value QFontMetricsFWrap::size(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsFWrap::strikeOutPos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->strikeOutPos());
 }
 
 Napi::Value QFontMetricsFWrap::swap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   Napi::Object wrap0_0 = info[0].As<Napi::Object>();
   QFontMetricsFWrap* wrap0_1 =
@@ -226,42 +208,36 @@ Napi::Value QFontMetricsFWrap::swap(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsFWrap::underlinePos(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->underlinePos());
 }
 
 Napi::Value QFontMetricsFWrap::xHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   return Napi::Value::From(env, this->instance->xHeight());
 }
 
 Napi::Value QFontMetricsFWrap::maxWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->maxWidth();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QFontMetricsFWrap::minLeftBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->minLeftBearing();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QFontMetricsFWrap::minRightBearing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->minRightBearing();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QFontMetricsFWrap::inFontUcs4(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   uint ucs4 = info[0].As<Napi::Number>().Uint32Value();
   bool result = this->instance->inFontUcs4(ucs4);
   return Napi::Boolean::New(env, result);
@@ -269,7 +245,6 @@ Napi::Value QFontMetricsFWrap::inFontUcs4(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontMetricsFWrap::boundingRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string textNapiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
   QRectF result = this->instance->boundingRect(text);
@@ -281,7 +256,6 @@ Napi::Value QFontMetricsFWrap::boundingRect(const Napi::CallbackInfo& info) {
 Napi::Value QFontMetricsFWrap::tightBoundingRect(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string textNapiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
   QRectF result = this->instance->tightBoundingRect(text);
@@ -292,7 +266,6 @@ Napi::Value QFontMetricsFWrap::tightBoundingRect(
 
 Napi::Value QFontMetricsFWrap::elidedText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   std::string textNapiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
   Qt::TextElideMode mode =

--- a/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
+++ b/src/cpp/lib/QtGui/QIcon/qicon_wrap.cpp
@@ -25,7 +25,6 @@ Napi::Object QIconWrap::init(Napi::Env env, Napi::Object exports) {
 QIconWrap::QIconWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QIconWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance =
@@ -50,8 +49,6 @@ QIcon* QIconWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QIconWrap::pixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number widthValue = info[0].As<Napi::Number>();
   Napi::Number heightValue = info[1].As<Napi::Number>();
   int width = widthValue.Int32Value();
@@ -78,15 +75,11 @@ Napi::Value QIconWrap::pixmap(const Napi::CallbackInfo& info) {
 
 Napi::Value QIconWrap::isMask(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isMask());
 }
 
 Napi::Value QIconWrap::setIsMask(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Boolean isMask = info[0].As<Napi::Boolean>();
     this->instance->setIsMask(isMask.Value());
@@ -99,15 +92,12 @@ Napi::Value QIconWrap::setIsMask(const Napi::CallbackInfo& info) {
 }
 Napi::Value QIconWrap::cacheKey(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Value::From(env, this->instance->cacheKey());
 }
 
 Napi::Value StaticQIconWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
+++ b/src/cpp/lib/QtGui/QImage/qimage_wrap.cpp
@@ -74,8 +74,6 @@ Napi::Object QImageWrap::init(Napi::Env env, Napi::Object exports) {
 QImageWrap::QImageWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QImageWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 0) {
     this->instance = std::make_unique<QImage>();
   } else if (info.Length() == 1 && info[0].IsString()) {
@@ -108,44 +106,37 @@ QImage* QImageWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QImageWrap::allGray(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Boolean::New(env, instance->allGray());
 }
 
 Napi::Value QImageWrap::bitPlaneCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->bitPlaneCount());
 }
 
 Napi::Value QImageWrap::bytesPerLine(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->bytesPerLine());
 }
 
 Napi::Value QImageWrap::cacheKey(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->cacheKey());
 }
 
 Napi::Value QImageWrap::color(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int64_t i = info[0].As<Napi::Number>();
   return Napi::Number::New(env, instance->color(i));
 }
 
 Napi::Value QImageWrap::colorCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, instance->colorCount());
 }
 
 void QImageWrap::convertTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QImage::Format format =
       static_cast<QImage::Format>(info[0].As<Napi::Number>().Int32Value());
   Qt::ImageConversionFlag conversionFlags =
@@ -156,7 +147,6 @@ void QImageWrap::convertTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::convertToFormat(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QImage::Format format =
       static_cast<QImage::Format>(info[0].As<Napi::Number>().Int32Value());
   Qt::ImageConversionFlag conversionFlags =
@@ -170,7 +160,6 @@ Napi::Value QImageWrap::convertToFormat(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::copy(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     QRect* rect =
         Napi::ObjectWrap<QRectWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -193,8 +182,6 @@ Napi::Value QImageWrap::copy(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::createAlphaMask(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::ImageConversionFlags flags = static_cast<Qt::ImageConversionFlags>(
       info[0].As<Napi::Number>().Int32Value());
   QImage img = this->instance->createAlphaMask(flags);
@@ -205,8 +192,6 @@ Napi::Value QImageWrap::createAlphaMask(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::createHeuristicMask(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool clipTight = info[0].As<Napi::Boolean>();
   QImage img = this->instance->createHeuristicMask(clipTight);
   auto instance = QImageWrap::constructor.New(
@@ -217,40 +202,27 @@ Napi::Value QImageWrap::createHeuristicMask(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::depth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, instance->depth());
-  ;
 }
 
 Napi::Value QImageWrap::devicePixelRatio(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, instance->devicePixelRatio());
-  ;
 }
 
 Napi::Value QImageWrap::dotsPerMeterX(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, instance->dotsPerMeterX());
   ;
 }
 
 Napi::Value QImageWrap::dotsPerMeterY(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, instance->dotsPerMeterY());
-  ;
 }
 
 void QImageWrap::fill(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info[0].IsObject()) {
     QColor* color =
         Napi::ObjectWrap<QColorWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -265,29 +237,21 @@ void QImageWrap::fill(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::format(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->format());
 }
 
 Napi::Value QImageWrap::hasAlphaChannel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->hasAlphaChannel());
 }
 
 Napi::Value QImageWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->height());
 }
 
 void QImageWrap::invertPixels(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QImage::InvertMode mode =
       static_cast<QImage::InvertMode>(info[0].As<Napi::Number>().Int32Value());
   this->instance->invertPixels(mode);
@@ -295,22 +259,16 @@ void QImageWrap::invertPixels(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::isGrayscale(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isGrayscale());
 }
 
 Napi::Value QImageWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isNull());
 }
 
 Napi::Value QImageWrap::load(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString fileName = QString(info[0].As<Napi::String>().Utf8Value().c_str());
   if (info.Length() == 2 && !info[1].IsNull()) {
     std::string format = info[1].As<Napi::String>().Utf8Value();
@@ -323,8 +281,6 @@ Napi::Value QImageWrap::load(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::loadFromData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Buffer<uchar> buffer = info[0].As<Napi::Buffer<uchar>>();
   if (info.Length() == 2 && !info[1].IsNull()) {
     std::string format = info[1].As<Napi::String>().Utf8Value();
@@ -339,8 +295,6 @@ Napi::Value QImageWrap::loadFromData(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::mirrored(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool horizontal = info[0].As<Napi::Boolean>();
   bool vertical = info[1].As<Napi::Boolean>();
 
@@ -352,8 +306,6 @@ Napi::Value QImageWrap::mirrored(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::offset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPoint point = this->instance->offset();
   auto instance = QPointWrap::constructor.New(
       {Napi::External<QPoint>::New(env, new QPoint(point))});
@@ -362,8 +314,6 @@ Napi::Value QImageWrap::offset(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::pixelColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     QPoint* point =
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -386,8 +336,6 @@ Napi::Value QImageWrap::pixelColor(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::pixelIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     QPoint* point =
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -403,8 +351,6 @@ Napi::Value QImageWrap::pixelIndex(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::rect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QRect rect = this->instance->rect();
   auto instance = QRectWrap::constructor.New(
       {Napi::External<QRect>::New(env, new QRect(rect))});
@@ -413,8 +359,6 @@ Napi::Value QImageWrap::rect(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::reinterpretAsFormat(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QImage::Format format =
       static_cast<QImage::Format>(info[0].As<Napi::Number>().Int32Value());
   return Napi::Boolean::New(env, this->instance->reinterpretAsFormat(format));
@@ -422,8 +366,6 @@ Napi::Value QImageWrap::reinterpretAsFormat(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::save(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString fileName(info[0].As<Napi::String>().Utf8Value().c_str());
   Napi::Value format = info[1];
   int32_t quality = info[2].As<Napi::Number>();
@@ -438,8 +380,6 @@ Napi::Value QImageWrap::save(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::scaled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 3) {
     QSize* size =
         Napi::ObjectWrap<QSizeWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -470,8 +410,6 @@ Napi::Value QImageWrap::scaled(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::scaledToHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t height = info[0].As<Napi::Number>();
   Qt::TransformationMode mode = static_cast<Qt::TransformationMode>(
       info[1].As<Napi::Number>().Int32Value());
@@ -483,8 +421,6 @@ Napi::Value QImageWrap::scaledToHeight(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::scaledToWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t width = info[0].As<Napi::Number>();
   Qt::TransformationMode mode = static_cast<Qt::TransformationMode>(
       info[1].As<Napi::Number>().Int32Value());
@@ -496,8 +432,6 @@ Napi::Value QImageWrap::scaledToWidth(const Napi::CallbackInfo& info) {
 
 void QImageWrap::setAlphaChannel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QImage* image =
       Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())
           ->getInternalInstance();
@@ -506,8 +440,6 @@ void QImageWrap::setAlphaChannel(const Napi::CallbackInfo& info) {
 
 void QImageWrap::setColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t index = info[0].As<Napi::Number>();
   int64_t colorValue = info[1].As<Napi::Number>();
   this->instance->setColor(index, colorValue);
@@ -515,40 +447,30 @@ void QImageWrap::setColor(const Napi::CallbackInfo& info) {
 
 void QImageWrap::setColorCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t colorCount = info[0].As<Napi::Number>();
   this->instance->setColorCount(colorCount);
 }
 
 void QImageWrap::setDevicePixelRatio(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t scaleFactor = info[0].As<Napi::Number>();
   this->instance->setDevicePixelRatio(scaleFactor);
 }
 
 void QImageWrap::setDotsPerMeterX(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t x = info[0].As<Napi::Number>();
   this->instance->setDotsPerMeterX(x);
 }
 
 void QImageWrap::setDotsPerMeterY(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int64_t y = info[0].As<Napi::Number>();
   this->instance->setDotsPerMeterY(y);
 }
 
 void QImageWrap::setOffset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPoint* offset =
       Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
           ->getInternalInstance();
@@ -557,8 +479,6 @@ void QImageWrap::setOffset(const Napi::CallbackInfo& info) {
 
 void QImageWrap::setPixel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     QPoint* position =
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -576,8 +496,6 @@ void QImageWrap::setPixel(const Napi::CallbackInfo& info) {
 
 void QImageWrap::setPixelColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     QPoint* position =
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -599,8 +517,6 @@ void QImageWrap::setPixelColor(const Napi::CallbackInfo& info) {
 
 void QImageWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString key(info[0].As<Napi::String>().Utf8Value().c_str());
   QString value(info[1].As<Napi::String>().Utf8Value().c_str());
   this->instance->setText(key, value);
@@ -608,8 +524,6 @@ void QImageWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::size(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QSize size = this->instance->size();
   auto instance = QSizeWrap::constructor.New(
       {Napi::External<QSize>::New(env, new QSize(size))});
@@ -618,15 +532,11 @@ Napi::Value QImageWrap::size(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::sizeInBytes(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->sizeInBytes());
 }
 
 void QImageWrap::swap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QImage* image =
       Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())
           ->getInternalInstance();
@@ -635,8 +545,6 @@ void QImageWrap::swap(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::text(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QString key =
       this->instance->text(info[0].As<Napi::String>().Utf8Value().c_str());
   return Napi::String::New(env, key.toUtf8().constData());
@@ -644,8 +552,6 @@ Napi::Value QImageWrap::text(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::textKeys(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QStringList keys = this->instance->textKeys();
   Napi::Array js_array = Napi::Array::New(env, keys.size());
 
@@ -659,8 +565,6 @@ Napi::Value QImageWrap::textKeys(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::valid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     QPoint* point =
         Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>())
@@ -676,15 +580,12 @@ Napi::Value QImageWrap::valid(const Napi::CallbackInfo& info) {
 
 Napi::Value QImageWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->width());
 }
 
 Napi::Value StaticQImageWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp
+++ b/src/cpp/lib/QtGui/QKeySequence/qkeysequence_wrap.cpp
@@ -26,7 +26,6 @@ Napi::Object QKeySequenceWrap::init(Napi::Env env, Napi::Object exports) {
 QKeySequenceWrap::QKeySequenceWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QKeySequenceWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance = std::unique_ptr<QKeySequence>(
@@ -53,22 +52,17 @@ QKeySequence* QKeySequenceWrap::getInternalInstance() {
 
 Napi::Value QKeySequenceWrap::count(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = this->instance->count();
   return Napi::Value::From(env, count);
 }
 
 Napi::Value QKeySequenceWrap::isEmpty(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->isEmpty());
 }
 
 Napi::Value QKeySequenceWrap::matches(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object keyObject = info[0].As<Napi::Object>();
   QKeySequenceWrap* keyWrap =
       Napi::ObjectWrap<QKeySequenceWrap>::Unwrap(keyObject);
@@ -79,8 +73,6 @@ Napi::Value QKeySequenceWrap::matches(const Napi::CallbackInfo& info) {
 
 Napi::Value QKeySequenceWrap::toString(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int format = info[0].As<Napi::Number>().Int32Value();
   QString result = this->instance->toString(
       static_cast<QKeySequence::SequenceFormat>(format));
@@ -90,7 +82,6 @@ Napi::Value QKeySequenceWrap::toString(const Napi::CallbackInfo& info) {
 Napi::Value StaticQKeySequenceWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QMovie/qmovie_wrap.cpp
+++ b/src/cpp/lib/QtGui/QMovie/qmovie_wrap.cpp
@@ -42,7 +42,6 @@ QMovieWrap::~QMovieWrap() { extrautils::safeDelete(this->instance); }
 QMovieWrap::QMovieWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMovieWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance = new NMovie(info[0].As<Napi::External<NMovie>>().Data());
@@ -64,7 +63,6 @@ QMovieWrap::QMovieWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QMovieWrap::setFileName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String fileName = info[0].As<Napi::String>();
   this->instance->setFileName(QString::fromStdString(fileName.Utf8Value()));
   return env.Null();
@@ -72,14 +70,12 @@ Napi::Value QMovieWrap::setFileName(const Napi::CallbackInfo& info) {
 
 Napi::Value QMovieWrap::fileName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString fileName = this->instance->fileName();
   return Napi::Value::From(env, fileName.toStdString());
 }
 
 Napi::Value QMovieWrap::setFormat(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String formatName = info[0].As<Napi::String>();
   std::string format = formatName.Utf8Value();
   QByteArray byteArray(format.c_str(), format.length());
@@ -89,14 +85,12 @@ Napi::Value QMovieWrap::setFormat(const Napi::CallbackInfo& info) {
 
 Napi::Value QMovieWrap::format(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QByteArray format = this->instance->format();
   return Napi::Value::From(env, format.toStdString());
 }
 
 Napi::Value QMovieWrap::setScaledSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   Napi::Object sizeObject = info[0].As<Napi::Object>();
   QSizeWrap* sizeWrap = Napi::ObjectWrap<QSizeWrap>::Unwrap(sizeObject);
@@ -106,21 +100,18 @@ Napi::Value QMovieWrap::setScaledSize(const Napi::CallbackInfo& info) {
 
 Napi::Value QMovieWrap::start(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->start();
   return env.Null();
 }
 
 Napi::Value QMovieWrap::stop(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->stop();
   return env.Null();
 }
 
 Napi::Value QMovieWrap::setPaused(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean paused = info[0].As<Napi::Boolean>();
   this->instance->setPaused(paused.Value());
   return env.Null();
@@ -128,14 +119,12 @@ Napi::Value QMovieWrap::setPaused(const Napi::CallbackInfo& info) {
 
 Napi::Value QMovieWrap::jumpToNextFrame(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool jumped = this->instance->jumpToNextFrame();
   return Napi::Value::From(env, jumped);
 }
 
 Napi::Value QMovieWrap::jumpToFrame(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number frameNo = info[0].As<Napi::Number>();
   bool jumped = this->instance->jumpToFrame(frameNo.Int32Value());
   return Napi::Value::From(env, jumped);
@@ -143,21 +132,18 @@ Napi::Value QMovieWrap::jumpToFrame(const Napi::CallbackInfo& info) {
 
 Napi::Value QMovieWrap::state(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QMovie::MovieState state = this->instance->state();
   return Napi::Value::From(env, static_cast<int>(state));
 }
 
 Napi::Value QMovieWrap::currentFrameNumber(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int currentFrameNumber = this->instance->currentFrameNumber();
   return Napi::Value::From(env, currentFrameNumber);
 }
 
 Napi::Value QMovieWrap::currentPixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QPixmap pixmap = this->instance->currentPixmap();
   auto instance = QPixmapWrap::constructor.New(
       {Napi::External<QPixmap>::New(env, new QPixmap(pixmap))});
@@ -166,7 +152,6 @@ Napi::Value QMovieWrap::currentPixmap(const Napi::CallbackInfo& info) {
 
 Napi::Value QMovieWrap::loadFromData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Buffer<const char> buffer = info[0].As<Napi::Buffer<const char>>();
   QByteArray byteArray = QByteArray(buffer.Data(), buffer.Length());
   this->bufferDevice->setData(byteArray);
@@ -175,7 +160,6 @@ Napi::Value QMovieWrap::loadFromData(const Napi::CallbackInfo& info) {
 }
 Napi::Value QMovieWrap::frameCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int frameCount = this->instance->frameCount();
   return Napi::Value::From(env, frameCount);
 }

--- a/src/cpp/lib/QtGui/QPalette/qpalette_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPalette/qpalette_wrap.cpp
@@ -23,8 +23,6 @@ Napi::Object QPaletteWrap::init(Napi::Env env, Napi::Object exports) {
 QPaletteWrap::QPaletteWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPaletteWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 0) {
     this->instance = std::make_unique<QPalette>();
   } else if (info.Length() == 1) {
@@ -43,8 +41,6 @@ QPalette* QPaletteWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QPaletteWrap::color(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QPalette::ColorGroup colorGroup = static_cast<QPalette::ColorGroup>(
       info[0].As<Napi::Number>().Int32Value());
   QPalette::ColorRole colorRole =

--- a/src/cpp/lib/QtGui/QPen/qpen_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPen/qpen_wrap.cpp
@@ -28,8 +28,6 @@ Napi::Object QPenWrap::init(Napi::Env env, Napi::Object exports) {
 QPenWrap::QPenWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPenWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 0) {
     this->instance = std::make_unique<QPen>();
   } else {
@@ -45,8 +43,6 @@ QPen* QPenWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QPenWrap::setColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info[0].IsNumber()) {
     Qt::GlobalColor color =
         (Qt::GlobalColor)info[0].As<Napi::Number>().Int32Value();
@@ -61,8 +57,6 @@ Napi::Value QPenWrap::setColor(const Napi::CallbackInfo& info) {
 
 Napi::Value QPenWrap::color(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QColor color = this->instance->color();
   auto instance = QColorWrap::constructor.New(
       {Napi::External<QColor>::New(env, new QColor(color))});
@@ -71,8 +65,6 @@ Napi::Value QPenWrap::color(const Napi::CallbackInfo& info) {
 
 Napi::Value QPenWrap::setStyle(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::PenStyle style = (Qt::PenStyle)info[0].As<Napi::Number>().Int32Value();
   this->instance->setStyle(style);
   return env.Null();
@@ -80,16 +72,12 @@ Napi::Value QPenWrap::setStyle(const Napi::CallbackInfo& info) {
 
 Napi::Value QPenWrap::style(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::PenStyle style = this->instance->style();
   return Napi::Number::New(env, static_cast<int>(style));
 }
 
 Napi::Value QPenWrap::setCapStyle(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::PenCapStyle style =
       (Qt::PenCapStyle)info[0].As<Napi::Number>().Int32Value();
   this->instance->setCapStyle(style);
@@ -98,8 +86,6 @@ Napi::Value QPenWrap::setCapStyle(const Napi::CallbackInfo& info) {
 
 Napi::Value QPenWrap::setWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int width = info[0].As<Napi::Number>().Int32Value();
   this->instance->setWidth(width);
   return env.Null();

--- a/src/cpp/lib/QtGui/QPicture/qpicture_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPicture/qpicture_wrap.cpp
@@ -26,8 +26,6 @@ Napi::Object QPictureWrap::init(Napi::Env env, Napi::Object exports) {
 QPictureWrap::QPictureWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPictureWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = std::unique_ptr<QPicture>(
@@ -53,8 +51,6 @@ QPictureWrap::~QPictureWrap() { this->instance.reset(); }
 
 Napi::Value QPictureWrap::setBoundingRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object boundingRectObject = info[0].As<Napi::Object>();
   QRectWrap* boundingRectWrap =
       Napi::ObjectWrap<QRectWrap>::Unwrap(boundingRectObject);
@@ -64,8 +60,6 @@ Napi::Value QPictureWrap::setBoundingRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QPictureWrap::boundingRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QRect rect = this->instance->boundingRect();
   auto instance = QRectWrap::constructor.New(
       {Napi::External<QRect>::New(env, new QRect(rect))});
@@ -74,15 +68,11 @@ Napi::Value QPictureWrap::boundingRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QPictureWrap::isNull(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isNull());
 }
 
 Napi::Value QPictureWrap::load(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string fileName = info[0].As<Napi::String>().Utf8Value();
   bool success = this->instance->load(QString::fromUtf8(fileName.c_str()));
   return Napi::Boolean::New(env, success);
@@ -90,8 +80,6 @@ Napi::Value QPictureWrap::load(const Napi::CallbackInfo& info) {
 
 Napi::Value QPictureWrap::save(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string fileName = info[0].As<Napi::String>().Utf8Value();
   bool success = this->instance->save(QString::fromUtf8(fileName.c_str()));
   return Napi::Boolean::New(env, success);
@@ -99,7 +87,5 @@ Napi::Value QPictureWrap::save(const Napi::CallbackInfo& info) {
 
 Napi::Value QPictureWrap::size(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->size());
 }

--- a/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
+++ b/src/cpp/lib/QtGui/QPixmap/qpixmap_wrap.cpp
@@ -28,7 +28,6 @@ Napi::Object QPixmapWrap::init(Napi::Env env, Napi::Object exports) {
 QPixmapWrap::QPixmapWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPixmapWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance = std::unique_ptr<QPixmap>(
@@ -53,7 +52,6 @@ QPixmap* QPixmapWrap::getInternalInstance() { return this->instance.get(); }
 
 Napi::Value QPixmapWrap::load(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool loadSuccess = false;
   if (info.Length() == 1) {
     Napi::String url = info[0].As<Napi::String>();
@@ -68,7 +66,6 @@ Napi::Value QPixmapWrap::load(const Napi::CallbackInfo& info) {
 
 Napi::Value QPixmapWrap::loadFromData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool loadSuccess = false;
 
   if (info.Length() > 0 && info.Length() < 3) {
@@ -91,7 +88,6 @@ Napi::Value QPixmapWrap::loadFromData(const Napi::CallbackInfo& info) {
 
 Napi::Value QPixmapWrap::save(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool loadSuccess = false;
   if (info.Length() >= 1 && info.Length() <= 3) {
     QString fileName =
@@ -111,7 +107,6 @@ Napi::Value QPixmapWrap::save(const Napi::CallbackInfo& info) {
 
 Napi::Value QPixmapWrap::scaled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number widthValue = info[0].As<Napi::Number>();
   Napi::Number heightValue = info[1].As<Napi::Number>();
   int width = widthValue.Int32Value();
@@ -136,18 +131,15 @@ Napi::Value QPixmapWrap::scaled(const Napi::CallbackInfo& info) {
 
 Napi::Value QPixmapWrap::height(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->height());
 }
 Napi::Value QPixmapWrap::width(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->width());
 }
 
 Napi::Value QPixmapWrap::fromImage(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   QImage* img = Napi::ObjectWrap<QImageWrap>::Unwrap(info[0].As<Napi::Object>())
                     ->getInternalInstance();
@@ -162,7 +154,6 @@ Napi::Value QPixmapWrap::fromImage(const Napi::CallbackInfo& info) {
 Napi::Value StaticQPixmapWrapMethods::fromQVariant(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);

--- a/src/cpp/lib/QtGui/QScreen/qscreen_wrap.cpp
+++ b/src/cpp/lib/QtGui/QScreen/qscreen_wrap.cpp
@@ -21,7 +21,6 @@ Napi::Object QScreenWrap::init(Napi::Env env, Napi::Object exports) {
 QScreenWrap::QScreenWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QScreenWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info[0].IsExternal()) {
     this->instance = info[0].As<Napi::External<QScreen>>().Data();
   } else {

--- a/src/cpp/lib/QtGui/QStyle/qstyle_wrap.cpp
+++ b/src/cpp/lib/QtGui/QStyle/qstyle_wrap.cpp
@@ -22,7 +22,6 @@ Napi::Object QStyleWrap::init(Napi::Env env, Napi::Object exports) {
 QStyleWrap::QStyleWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QStyleWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info[0].IsExternal()) {
     this->instance = info[0].As<Napi::External<QStyle>>().Data();
   } else {
@@ -36,7 +35,6 @@ QStyle* QStyleWrap::getInternalInstance() { return this->instance; }
 
 Napi::Value QStyleWrap::pixelMetric(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int metricInt = info[0].As<Napi::Number>().Int32Value();
   QStyle::PixelMetric metric = static_cast<QStyle::PixelMetric>(metricInt);
 
@@ -45,7 +43,6 @@ Napi::Value QStyleWrap::pixelMetric(const Napi::CallbackInfo& info) {
 
 Napi::Value QStyleWrap::polish(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* qwidgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);
@@ -56,7 +53,6 @@ Napi::Value QStyleWrap::polish(const Napi::CallbackInfo& info) {
 
 Napi::Value QStyleWrap::unpolish(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* qwidgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);

--- a/src/cpp/lib/QtGui/QWindow/qwindow_wrap.cpp
+++ b/src/cpp/lib/QtGui/QWindow/qwindow_wrap.cpp
@@ -23,7 +23,6 @@ QWindow* QWindowWrap::getInternalInstance() { return this->instance; }
 QWindowWrap::QWindowWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QWindowWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1 && info[0].IsExternal()) {
     this->instance = info[0].As<Napi::External<QWindow>>().Data();
   } else {
@@ -49,8 +48,6 @@ void QWindowWrap::connectSignalsToEventEmitter() {
 
 Napi::Value QWindowWrap::screen(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QScreen* screen = this->instance->screen();
   if (screen) {
     return WrapperCache::instance.get<QScreen, QScreenWrap>(env, screen);

--- a/src/cpp/lib/QtWidgets/QAction/qaction_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QAction/qaction_wrap.cpp
@@ -42,7 +42,6 @@ NAction* QActionWrap::getInternalInstance() { return this->instance; }
 QActionWrap::QActionWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QActionWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NAction>>().Data();
@@ -74,7 +73,6 @@ QActionWrap::~QActionWrap() {
 
 Napi::Value QActionWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String text = info[0].As<Napi::String>();
   this->instance->setText(QString::fromStdString(text.Utf8Value()));
   return env.Null();
@@ -82,7 +80,6 @@ Napi::Value QActionWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setEnabled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean enabled = info[0].As<Napi::Boolean>();
   this->instance->setEnabled(enabled.Value());
   return env.Null();
@@ -90,8 +87,6 @@ Napi::Value QActionWrap::setEnabled(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object iconObject = info[0].As<Napi::Object>();
   QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
   this->instance->setIcon(*iconWrap->getInternalInstance());
@@ -100,8 +95,6 @@ Napi::Value QActionWrap::setIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setMenu(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   QMenuWrap* menuWrap = Napi::ObjectWrap<QMenuWrap>::Unwrap(menuObject);
   this->instance->setMenu(menuWrap->getInternalInstance());
@@ -110,8 +103,6 @@ Napi::Value QActionWrap::setMenu(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setShortcut(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object shortcutSequence = info[0].As<Napi::Object>();
   QKeySequenceWrap* keysequence =
       Napi::ObjectWrap<QKeySequenceWrap>::Unwrap(shortcutSequence);
@@ -121,8 +112,6 @@ Napi::Value QActionWrap::setShortcut(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setShortcutContext(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number shortcutContextEnum = info[0].As<Napi::Number>();
   int shortCutContext = shortcutContextEnum.Int32Value();
   this->instance->setShortcutContext(
@@ -132,15 +121,11 @@ Napi::Value QActionWrap::setShortcutContext(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::isCheckable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isCheckable());
 }
 
 Napi::Value QActionWrap::setCheckable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Boolean isCheckable = info[0].As<Napi::Boolean>();
     this->instance->setCheckable(isCheckable);
@@ -154,15 +139,11 @@ Napi::Value QActionWrap::setCheckable(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::isChecked(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isChecked());
 }
 
 Napi::Value QActionWrap::setChecked(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Boolean isChecked = info[0].As<Napi::Boolean>();
     this->instance->setChecked(isChecked);
@@ -176,15 +157,11 @@ Napi::Value QActionWrap::setChecked(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::isSeparator(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isSeparator());
 }
 
 Napi::Value QActionWrap::setSeparator(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Boolean isSeparator = info[0].As<Napi::Boolean>();
     this->instance->setSeparator(isSeparator);
@@ -198,8 +175,6 @@ Napi::Value QActionWrap::setSeparator(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object fontObject = info[0].As<Napi::Object>();
   QFontWrap* fontWrap = Napi::ObjectWrap<QFontWrap>::Unwrap(fontObject);
   QFont* font = fontWrap->getInternalInstance();
@@ -210,8 +185,6 @@ Napi::Value QActionWrap::setFont(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::setData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object variantObject = info[0].As<Napi::Object>();
   QVariantWrap* variantWrap =
       Napi::ObjectWrap<QVariantWrap>::Unwrap(variantObject);
@@ -224,8 +197,6 @@ Napi::Value QActionWrap::setData(const Napi::CallbackInfo& info) {
 
 Napi::Value QActionWrap::data(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QVariant variant = this->instance->data();
   if (variant.isNull()) {
     return env.Null();

--- a/src/cpp/lib/QtWidgets/QBoxLayout/qboxlayout_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QBoxLayout/qboxlayout_wrap.cpp
@@ -36,8 +36,6 @@ QBoxLayoutWrap::~QBoxLayoutWrap() { extrautils::safeDelete(this->instance); }
 QBoxLayoutWrap::QBoxLayoutWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QBoxLayoutWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2) {
     QBoxLayout::Direction dir = static_cast<QBoxLayout::Direction>(
         info[0].As<Napi::Number>().Int32Value());
@@ -59,7 +57,6 @@ QBoxLayoutWrap::QBoxLayoutWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QBoxLayoutWrap::addLayout(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object qlayoutObject = info[0].As<Napi::Object>();
   QLayoutWrap* layout = Napi::ObjectWrap<QLayoutWrap>::Unwrap(qlayoutObject);
   int stretch = info[1].As<Napi::Number>().Int32Value();
@@ -69,7 +66,6 @@ Napi::Value QBoxLayoutWrap::addLayout(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::addSpacing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int size = info[0].As<Napi::Number>().Int32Value();
   this->instance->addSpacing(size);
   return env.Null();
@@ -77,7 +73,6 @@ Napi::Value QBoxLayoutWrap::addSpacing(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::addStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int stretch = info[0].As<Napi::Number>().Int32Value();
   this->instance->addStretch(stretch);
   return env.Null();
@@ -85,7 +80,6 @@ Napi::Value QBoxLayoutWrap::addStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::addStrut(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int size = info[0].As<Napi::Number>().Int32Value();
   this->instance->addStrut(size);
   return env.Null();
@@ -93,8 +87,6 @@ Napi::Value QBoxLayoutWrap::addStrut(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::addWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);
@@ -108,8 +100,6 @@ Napi::Value QBoxLayoutWrap::addWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::insertWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object qwidgetObject = info[1].As<Napi::Object>();
   NodeWidgetWrap* widget =
@@ -122,13 +112,11 @@ Napi::Value QBoxLayoutWrap::insertWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::direction(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, this->instance->direction());
 }
 
 Napi::Value QBoxLayoutWrap::insertLayout(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object qlayoutObject = info[1].As<Napi::Object>();
   QLayoutWrap* layout = Napi::ObjectWrap<QLayoutWrap>::Unwrap(qlayoutObject);
@@ -139,8 +127,6 @@ Napi::Value QBoxLayoutWrap::insertLayout(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::insertSpacing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   int size = info[1].As<Napi::Number>().Int32Value();
   this->instance->insertSpacing(index, size);
@@ -149,8 +135,6 @@ Napi::Value QBoxLayoutWrap::insertSpacing(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::insertStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   int stretch = info[1].As<Napi::Number>().Int32Value();
   this->instance->insertStretch(index, stretch);
@@ -159,8 +143,6 @@ Napi::Value QBoxLayoutWrap::insertStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::removeWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);
@@ -170,7 +152,6 @@ Napi::Value QBoxLayoutWrap::removeWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::setDirection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QBoxLayout::Direction dir = static_cast<QBoxLayout::Direction>(
       info[0].As<Napi::Number>().Int32Value());
   this->instance->setDirection(dir);
@@ -179,8 +160,6 @@ Napi::Value QBoxLayoutWrap::setDirection(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::setStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   int stretch = info[1].As<Napi::Number>().Int32Value();
   this->instance->setStretch(index, stretch);
@@ -189,8 +168,6 @@ Napi::Value QBoxLayoutWrap::setStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QBoxLayoutWrap::count(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = this->instance->count();
   return Napi::Number::New(env, count);
 }

--- a/src/cpp/lib/QtWidgets/QButtonGroup/qbuttongroup_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QButtonGroup/qbuttongroup_wrap.cpp
@@ -35,8 +35,6 @@ NButtonGroup* QButtonGroupWrap::getInternalInstance() { return this->instance; }
 QButtonGroupWrap::QButtonGroupWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QButtonGroupWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -59,7 +57,6 @@ QButtonGroupWrap::~QButtonGroupWrap() {
 
 Napi::Value QButtonGroupWrap::addButton(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object buttonObject = info[0].As<Napi::Object>();
   QObjectWrap* objectWrap = Napi::ObjectWrap<QObjectWrap>::Unwrap(buttonObject);
   QAbstractButton* button =
@@ -71,7 +68,6 @@ Napi::Value QButtonGroupWrap::addButton(const Napi::CallbackInfo& info) {
 }
 Napi::Value QButtonGroupWrap::removeButton(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object buttonObject = info[0].As<Napi::Object>();
   QObjectWrap* objectWrap = Napi::ObjectWrap<QObjectWrap>::Unwrap(buttonObject);
   QAbstractButton* button =
@@ -81,20 +77,17 @@ Napi::Value QButtonGroupWrap::removeButton(const Napi::CallbackInfo& info) {
 }
 Napi::Value QButtonGroupWrap::checkedId(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = static_cast<int>(this->instance->checkedId());
   return Napi::Number::From(env, value);
 }
 Napi::Value QButtonGroupWrap::checkedButton(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = Napi::External<QAbstractButton>::New(
       env, this->instance->checkedButton());
   return Napi::Value::From(env, value);
 }
 Napi::Value QButtonGroupWrap::id(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object buttonObject = info[0].As<Napi::Object>();
   QObjectWrap* objectWrap = Napi::ObjectWrap<QObjectWrap>::Unwrap(buttonObject);
   QAbstractButton* button =
@@ -104,7 +97,6 @@ Napi::Value QButtonGroupWrap::id(const Napi::CallbackInfo& info) {
 }
 Napi::Value QButtonGroupWrap::setId(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object buttonObject = info[0].As<Napi::Object>();
   QObjectWrap* objectWrap = Napi::ObjectWrap<QObjectWrap>::Unwrap(buttonObject);
   QAbstractButton* button =
@@ -116,7 +108,6 @@ Napi::Value QButtonGroupWrap::setId(const Napi::CallbackInfo& info) {
 }
 Napi::Value QButtonGroupWrap::buttons(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   QList<QAbstractButton*> items = this->instance->buttons();
   Napi::Array napiItems = Napi::Array::New(env, items.size());
@@ -130,7 +121,6 @@ Napi::Value QButtonGroupWrap::buttons(const Napi::CallbackInfo& info) {
 }
 Napi::Value QButtonGroupWrap::button(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number id = info[0].As<Napi::Number>();
 
   auto value =

--- a/src/cpp/lib/QtWidgets/QCalendarWidget/qcalendarwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QCalendarWidget/qcalendarwidget_wrap.cpp
@@ -42,8 +42,6 @@ QCalendarWidgetWrap::~QCalendarWidgetWrap() {
 QCalendarWidgetWrap::QCalendarWidgetWrap(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<QCalendarWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap *parentWidgetWrap =
@@ -64,20 +62,17 @@ QCalendarWidgetWrap::QCalendarWidgetWrap(const Napi::CallbackInfo &info)
 
 Napi::Value QCalendarWidgetWrap::monthShown(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->monthShown());
 }
 
 Napi::Value QCalendarWidgetWrap::yearShown(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->yearShown());
 }
 
 Napi::Value QCalendarWidgetWrap::setCurrentPage(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   int year = info[0].As<Napi::Number>().Int32Value();
   int month = info[1].As<Napi::Number>().Int32Value();
@@ -87,14 +82,12 @@ Napi::Value QCalendarWidgetWrap::setCurrentPage(
 
 Napi::Value QCalendarWidgetWrap::showNextMonth(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showNextMonth();
   return env.Null();
 }
 
 Napi::Value QCalendarWidgetWrap::showNextYear(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showNextYear();
   return env.Null();
 }
@@ -102,7 +95,6 @@ Napi::Value QCalendarWidgetWrap::showNextYear(const Napi::CallbackInfo &info) {
 Napi::Value QCalendarWidgetWrap::showPreviousMonth(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showPreviousMonth();
   return env.Null();
 }
@@ -110,7 +102,6 @@ Napi::Value QCalendarWidgetWrap::showPreviousMonth(
 Napi::Value QCalendarWidgetWrap::showPreviousYear(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showPreviousYear();
   return env.Null();
 }
@@ -118,14 +109,12 @@ Napi::Value QCalendarWidgetWrap::showPreviousYear(
 Napi::Value QCalendarWidgetWrap::showSelectedDate(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showSelectedDate();
   return env.Null();
 }
 
 Napi::Value QCalendarWidgetWrap::showToday(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showToday();
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QCheckBox/qcheckbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QCheckBox/qcheckbox_wrap.cpp
@@ -25,8 +25,6 @@ NCheckBox* QCheckBoxWrap::getInternalInstance() { return this->instance; }
 QCheckBoxWrap::QCheckBoxWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QCheckBoxWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NCheckBox>>().Data();
@@ -59,16 +57,12 @@ QCheckBoxWrap::~QCheckBoxWrap() {
 
 Napi::Value QCheckBoxWrap::checkState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::CheckState state = this->instance->checkState();
   return Napi::Value::From(env, static_cast<int>(state));
 }
 
 Napi::Value QCheckBoxWrap::setCheckState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = info[0].As<Napi::Number>().Int32Value();
   this->instance->setCheckState(static_cast<Qt::CheckState>(state));
   return env.Null();

--- a/src/cpp/lib/QtWidgets/QColorDialog/qcolordialog_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QColorDialog/qcolordialog_wrap.cpp
@@ -39,8 +39,6 @@ QColorDialogWrap::~QColorDialogWrap() {
 QColorDialogWrap::QColorDialogWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QColorDialogWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -60,8 +58,6 @@ QColorDialogWrap::QColorDialogWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QColorDialogWrap::selectedColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QColor color = this->instance->selectedColor();
   auto instance = QColorWrap::constructor.New(
       {Napi::External<QColor>::New(env, new QColor(color))});
@@ -70,8 +66,6 @@ Napi::Value QColorDialogWrap::selectedColor(const Napi::CallbackInfo& info) {
 
 Napi::Value QColorDialogWrap::setOption(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int option = info[0].As<Napi::Number>().Int32Value();
   bool on = info[1].As<Napi::Boolean>().Value();
   this->instance->setOption(
@@ -81,8 +75,6 @@ Napi::Value QColorDialogWrap::setOption(const Napi::CallbackInfo& info) {
 
 Napi::Value QColorDialogWrap::testOption(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int option = info[0].As<Napi::Number>().Int32Value();
   bool on = this->instance->testOption(
       static_cast<QColorDialog::ColorDialogOption>(option));
@@ -92,8 +84,6 @@ Napi::Value QColorDialogWrap::testOption(const Napi::CallbackInfo& info) {
 Napi::Value StaticQColorDialogWrapMethods::customColor(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QColor color = QColorDialog::customColor(index);
   auto instance = QColorWrap::constructor.New(
@@ -104,8 +94,6 @@ Napi::Value StaticQColorDialogWrapMethods::customColor(
 Napi::Value StaticQColorDialogWrapMethods::customCount(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = QColorDialog::customCount();
   return Napi::Number::New(env, count);
 }
@@ -113,8 +101,6 @@ Napi::Value StaticQColorDialogWrapMethods::customCount(
 Napi::Value StaticQColorDialogWrapMethods::setCustomColor(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object colorObject = info[1].As<Napi::Object>();
   QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject);
@@ -125,8 +111,6 @@ Napi::Value StaticQColorDialogWrapMethods::setCustomColor(
 Napi::Value StaticQColorDialogWrapMethods::setStandardColor(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object colorObject = info[1].As<Napi::Object>();
   QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject);
@@ -137,8 +121,6 @@ Napi::Value StaticQColorDialogWrapMethods::setStandardColor(
 Napi::Value StaticQColorDialogWrapMethods::standardColor(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QColor color = QColorDialog::standardColor(index);
   auto instance = QColorWrap::constructor.New(

--- a/src/cpp/lib/QtWidgets/QComboBox/qcombobox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QComboBox/qcombobox_wrap.cpp
@@ -75,8 +75,6 @@ QComboBoxWrap::~QComboBoxWrap() { extrautils::safeDelete(this->instance); }
 QComboBoxWrap::QComboBoxWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QComboBoxWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -96,7 +94,6 @@ QComboBoxWrap::QComboBoxWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QComboBoxWrap::addItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 3) {
     Napi::Object iconWrap = info[0].As<Napi::Object>();
     QIconWrap* iconWrapValue = Napi::ObjectWrap<QIconWrap>::Unwrap(iconWrap);
@@ -121,8 +118,6 @@ Napi::Value QComboBoxWrap::addItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::insertItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   std::string text = info[1].As<Napi::String>().Utf8Value();
 
@@ -132,8 +127,6 @@ Napi::Value QComboBoxWrap::insertItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::addItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array textsNapi = info[0].As<Napi::Array>();
   QList<QString> list;
   for (int i = 0; i < textsNapi.Length(); i++) {
@@ -148,8 +141,6 @@ Napi::Value QComboBoxWrap::addItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::insertItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Array textsNapi = info[1].As<Napi::Array>();
   QList<QString> list;
@@ -165,22 +156,16 @@ Napi::Value QComboBoxWrap::insertItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::currentIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->currentIndex());
 }
 
 Napi::Value QComboBoxWrap::currentText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::String::New(env, this->instance->currentText().toStdString());
 }
 
 Napi::Value QComboBoxWrap::insertSeparator(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
 
   this->instance->insertSeparator(index);
@@ -189,8 +174,6 @@ Napi::Value QComboBoxWrap::insertSeparator(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::itemText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
 
   return Napi::String::New(env, this->instance->itemText(index).toStdString());
@@ -198,8 +181,6 @@ Napi::Value QComboBoxWrap::itemText(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::itemData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QVariant* variant = new QVariant(this->instance->itemData(index));
   auto variantWrap = QVariantWrap::constructor.New(
@@ -209,8 +190,6 @@ Napi::Value QComboBoxWrap::itemData(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::removeItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
 
   this->instance->removeItem(index);
@@ -219,14 +198,11 @@ Napi::Value QComboBoxWrap::removeItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::sizeAdjustPolicy(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->sizeAdjustPolicy());
 }
 Napi::Value QComboBoxWrap::setSizeAdjustPolicy(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  QComboBox::SizeAdjustPolicy policy = static_cast<QComboBox::SizeAdjustPolicy>(
+ QComboBox::SizeAdjustPolicy policy = static_cast<QComboBox::SizeAdjustPolicy>(
       info[0].As<Napi::Number>().Int32Value());
   this->instance->setSizeAdjustPolicy(policy);
   return env.Null();
@@ -234,15 +210,11 @@ Napi::Value QComboBoxWrap::setSizeAdjustPolicy(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::maxVisibleItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->maxVisibleItems());
 }
 
 Napi::Value QComboBoxWrap::setMaxVisibleItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int maxItems = info[0].As<Napi::Number>().Int32Value();
 
   this->instance->setMaxVisibleItems(maxItems);
@@ -251,15 +223,11 @@ Napi::Value QComboBoxWrap::setMaxVisibleItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::isEditable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isEditable());
 }
 
 Napi::Value QComboBoxWrap::setEditable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool editable = info[0].As<Napi::Boolean>().Value();
 
   this->instance->setEditable(editable);
@@ -268,16 +236,12 @@ Napi::Value QComboBoxWrap::setEditable(const Napi::CallbackInfo& info) {
 
 Napi::Value QComboBoxWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QComboBoxWrap::setModel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QStandardItemModelWrap* modelWrap =
       Napi::ObjectWrap<QStandardItemModelWrap>::Unwrap(itemObject);
@@ -288,8 +252,6 @@ Napi::Value QComboBoxWrap::setModel(const Napi::CallbackInfo& info) {
 }
 Napi::Value QComboBoxWrap::setEditText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String text = info[0].As<Napi::String>();
   this->instance->setEditText(text.Utf8Value().c_str());
 
@@ -297,33 +259,28 @@ Napi::Value QComboBoxWrap::setEditText(const Napi::CallbackInfo& info) {
 }
 Napi::Value QComboBoxWrap::count(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->count();
   return Napi::Number::New(env, result);
 }
 Napi::Value QComboBoxWrap::duplicatesEnabled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->duplicatesEnabled();
   return Napi::Boolean::New(env, result);
 }
 Napi::Value QComboBoxWrap::hasFrame(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->hasFrame();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QComboBoxWrap::hidePopup(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->hidePopup();
   return env.Null();
 }
 
 Napi::Value QComboBoxWrap::iconSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QSize result = this->instance->iconSize();
   auto resultInstance = QSizeWrap::constructor.New(
       {Napi::External<QSize>::New(env, new QSize(result))});
@@ -331,26 +288,22 @@ Napi::Value QComboBoxWrap::iconSize(const Napi::CallbackInfo& info) {
 }
 Napi::Value QComboBoxWrap::maxCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->maxCount();
   return Napi::Number::New(env, result);
 }
 Napi::Value QComboBoxWrap::minimumContentsLength(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->minimumContentsLength();
   return Napi::Number::New(env, result);
 }
 Napi::Value QComboBoxWrap::modelColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->modelColumn();
   return Napi::Number::New(env, result);
 }
 Napi::Value QComboBoxWrap::rootModelIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndex result = this->instance->rootModelIndex();
   auto resultInstance = QModelIndexWrap::constructor.New(
       {Napi::External<QModelIndex>::New(env, new QModelIndex(result))});
@@ -359,7 +312,6 @@ Napi::Value QComboBoxWrap::rootModelIndex(const Napi::CallbackInfo& info) {
 Napi::Value QComboBoxWrap::setDuplicatesEnabled(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool enable = info[0].As<Napi::Boolean>().Value();
   this->instance->setDuplicatesEnabled(enable);
   return env.Null();
@@ -367,21 +319,18 @@ Napi::Value QComboBoxWrap::setDuplicatesEnabled(
 Napi::Value QComboBoxWrap::setMinimumContentsLength(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int characters = info[0].As<Napi::Number>().Int32Value();
   this->instance->setMinimumContentsLength(characters);
   return env.Null();
 }
 Napi::Value QComboBoxWrap::setModelColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int visibleColumn = info[0].As<Napi::Number>().Int32Value();
   this->instance->setModelColumn(visibleColumn);
   return env.Null();
 }
 Napi::Value QComboBoxWrap::setRootModelIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QModelIndexWrap* indexWrap =
       Napi::ObjectWrap<QModelIndexWrap>::Unwrap(info[0].As<Napi::Object>());
   QModelIndex* index = indexWrap->getInternalInstance();
@@ -390,20 +339,17 @@ Napi::Value QComboBoxWrap::setRootModelIndex(const Napi::CallbackInfo& info) {
 }
 Napi::Value QComboBoxWrap::clearEditText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clearEditText();
   return env.Null();
 }
 Napi::Value QComboBoxWrap::setFrame(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool f = info[0].As<Napi::Boolean>().Value();
   this->instance->setFrame(f);
   return env.Null();
 }
 Napi::Value QComboBoxWrap::setItemText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int index = info[0].As<Napi::Number>().Int32Value();
   std::string textNapiText = info[1].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(textNapiText.c_str());
@@ -412,26 +358,22 @@ Napi::Value QComboBoxWrap::setItemText(const Napi::CallbackInfo& info) {
 }
 Napi::Value QComboBoxWrap::setMaxCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int max = info[0].As<Napi::Number>().Int32Value();
   this->instance->setMaxCount(max);
   return env.Null();
 }
 Napi::Value QComboBoxWrap::showPopup(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->showPopup();
   return env.Null();
 }
 Napi::Value QComboBoxWrap::insertPolicy(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QComboBox::InsertPolicy result = this->instance->insertPolicy();
   return Napi::Number::New(env, static_cast<uint>(result));
 }
 Napi::Value QComboBoxWrap::setInsertPolicy(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QComboBox::InsertPolicy policy = static_cast<QComboBox::InsertPolicy>(
       info[0].As<Napi::Number>().Int32Value());
   this->instance->setInsertPolicy(policy);
@@ -439,7 +381,6 @@ Napi::Value QComboBoxWrap::setInsertPolicy(const Napi::CallbackInfo& info) {
 }
 Napi::Value QComboBoxWrap::setIconSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QSizeWrap* sizeWrap =
       Napi::ObjectWrap<QSizeWrap>::Unwrap(info[0].As<Napi::Object>());
   QSize* size = sizeWrap->getInternalInstance();

--- a/src/cpp/lib/QtWidgets/QDateEdit/qdateedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDateEdit/qdateedit_wrap.cpp
@@ -20,8 +20,6 @@ NDateEdit* QDateEditWrap::getInternalInstance() { return this->instance; }
 QDateEditWrap::QDateEditWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDateEditWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QDateTimeEdit/qdatetimeedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDateTimeEdit/qdatetimeedit_wrap.cpp
@@ -22,8 +22,6 @@ NDateTimeEdit* QDateTimeEditWrap::getInternalInstance() {
 QDateTimeEditWrap::QDateTimeEditWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDateTimeEditWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QDial/qdial_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDial/qdial_wrap.cpp
@@ -24,8 +24,6 @@ NDial* QDialWrap::getInternalInstance() { return this->instance; }
 QDialWrap::QDialWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDialWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QDialog/qdialog_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDialog/qdialog_wrap.cpp
@@ -21,7 +21,6 @@ QDialogWrap::~QDialogWrap() { extrautils::safeDelete(this->instance); }
 QDialogWrap::QDialogWrap(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<QDialogWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance =

--- a/src/cpp/lib/QtWidgets/QDoubleSpinBox/qdoublespinbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QDoubleSpinBox/qdoublespinbox_wrap.cpp
@@ -26,8 +26,6 @@ NDoubleSpinBox* QDoubleSpinBoxWrap::getInternalInstance() {
 QDoubleSpinBoxWrap::QDoubleSpinBoxWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QDoubleSpinBoxWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -51,8 +49,6 @@ QDoubleSpinBoxWrap::~QDoubleSpinBoxWrap() {
 
 Napi::Value QDoubleSpinBoxWrap::setRange(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   double minimum = info[0].As<Napi::Number>().DoubleValue();
   double maximum = info[1].As<Napi::Number>().DoubleValue();
   this->instance->setRange(minimum, maximum);
@@ -61,8 +57,6 @@ Napi::Value QDoubleSpinBoxWrap::setRange(const Napi::CallbackInfo& info) {
 
 Napi::Value QDoubleSpinBoxWrap::textFromValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   double value = info[0].As<Napi::Number>().DoubleValue();
   QString text = this->instance->textFromValue(value);
   return Napi::String::New(env, text.toStdString());
@@ -70,8 +64,6 @@ Napi::Value QDoubleSpinBoxWrap::textFromValue(const Napi::CallbackInfo& info) {
 
 Napi::Value QDoubleSpinBoxWrap::valueFromText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string napiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(napiText.c_str());
   double value = this->instance->valueFromText(text);

--- a/src/cpp/lib/QtWidgets/QErrorMessage/qerrormessage_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QErrorMessage/qerrormessage_wrap.cpp
@@ -30,8 +30,6 @@ QErrorMessageWrap::~QErrorMessageWrap() {
 QErrorMessageWrap::QErrorMessageWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QErrorMessageWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -51,8 +49,6 @@ QErrorMessageWrap::QErrorMessageWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QErrorMessageWrap::showMessage(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string napiMessage = info[0].As<Napi::String>().Utf8Value();
   QString message = QString::fromUtf8(napiMessage.c_str());
   this->instance->showMessage(message);

--- a/src/cpp/lib/QtWidgets/QFileDialog/qfiledialog_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QFileDialog/qfiledialog_wrap.cpp
@@ -33,8 +33,6 @@ QFileDialogWrap::~QFileDialogWrap() { extrautils::safeDelete(this->instance); }
 QFileDialogWrap::QFileDialogWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFileDialogWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 4) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -60,8 +58,6 @@ QFileDialogWrap::QFileDialogWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QFileDialogWrap::supportedSchemes(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QStringList schemes = this->instance->supportedSchemes();
   Napi::Array schemesNapi = Napi::Array::New(env, schemes.size());
   for (int i = 0; i < schemes.size(); i++) {
@@ -74,8 +70,6 @@ Napi::Value QFileDialogWrap::supportedSchemes(const Napi::CallbackInfo& info) {
 Napi::Value QFileDialogWrap::setSupportedSchemes(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array schemesNapi = info[0].As<Napi::Array>();
   QList<QString> list;
   for (int i = 0; i < schemesNapi.Length(); i++) {
@@ -90,8 +84,6 @@ Napi::Value QFileDialogWrap::setSupportedSchemes(
 
 Napi::Value QFileDialogWrap::labelText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int labelInt = info[0].As<Napi::Number>().Int32Value();
   QFileDialog::DialogLabel label =
       static_cast<QFileDialog::DialogLabel>(labelInt);
@@ -102,8 +94,6 @@ Napi::Value QFileDialogWrap::labelText(const Napi::CallbackInfo& info) {
 
 Napi::Value QFileDialogWrap::setLabelText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int labelInt = info[0].As<Napi::Number>().Int32Value();
   QFileDialog::DialogLabel label =
       static_cast<QFileDialog::DialogLabel>(labelInt);
@@ -116,8 +106,6 @@ Napi::Value QFileDialogWrap::setLabelText(const Napi::CallbackInfo& info) {
 
 Napi::Value QFileDialogWrap::setOption(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int optionInt = info[0].As<Napi::Number>().Int32Value();
   QFileDialog::Option option = static_cast<QFileDialog::Option>(optionInt);
   bool on = info[1].As<Napi::Boolean>().Value();
@@ -128,8 +116,6 @@ Napi::Value QFileDialogWrap::setOption(const Napi::CallbackInfo& info) {
 
 Napi::Value QFileDialogWrap::setNameFilter(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string filter = info[0].As<Napi::String>().Utf8Value();
 
   this->instance->setNameFilter(QString::fromStdString(filter));
@@ -138,8 +124,6 @@ Napi::Value QFileDialogWrap::setNameFilter(const Napi::CallbackInfo& info) {
 
 Napi::Value QFileDialogWrap::selectedFiles(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QStringList files = this->instance->selectedFiles();
   Napi::Array fileList = Napi::Array::New(env, files.size());
   for (int i = 0; i < files.size(); i++) {

--- a/src/cpp/lib/QtWidgets/QFontDialog/qfontdialog_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QFontDialog/qfontdialog_wrap.cpp
@@ -28,8 +28,6 @@ QFontDialogWrap::~QFontDialogWrap() { extrautils::safeDelete(this->instance); }
 QFontDialogWrap::QFontDialogWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFontDialogWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -49,8 +47,6 @@ QFontDialogWrap::QFontDialogWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QFontDialogWrap::selectedFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QFont font = this->instance->selectedFont();
   auto instance = QFontWrap::constructor.New(
       {Napi::External<QFont>::New(env, new QFont(font))});
@@ -59,8 +55,6 @@ Napi::Value QFontDialogWrap::selectedFont(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontDialogWrap::setOption(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int option = info[0].As<Napi::Number>().Int32Value();
   bool on = info[1].As<Napi::Boolean>().Value();
   this->instance->setOption(static_cast<QFontDialog::FontDialogOption>(option),
@@ -70,8 +64,6 @@ Napi::Value QFontDialogWrap::setOption(const Napi::CallbackInfo& info) {
 
 Napi::Value QFontDialogWrap::testOption(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int option = info[0].As<Napi::Number>().Int32Value();
   bool on = this->instance->testOption(
       static_cast<QFontDialog::FontDialogOption>(option));

--- a/src/cpp/lib/QtWidgets/QFrame/qframe_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QFrame/qframe_wrap.cpp
@@ -21,8 +21,6 @@ QFrameWrap::~QFrameWrap() { extrautils::safeDelete(this->instance); }
 QFrameWrap::QFrameWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QFrameWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QGraphicsBlurEffect/qgraphicsblureffect_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QGraphicsBlurEffect/qgraphicsblureffect_wrap.cpp
@@ -28,8 +28,6 @@ QGraphicsBlurEffectWrap::~QGraphicsBlurEffectWrap() {
 QGraphicsBlurEffectWrap::QGraphicsBlurEffectWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QGraphicsBlurEffectWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     QObjectWrap* parentObjectWrap =

--- a/src/cpp/lib/QtWidgets/QGraphicsDropShadowEffect/qgraphicsdropshadoweffect_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QGraphicsDropShadowEffect/qgraphicsdropshadoweffect_wrap.cpp
@@ -31,8 +31,6 @@ QGraphicsDropShadowEffectWrap::QGraphicsDropShadowEffectWrap(
     const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QGraphicsDropShadowEffectWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     QObjectWrap* parentObjectWrap =

--- a/src/cpp/lib/QtWidgets/QGridLayout/qgridlayout_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QGridLayout/qgridlayout_wrap.cpp
@@ -44,8 +44,6 @@ QGridLayoutWrap::~QGridLayoutWrap() { extrautils::safeDelete(this->instance); }
 QGridLayoutWrap::QGridLayoutWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QGridLayoutWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -62,8 +60,6 @@ QGridLayoutWrap::QGridLayoutWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QGridLayoutWrap::addLayout(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qlayoutObject = info[0].As<Napi::Object>();
   QLayoutWrap* layout = Napi::ObjectWrap<QLayoutWrap>::Unwrap(qlayoutObject);
   int row = info[1].As<Napi::Number>().Int32Value();
@@ -79,8 +75,6 @@ Napi::Value QGridLayoutWrap::addLayout(const Napi::CallbackInfo& info) {
 
 Napi::Value QGridLayoutWrap::addWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   Napi::Number qrow = info[1].As<Napi::Number>();
   Napi::Number qcol = info[2].As<Napi::Number>();
@@ -96,8 +90,6 @@ Napi::Value QGridLayoutWrap::addWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QGridLayoutWrap::removeWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);
@@ -107,8 +99,6 @@ Napi::Value QGridLayoutWrap::removeWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QGridLayoutWrap::columnStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int value = static_cast<int>(this->instance->columnStretch(column));
   return Napi::Number::From(env, value);
@@ -116,8 +106,6 @@ Napi::Value QGridLayoutWrap::columnStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QGridLayoutWrap::rowStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int value = static_cast<int>(this->instance->rowStretch(row));
   return Napi::Number::From(env, value);
@@ -125,8 +113,6 @@ Napi::Value QGridLayoutWrap::rowStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QGridLayoutWrap::setColumnStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int stretch = info[1].As<Napi::Number>().Int32Value();
   this->instance->setColumnStretch(column, stretch);
@@ -135,8 +121,6 @@ Napi::Value QGridLayoutWrap::setColumnStretch(const Napi::CallbackInfo& info) {
 
 Napi::Value QGridLayoutWrap::setRowStretch(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int stretch = info[1].As<Napi::Number>().Int32Value();
   this->instance->setRowStretch(row, stretch);
@@ -146,8 +130,6 @@ Napi::Value QGridLayoutWrap::setRowStretch(const Napi::CallbackInfo& info) {
 Napi::Value QGridLayoutWrap::columnMinimumWidth(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int value = static_cast<int>(this->instance->columnMinimumWidth(column));
   return Napi::Number::From(env, value);
@@ -155,8 +137,6 @@ Napi::Value QGridLayoutWrap::columnMinimumWidth(
 
 Napi::Value QGridLayoutWrap::rowMinimumHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int value = static_cast<int>(this->instance->rowMinimumHeight(row));
   return Napi::Number::From(env, value);
@@ -165,8 +145,6 @@ Napi::Value QGridLayoutWrap::rowMinimumHeight(const Napi::CallbackInfo& info) {
 Napi::Value QGridLayoutWrap::setColumnMinimumWidth(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int minSize = info[1].As<Napi::Number>().Int32Value();
   this->instance->setColumnMinimumWidth(column, minSize);
@@ -176,8 +154,6 @@ Napi::Value QGridLayoutWrap::setColumnMinimumWidth(
 Napi::Value QGridLayoutWrap::setRowMinimumHeight(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int minSize = info[1].As<Napi::Number>().Int32Value();
   this->instance->setRowMinimumHeight(row, minSize);
@@ -186,16 +162,12 @@ Napi::Value QGridLayoutWrap::setRowMinimumHeight(
 
 Napi::Value QGridLayoutWrap::horizontalSpacing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int value = static_cast<int>(this->instance->horizontalSpacing());
   return Napi::Number::From(env, value);
 }
 
 Napi::Value QGridLayoutWrap::verticalSpacing(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int value = static_cast<int>(this->instance->verticalSpacing());
   return Napi::Number::From(env, value);
 }
@@ -203,8 +175,6 @@ Napi::Value QGridLayoutWrap::verticalSpacing(const Napi::CallbackInfo& info) {
 Napi::Value QGridLayoutWrap::setHorizontalSpacing(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int spacing = info[0].As<Napi::Number>().Int32Value();
   this->instance->setHorizontalSpacing(spacing);
   return env.Null();
@@ -213,8 +183,6 @@ Napi::Value QGridLayoutWrap::setHorizontalSpacing(
 Napi::Value QGridLayoutWrap::setVerticalSpacing(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int spacing = info[0].As<Napi::Number>().Int32Value();
   this->instance->setVerticalSpacing(spacing);
   return env.Null();
@@ -222,16 +190,12 @@ Napi::Value QGridLayoutWrap::setVerticalSpacing(
 
 Napi::Value QGridLayoutWrap::columnCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int value = static_cast<int>(this->instance->columnCount());
   return Napi::Number::From(env, value);
 }
 
 Napi::Value QGridLayoutWrap::rowCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int value = static_cast<int>(this->instance->rowCount());
   return Napi::Number::From(env, value);
 }

--- a/src/cpp/lib/QtWidgets/QGroupBox/qgroupbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QGroupBox/qgroupbox_wrap.cpp
@@ -22,8 +22,6 @@ NGroupBox* QGroupBoxWrap::getInternalInstance() { return this->instance; }
 QGroupBoxWrap::QGroupBoxWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QGroupBoxWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QHeaderView/qheaderview_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QHeaderView/qheaderview_wrap.cpp
@@ -125,8 +125,6 @@ QHeaderViewWrap::~QHeaderViewWrap() {
 QHeaderViewWrap::QHeaderViewWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QHeaderViewWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   size_t len = info.Length();
 
   this->disableDeletion = false;
@@ -162,21 +160,18 @@ QHeaderViewWrap::QHeaderViewWrap(const Napi::CallbackInfo& info)
 Napi::Value QHeaderViewWrap::cascadingSectionResizes(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->cascadingSectionResizes();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::count(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->count();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::defaultAlignment(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Qt::Alignment result = this->instance->defaultAlignment();
   return Napi::Number::New(env, static_cast<uint>(result));
 }
@@ -184,7 +179,6 @@ Napi::Value QHeaderViewWrap::defaultAlignment(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::defaultSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->defaultSectionSize();
   return Napi::Number::New(env, result);
 }
@@ -192,14 +186,12 @@ Napi::Value QHeaderViewWrap::defaultSectionSize(
 Napi::Value QHeaderViewWrap::hiddenSectionCount(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->hiddenSectionCount();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::hideSection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   this->instance->hideSection(logicalIndex);
   return env.Null();
@@ -207,7 +199,6 @@ Napi::Value QHeaderViewWrap::hideSection(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::highlightSections(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->highlightSections();
   return Napi::Boolean::New(env, result);
 }
@@ -215,14 +206,12 @@ Napi::Value QHeaderViewWrap::highlightSections(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::isFirstSectionMovable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->isFirstSectionMovable();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::isSectionHidden(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   bool result = this->instance->isSectionHidden(logicalIndex);
   return Napi::Boolean::New(env, result);
@@ -231,21 +220,18 @@ Napi::Value QHeaderViewWrap::isSectionHidden(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::isSortIndicatorShown(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->isSortIndicatorShown();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::length(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->length();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::logicalIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int visualIndex = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->logicalIndex(visualIndex);
   return Napi::Number::New(env, result);
@@ -253,7 +239,6 @@ Napi::Value QHeaderViewWrap::logicalIndex(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::logicalIndexAt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int position = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->logicalIndexAt(position);
   return Napi::Number::New(env, result);
@@ -262,7 +247,6 @@ Napi::Value QHeaderViewWrap::logicalIndexAt(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::logicalIndexAt_number_number(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int result = this->instance->logicalIndexAt(x, y);
@@ -272,7 +256,6 @@ Napi::Value QHeaderViewWrap::logicalIndexAt_number_number(
 Napi::Value QHeaderViewWrap::logicalIndexAt_qpoint(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QPointWrap* posWrap =
       Napi::ObjectWrap<QPointWrap>::Unwrap(info[0].As<Napi::Object>());
   QPoint* pos = posWrap->getInternalInstance();
@@ -283,7 +266,6 @@ Napi::Value QHeaderViewWrap::logicalIndexAt_qpoint(
 Napi::Value QHeaderViewWrap::maximumSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->maximumSectionSize();
   return Napi::Number::New(env, result);
 }
@@ -291,14 +273,12 @@ Napi::Value QHeaderViewWrap::maximumSectionSize(
 Napi::Value QHeaderViewWrap::minimumSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->minimumSectionSize();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::moveSection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int from = info[0].As<Napi::Number>().Int32Value();
   int to = info[1].As<Napi::Number>().Int32Value();
   this->instance->moveSection(from, to);
@@ -307,14 +287,12 @@ Napi::Value QHeaderViewWrap::moveSection(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::offset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->offset();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::orientation(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Qt::Orientation result = this->instance->orientation();
   return Napi::Number::New(env, static_cast<uint>(result));
 }
@@ -322,7 +300,6 @@ Napi::Value QHeaderViewWrap::orientation(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::resetDefaultSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->resetDefaultSectionSize();
   return env.Null();
 }
@@ -330,14 +307,12 @@ Napi::Value QHeaderViewWrap::resetDefaultSectionSize(
 Napi::Value QHeaderViewWrap::resizeContentsPrecision(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->resizeContentsPrecision();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::resizeSection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   int size = info[1].As<Napi::Number>().Int32Value();
   this->instance->resizeSection(logicalIndex, size);
@@ -346,7 +321,6 @@ Napi::Value QHeaderViewWrap::resizeSection(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::resizeSections(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QHeaderView::ResizeMode mode = static_cast<QHeaderView::ResizeMode>(
       info[0].As<Napi::Number>().Int32Value());
   this->instance->resizeSections(mode);
@@ -355,7 +329,6 @@ Napi::Value QHeaderViewWrap::resizeSections(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::sectionPosition(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->sectionPosition(logicalIndex);
   return Napi::Number::New(env, result);
@@ -363,7 +336,6 @@ Napi::Value QHeaderViewWrap::sectionPosition(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::sectionResizeMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   QHeaderView::ResizeMode result =
       this->instance->sectionResizeMode(logicalIndex);
@@ -372,7 +344,6 @@ Napi::Value QHeaderViewWrap::sectionResizeMode(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::sectionSize(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->sectionSize(logicalIndex);
   return Napi::Number::New(env, result);
@@ -380,7 +351,6 @@ Napi::Value QHeaderViewWrap::sectionSize(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::sectionSizeHint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->sectionSizeHint(logicalIndex);
   return Napi::Number::New(env, result);
@@ -389,7 +359,6 @@ Napi::Value QHeaderViewWrap::sectionSizeHint(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::sectionViewportPosition(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->sectionViewportPosition(logicalIndex);
   return Napi::Number::New(env, result);
@@ -397,28 +366,24 @@ Napi::Value QHeaderViewWrap::sectionViewportPosition(
 
 Napi::Value QHeaderViewWrap::sectionsClickable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->sectionsClickable();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::sectionsHidden(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->sectionsHidden();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::sectionsMovable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->sectionsMovable();
   return Napi::Boolean::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::sectionsMoved(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool result = this->instance->sectionsMoved();
   return Napi::Boolean::New(env, result);
 }
@@ -426,7 +391,6 @@ Napi::Value QHeaderViewWrap::sectionsMoved(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::setCascadingSectionResizes(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool enable = info[0].As<Napi::Boolean>().Value();
   this->instance->setCascadingSectionResizes(enable);
   return env.Null();
@@ -435,7 +399,6 @@ Napi::Value QHeaderViewWrap::setCascadingSectionResizes(
 Napi::Value QHeaderViewWrap::setDefaultAlignment(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Qt::Alignment alignment =
       static_cast<Qt::Alignment>(info[0].As<Napi::Number>().Int32Value());
   this->instance->setDefaultAlignment(alignment);
@@ -445,7 +408,6 @@ Napi::Value QHeaderViewWrap::setDefaultAlignment(
 Napi::Value QHeaderViewWrap::setDefaultSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int size = info[0].As<Napi::Number>().Int32Value();
   this->instance->setDefaultSectionSize(size);
   return env.Null();
@@ -454,7 +416,6 @@ Napi::Value QHeaderViewWrap::setDefaultSectionSize(
 Napi::Value QHeaderViewWrap::setFirstSectionMovable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool movable = info[0].As<Napi::Boolean>().Value();
   this->instance->setFirstSectionMovable(movable);
   return env.Null();
@@ -463,7 +424,6 @@ Napi::Value QHeaderViewWrap::setFirstSectionMovable(
 Napi::Value QHeaderViewWrap::setHighlightSections(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool highlight = info[0].As<Napi::Boolean>().Value();
   this->instance->setHighlightSections(highlight);
   return env.Null();
@@ -472,7 +432,6 @@ Napi::Value QHeaderViewWrap::setHighlightSections(
 Napi::Value QHeaderViewWrap::setMaximumSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int size = info[0].As<Napi::Number>().Int32Value();
   this->instance->setMaximumSectionSize(size);
   return env.Null();
@@ -481,7 +440,6 @@ Napi::Value QHeaderViewWrap::setMaximumSectionSize(
 Napi::Value QHeaderViewWrap::setMinimumSectionSize(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int size = info[0].As<Napi::Number>().Int32Value();
   this->instance->setMinimumSectionSize(size);
   return env.Null();
@@ -490,7 +448,6 @@ Napi::Value QHeaderViewWrap::setMinimumSectionSize(
 Napi::Value QHeaderViewWrap::setResizeContentsPrecision(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int precision = info[0].As<Napi::Number>().Int32Value();
   this->instance->setResizeContentsPrecision(precision);
   return env.Null();
@@ -498,7 +455,6 @@ Napi::Value QHeaderViewWrap::setResizeContentsPrecision(
 
 Napi::Value QHeaderViewWrap::setSectionHidden(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   bool hide = info[1].As<Napi::Boolean>().Value();
   this->instance->setSectionHidden(logicalIndex, hide);
@@ -508,7 +464,6 @@ Napi::Value QHeaderViewWrap::setSectionHidden(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::setSectionResizeMode_mode(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QHeaderView::ResizeMode mode = static_cast<QHeaderView::ResizeMode>(
       info[0].As<Napi::Number>().Int32Value());
   this->instance->setSectionResizeMode(mode);
@@ -518,7 +473,6 @@ Napi::Value QHeaderViewWrap::setSectionResizeMode_mode(
 Napi::Value QHeaderViewWrap::setSectionResizeMode_number_mode(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   QHeaderView::ResizeMode mode = static_cast<QHeaderView::ResizeMode>(
       info[1].As<Napi::Number>().Int32Value());
@@ -529,7 +483,6 @@ Napi::Value QHeaderViewWrap::setSectionResizeMode_number_mode(
 Napi::Value QHeaderViewWrap::setSectionsClickable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool clickable = info[0].As<Napi::Boolean>().Value();
   this->instance->setSectionsClickable(clickable);
   return env.Null();
@@ -538,7 +491,6 @@ Napi::Value QHeaderViewWrap::setSectionsClickable(
 Napi::Value QHeaderViewWrap::setSectionsMovable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool movable = info[0].As<Napi::Boolean>().Value();
   this->instance->setSectionsMovable(movable);
   return env.Null();
@@ -546,7 +498,6 @@ Napi::Value QHeaderViewWrap::setSectionsMovable(
 
 Napi::Value QHeaderViewWrap::setSortIndicator(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   Qt::SortOrder order =
       static_cast<Qt::SortOrder>(info[1].As<Napi::Number>().Int32Value());
@@ -557,14 +508,12 @@ Napi::Value QHeaderViewWrap::setSortIndicator(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::setSortIndicatorShown(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool show = info[0].As<Napi::Boolean>().Value();
   this->instance->setSortIndicatorShown(show);
   return env.Null();
 }
 Napi::Value QHeaderViewWrap::showSection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   this->instance->showSection(logicalIndex);
   return env.Null();
@@ -573,7 +522,6 @@ Napi::Value QHeaderViewWrap::showSection(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::sortIndicatorOrder(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Qt::SortOrder result = this->instance->sortIndicatorOrder();
   return Napi::Number::New(env, static_cast<uint>(result));
 }
@@ -581,21 +529,18 @@ Napi::Value QHeaderViewWrap::sortIndicatorOrder(
 Napi::Value QHeaderViewWrap::sortIndicatorSection(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->sortIndicatorSection();
   return Napi::Number::New(env, result);
 }
 Napi::Value QHeaderViewWrap::stretchSectionCount(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int result = this->instance->stretchSectionCount();
   return Napi::Number::New(env, result);
 }
 
 Napi::Value QHeaderViewWrap::swapSections(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int first = info[0].As<Napi::Number>().Int32Value();
   int second = info[1].As<Napi::Number>().Int32Value();
   this->instance->swapSections(first, second);
@@ -604,7 +549,6 @@ Napi::Value QHeaderViewWrap::swapSections(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::visualIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int logicalIndex = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->visualIndex(logicalIndex);
   return Napi::Number::New(env, result);
@@ -612,7 +556,6 @@ Napi::Value QHeaderViewWrap::visualIndex(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::visualIndexAt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int position = info[0].As<Napi::Number>().Int32Value();
   int result = this->instance->visualIndexAt(position);
   return Napi::Number::New(env, result);
@@ -620,7 +563,6 @@ Napi::Value QHeaderViewWrap::visualIndexAt(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::headerDataChanged(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Qt::Orientation orientation =
       static_cast<Qt::Orientation>(info[0].As<Napi::Number>().Int32Value());
   int logicalFirst = info[1].As<Napi::Number>().Int32Value();
@@ -631,7 +573,6 @@ Napi::Value QHeaderViewWrap::headerDataChanged(const Napi::CallbackInfo& info) {
 
 Napi::Value QHeaderViewWrap::setOffset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int offset = info[0].As<Napi::Number>().Int32Value();
   this->instance->setOffset(offset);
   return env.Null();
@@ -640,7 +581,6 @@ Napi::Value QHeaderViewWrap::setOffset(const Napi::CallbackInfo& info) {
 Napi::Value QHeaderViewWrap::setOffsetToLastSection(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->setOffsetToLastSection();
   return env.Null();
 }
@@ -648,7 +588,6 @@ Napi::Value QHeaderViewWrap::setOffsetToLastSection(
 Napi::Value QHeaderViewWrap::setOffsetToSectionPosition(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int visualSectionNumber = info[0].As<Napi::Number>().Int32Value();
   this->instance->setOffsetToSectionPosition(visualSectionNumber);
   return env.Null();

--- a/src/cpp/lib/QtWidgets/QInputDialog/qinputdialog_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QInputDialog/qinputdialog_wrap.cpp
@@ -67,7 +67,6 @@ QInputDialogWrap::~QInputDialogWrap() {
 QInputDialogWrap::QInputDialogWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QInputDialogWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -87,21 +86,18 @@ QInputDialogWrap::QInputDialogWrap(const Napi::CallbackInfo& info)
 Napi::Value QInputDialogWrap::setCancelButtonText(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::String>().Utf8Value().c_str();
   this->instance->setCancelButtonText(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::cancelButtonText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->cancelButtonText().toStdString();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setComboBoxEditable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Boolean>().Value();
   this->instance->setComboBoxEditable(value);
   return env.Null();
@@ -109,176 +105,149 @@ Napi::Value QInputDialogWrap::setComboBoxEditable(
 Napi::Value QInputDialogWrap::isComboBoxEditable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->isComboBoxEditable();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setDoubleDecimals(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setDoubleDecimals(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::doubleDecimals(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->doubleDecimals();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setDoubleMaximum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setDoubleMaximum(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::doubleMaximum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->doubleMaximum();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setDoubleMinimum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setDoubleMinimum(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::doubleMinimum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->doubleMinimum();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::doubleStep(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->doubleStep();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setDoubleStep(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setDoubleStep(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::doubleValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->doubleValue();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setDoubleValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setDoubleValue(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::inputMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->inputMode();
   return Napi::Value::From(env, static_cast<int>(retValue));
 }
 Napi::Value QInputDialogWrap::setInputMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setInputMode(static_cast<QInputDialog::InputMode>(value));
   return env.Null();
 }
 Napi::Value QInputDialogWrap::intMaximum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->intMaximum();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setIntMaximum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setIntMaximum(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::intMinimum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->intMinimum();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setIntMinimum(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setIntMinimum(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::intStep(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->intStep();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setIntStep(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setIntStep(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::intValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->intValue();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setIntValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setIntValue(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::labelText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->labelText().toStdString();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setLabelText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::String>().Utf8Value().c_str();
   this->instance->setLabelText(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::okButtonText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->okButtonText().toStdString();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setOkButtonText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::String>().Utf8Value().c_str();
   this->instance->setOkButtonText(value);
   return env.Null();
 }
 Napi::Value QInputDialogWrap::options(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->options();
   return Napi::Value::From(env, static_cast<int>(retValue));
 }
 Napi::Value QInputDialogWrap::setOptions(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setOptions(
       static_cast<QInputDialog::InputDialogOptions>(value));
@@ -286,26 +255,22 @@ Napi::Value QInputDialogWrap::setOptions(const Napi::CallbackInfo& info) {
 }
 Napi::Value QInputDialogWrap::textEchoMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->textEchoMode();
   return Napi::Value::From(env, static_cast<int>(retValue));
 }
 Napi::Value QInputDialogWrap::setTextEchoMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::Number>().Int32Value();
   this->instance->setTextEchoMode(static_cast<QLineEdit::EchoMode>(value));
   return env.Null();
 }
 Napi::Value QInputDialogWrap::textValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto retValue = this->instance->textValue().toStdString();
   return Napi::Value::From(env, retValue);
 }
 Napi::Value QInputDialogWrap::setTextValue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   auto value = info[0].As<Napi::String>().Utf8Value().c_str();
   this->instance->setTextValue(value);
   return env.Null();

--- a/src/cpp/lib/QtWidgets/QLCDNumber/qlcdnumber_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLCDNumber/qlcdnumber_wrap.cpp
@@ -31,8 +31,6 @@ QLCDNumberWrap::~QLCDNumberWrap() { extrautils::safeDelete(this->instance); }
 QLCDNumberWrap::QLCDNumberWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QLCDNumberWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -51,8 +49,6 @@ QLCDNumberWrap::QLCDNumberWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QLCDNumberWrap::checkOverflow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Value value = info[0];
   bool result;
   if (extrautils::isNapiValueInt(env, value)) {
@@ -67,8 +63,6 @@ Napi::Value QLCDNumberWrap::checkOverflow(const Napi::CallbackInfo& info) {
 
 Napi::Value QLCDNumberWrap::display(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Value value = info[0];
   if (value.IsString()) {
     std::string napis = value.As<Napi::String>().Utf8Value();
@@ -86,32 +80,24 @@ Napi::Value QLCDNumberWrap::display(const Napi::CallbackInfo& info) {
 
 Napi::Value QLCDNumberWrap::setBinMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->setBinMode();
   return env.Null();
 }
 
 Napi::Value QLCDNumberWrap::setDecMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->setDecMode();
   return env.Null();
 }
 
 Napi::Value QLCDNumberWrap::setHexMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->setHexMode();
   return env.Null();
 }
 
 Napi::Value QLCDNumberWrap::setOctMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->setOctMode();
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QLabel/qlabel_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLabel/qlabel_wrap.cpp
@@ -37,8 +37,6 @@ QLabelWrap::~QLabelWrap() { extrautils::safeDelete(this->instance); }
 QLabelWrap::QLabelWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QLabelWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -58,8 +56,6 @@ QLabelWrap::QLabelWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QLabelWrap::setSelection(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int start = info[0].As<Napi::Number>().Int32Value();
   int length = info[1].As<Napi::Number>().Int32Value();
   this->instance->setSelection(start, length);
@@ -68,15 +64,11 @@ Napi::Value QLabelWrap::setSelection(const Napi::CallbackInfo& info) {
 
 Napi::Value QLabelWrap::selectionStart(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->selectionStart());
 }
 
 Napi::Value QLabelWrap::setBuddy(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object buddyObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* buddyWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(buddyObject);
@@ -86,16 +78,12 @@ Napi::Value QLabelWrap::setBuddy(const Napi::CallbackInfo& info) {
 
 Napi::Value QLabelWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QLabelWrap::setMovie(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object movieObject = info[0].As<Napi::Object>();
   QMovieWrap* movieWrap = Napi::ObjectWrap<QMovieWrap>::Unwrap(movieObject);
   this->instance->setMovie(movieWrap->getInternalInstance());
@@ -104,8 +92,6 @@ Napi::Value QLabelWrap::setMovie(const Napi::CallbackInfo& info) {
 
 Napi::Value QLabelWrap::setNumDouble(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   double num = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setNum(num);
   return env.Null();
@@ -113,8 +99,6 @@ Napi::Value QLabelWrap::setNumDouble(const Napi::CallbackInfo& info) {
 
 Napi::Value QLabelWrap::setNumInt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int num = info[0].As<Napi::Number>().Int32Value();
   this->instance->setNum(num);
   return env.Null();
@@ -122,8 +106,6 @@ Napi::Value QLabelWrap::setNumInt(const Napi::CallbackInfo& info) {
 
 Napi::Value QLabelWrap::setPicture(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object pictureObject = info[0].As<Napi::Object>();
   QPictureWrap* pictureWrap =
       Napi::ObjectWrap<QPictureWrap>::Unwrap(pictureObject);
@@ -133,8 +115,6 @@ Napi::Value QLabelWrap::setPicture(const Napi::CallbackInfo& info) {
 
 Napi::Value QLabelWrap::setPixmap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object pixmapObject = info[0].As<Napi::Object>();
   QPixmapWrap* pixmapWrap = Napi::ObjectWrap<QPixmapWrap>::Unwrap(pixmapObject);
   this->instance->setPixmap(*pixmapWrap->getInternalInstance());

--- a/src/cpp/lib/QtWidgets/QLayout/qlayout_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLayout/qlayout_wrap.cpp
@@ -14,8 +14,6 @@ NLayout* QLayoutWrap::getInternalInstance() { return this->instance; }
 
 QLayoutWrap::QLayoutWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QLayoutWrap>(info) {
-  Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 }
 
 QLayoutWrap::~QLayoutWrap() { extrautils::safeDelete(this->instance); }

--- a/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QLineEdit/qlineedit_wrap.cpp
@@ -30,8 +30,6 @@ NLineEdit* QLineEditWrap::getInternalInstance() { return this->instance; }
 QLineEditWrap::QLineEditWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QLineEditWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -52,7 +50,6 @@ QLineEditWrap::~QLineEditWrap() { extrautils::safeDelete(this->instance); }
 
 Napi::Value QLineEditWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String text = info[0].As<Napi::String>();
   this->instance->setText(text.Utf8Value().c_str());
   return env.Null();
@@ -60,7 +57,6 @@ Napi::Value QLineEditWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QLineEditWrap::setReadOnly(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean isReadOnly = info[0].As<Napi::Boolean>();
   this->instance->setReadOnly(isReadOnly.Value());
   return env.Null();
@@ -68,14 +64,12 @@ Napi::Value QLineEditWrap::setReadOnly(const Napi::CallbackInfo& info) {
 
 Napi::Value QLineEditWrap::text(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QString text = this->instance->text();
   return Napi::String::New(env, text.toStdString().c_str());
 }
 
 Napi::Value QLineEditWrap::setPlaceholderText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String text = info[0].As<Napi::String>();
   this->instance->setPlaceholderText(text.Utf8Value().c_str());
   return env.Null();
@@ -83,14 +77,12 @@ Napi::Value QLineEditWrap::setPlaceholderText(const Napi::CallbackInfo& info) {
 
 Napi::Value QLineEditWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QLineEditWrap::setEchoMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number mode = info[0].As<Napi::Number>();
   this->instance->setEchoMode(
       static_cast<QLineEdit::EchoMode>(mode.Int32Value()));

--- a/src/cpp/lib/QtWidgets/QListView/qlistview_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QListView/qlistview_wrap.cpp
@@ -25,8 +25,6 @@ QListViewWrap::~QListViewWrap() {
 QListViewWrap::QListViewWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QListViewWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NListView>>().Data();

--- a/src/cpp/lib/QtWidgets/QListWidget/qlistwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QListWidget/qlistwidget_wrap.cpp
@@ -51,8 +51,6 @@ QListWidgetWrap::~QListWidgetWrap() { extrautils::safeDelete(this->instance); }
 QListWidgetWrap::QListWidgetWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QListWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -71,8 +69,6 @@ QListWidgetWrap::QListWidgetWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QListWidgetWrap::addItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -82,8 +78,6 @@ Napi::Value QListWidgetWrap::addItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::addItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array labelsNapi = info[0].As<Napi::Array>();
   QStringList labels;
   for (int i = 0; i < labelsNapi.Length(); i++) {
@@ -98,8 +92,6 @@ Napi::Value QListWidgetWrap::addItems(const Napi::CallbackInfo& info) {
 Napi::Value QListWidgetWrap::closePersistentEditor_QListWidgetItem(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -109,8 +101,6 @@ Napi::Value QListWidgetWrap::closePersistentEditor_QListWidgetItem(
 
 Napi::Value QListWidgetWrap::currentItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QListWidgetItem* item = this->instance->currentItem();
   auto instance = QListWidgetItemWrap::constructor.New(
       {Napi::External<QListWidgetItem>::New(env, item),
@@ -120,8 +110,6 @@ Napi::Value QListWidgetWrap::currentItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::editItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -131,8 +119,6 @@ Napi::Value QListWidgetWrap::editItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::findItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string napiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(napiText.c_str());
   int flags = info[1].As<Napi::Number>().Int32Value();
@@ -152,8 +138,6 @@ Napi::Value QListWidgetWrap::findItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::insertItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   Napi::Object itemObject = info[1].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
@@ -164,8 +148,6 @@ Napi::Value QListWidgetWrap::insertItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::insertItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   Napi::Array labelsNapi = info[1].As<Napi::Array>();
   QStringList labels;
@@ -181,8 +163,6 @@ Napi::Value QListWidgetWrap::insertItems(const Napi::CallbackInfo& info) {
 Napi::Value QListWidgetWrap::isPersistentEditorOpen_QListWidgetItem(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -193,8 +173,6 @@ Napi::Value QListWidgetWrap::isPersistentEditorOpen_QListWidgetItem(
 
 Napi::Value QListWidgetWrap::item(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   QListWidgetItem* item = this->instance->item(row);
   auto instance = QListWidgetItemWrap::constructor.New(
@@ -205,8 +183,6 @@ Napi::Value QListWidgetWrap::item(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::itemAt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   QListWidgetItem* item = this->instance->itemAt(x, y);
@@ -218,8 +194,6 @@ Napi::Value QListWidgetWrap::itemAt(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::itemWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -233,8 +207,6 @@ Napi::Value QListWidgetWrap::itemWidget(const Napi::CallbackInfo& info) {
 Napi::Value QListWidgetWrap::openPersistentEditor_QListWidgetItem(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -244,8 +216,6 @@ Napi::Value QListWidgetWrap::openPersistentEditor_QListWidgetItem(
 
 Napi::Value QListWidgetWrap::removeItemWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -255,8 +225,6 @@ Napi::Value QListWidgetWrap::removeItemWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::row(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -266,8 +234,6 @@ Napi::Value QListWidgetWrap::row(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::selectedItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QList<QListWidgetItem*> items = this->instance->selectedItems();
   Napi::Array napiItems = Napi::Array::New(env, items.size());
   for (int i = 0; i < items.size(); i++) {
@@ -283,8 +249,6 @@ Napi::Value QListWidgetWrap::selectedItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::setCurrentItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -294,8 +258,6 @@ Napi::Value QListWidgetWrap::setCurrentItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::setItemWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   Napi::Object widgetObject = info[1].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
@@ -309,8 +271,6 @@ Napi::Value QListWidgetWrap::setItemWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::sortItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int order = info[0].As<Napi::Number>().Int32Value();
   this->instance->sortItems(static_cast<Qt::SortOrder>(order));
   return env.Null();
@@ -318,8 +278,6 @@ Napi::Value QListWidgetWrap::sortItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::takeItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->takeItem(row);
   return env.Null();
@@ -327,8 +285,6 @@ Napi::Value QListWidgetWrap::takeItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::visualItemRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);
@@ -340,16 +296,12 @@ Napi::Value QListWidgetWrap::visualItemRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QListWidgetWrap::scrollToItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QListWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QListWidgetItemWrap>::Unwrap(itemObject);

--- a/src/cpp/lib/QtWidgets/QListWidgetItem/qlistwidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QListWidgetItem/qlistwidgetitem_wrap.cpp
@@ -66,8 +66,6 @@ QListWidgetItemWrap::~QListWidgetItemWrap() {
 QListWidgetItemWrap::QListWidgetItemWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QListWidgetItemWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<QListWidgetItem>>().Data();
@@ -92,8 +90,6 @@ QListWidgetItemWrap::QListWidgetItemWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QListWidgetItemWrap::setBackground(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object brushObject = info[0].As<Napi::Object>();
   QBrushWrap* brushWrap = Napi::ObjectWrap<QBrushWrap>::Unwrap(brushObject);
   this->instance->setBackground(*brushWrap->getInternalInstance());
@@ -102,8 +98,6 @@ Napi::Value QListWidgetItemWrap::setBackground(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::background(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QBrush brush = this->instance->background();
   auto instance = QBrushWrap::constructor.New(
       {Napi::External<QBrush>::New(env, new QBrush(brush))});
@@ -112,8 +106,6 @@ Napi::Value QListWidgetItemWrap::background(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::setCheckState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = info[0].As<Napi::Number>().Int32Value();
   this->instance->setCheckState(static_cast<Qt::CheckState>(state));
   return env.Null();
@@ -121,16 +113,12 @@ Napi::Value QListWidgetItemWrap::setCheckState(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::checkState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = static_cast<int>(this->instance->checkState());
   return Napi::Number::New(env, state);
 }
 
 Napi::Value QListWidgetItemWrap::setData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int role = info[0].As<Napi::Number>().Int32Value();
   Napi::Object variantObject = info[1].As<Napi::Object>();
   QVariantWrap* variantWrap =
@@ -141,8 +129,6 @@ Napi::Value QListWidgetItemWrap::setData(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::data(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int role = info[0].As<Napi::Number>().Int32Value();
   QVariant data = this->instance->data(role);
   auto instance = QVariantWrap::constructor.New(
@@ -152,8 +138,6 @@ Napi::Value QListWidgetItemWrap::data(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::setFlags(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int flags = info[0].As<Napi::Number>().Int32Value();
   this->instance->setFlags(static_cast<Qt::ItemFlags>(flags));
   return env.Null();
@@ -161,16 +145,12 @@ Napi::Value QListWidgetItemWrap::setFlags(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::flags(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int flags = static_cast<int>(this->instance->flags());
   return Napi::Number::New(env, flags);
 }
 
 Napi::Value QListWidgetItemWrap::setFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object fontObject = info[0].As<Napi::Object>();
   QFontWrap* fontWrap = Napi::ObjectWrap<QFontWrap>::Unwrap(fontObject);
   this->instance->setFont(*fontWrap->getInternalInstance());
@@ -179,8 +159,6 @@ Napi::Value QListWidgetItemWrap::setFont(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::font(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QFont font = this->instance->font();
   auto instance = QFontWrap::constructor.New(
       {Napi::External<QFont>::New(env, new QFont(font))});
@@ -189,8 +167,6 @@ Napi::Value QListWidgetItemWrap::font(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::setForeground(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object brushObject = info[0].As<Napi::Object>();
   QBrushWrap* brushWrap = Napi::ObjectWrap<QBrushWrap>::Unwrap(brushObject);
   this->instance->setForeground(*brushWrap->getInternalInstance());
@@ -199,8 +175,6 @@ Napi::Value QListWidgetItemWrap::setForeground(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::foreground(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QBrush brush = this->instance->foreground();
   auto instance = QBrushWrap::constructor.New(
       {Napi::External<QBrush>::New(env, new QBrush(brush))});
@@ -209,8 +183,6 @@ Napi::Value QListWidgetItemWrap::foreground(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object iconObject = info[0].As<Napi::Object>();
   QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
   this->instance->setIcon(*iconWrap->getInternalInstance());
@@ -219,8 +191,6 @@ Napi::Value QListWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QIcon icon = this->instance->icon();
   auto instance = QIconWrap::constructor.New(
       {Napi::External<QIcon>::New(env, new QIcon(icon))});
@@ -229,8 +199,6 @@ Napi::Value QListWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::setHidden(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool hide = info[0].As<Napi::Boolean>().Value();
   this->instance->setHidden(hide);
   return env.Null();
@@ -238,15 +206,11 @@ Napi::Value QListWidgetItemWrap::setHidden(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::isHidden(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isHidden());
 }
 
 Napi::Value QListWidgetItemWrap::setSelected(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool select = info[0].As<Napi::Boolean>().Value();
   this->instance->setSelected(select);
   return env.Null();
@@ -254,15 +218,11 @@ Napi::Value QListWidgetItemWrap::setSelected(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::isSelected(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isSelected());
 }
 
 Napi::Value QListWidgetItemWrap::setSizeHint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object sizeObject = info[0].As<Napi::Object>();
   QSizeWrap* sizeWrap = Napi::ObjectWrap<QSizeWrap>::Unwrap(sizeObject);
   this->instance->setSizeHint(*sizeWrap->getInternalInstance());
@@ -271,8 +231,6 @@ Napi::Value QListWidgetItemWrap::setSizeHint(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::sizeHint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QSize size = this->instance->sizeHint();
   auto instance = QSizeWrap::constructor.New({Napi::External<QSize>::New(
       env, new QSize(size.width(), size.height()))});
@@ -281,8 +239,6 @@ Napi::Value QListWidgetItemWrap::sizeHint(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::setStatusTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string statusTip = info[0].As<Napi::String>().Utf8Value();
   this->instance->setStatusTip(QString::fromUtf8(statusTip.c_str()));
   return env.Null();
@@ -290,16 +246,12 @@ Napi::Value QListWidgetItemWrap::setStatusTip(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::statusTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string statusTip = this->instance->text().toStdString();
   return Napi::String::New(env, statusTip);
 }
 
 Napi::Value QListWidgetItemWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string text = info[0].As<Napi::String>().Utf8Value();
   this->instance->setText(QString::fromUtf8(text.c_str()));
   return env.Null();
@@ -307,8 +259,6 @@ Napi::Value QListWidgetItemWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::text(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string text = this->instance->text().toStdString();
   return Napi::String::New(env, text);
 }
@@ -316,8 +266,6 @@ Napi::Value QListWidgetItemWrap::text(const Napi::CallbackInfo& info) {
 Napi::Value QListWidgetItemWrap::setTextAlignment(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int alignment = info[0].As<Napi::Number>().Int32Value();
   this->instance->setTextAlignment(alignment);
   return env.Null();
@@ -325,16 +273,12 @@ Napi::Value QListWidgetItemWrap::setTextAlignment(
 
 Napi::Value QListWidgetItemWrap::textAlignment(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int alignment = this->instance->textAlignment();
   return Napi::Number::New(env, alignment);
 }
 
 Napi::Value QListWidgetItemWrap::setToolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string toolTip = info[0].As<Napi::String>().Utf8Value();
   this->instance->setToolTip(QString::fromUtf8(toolTip.c_str()));
   return env.Null();
@@ -342,16 +286,12 @@ Napi::Value QListWidgetItemWrap::setToolTip(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::toolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string toolTip = this->instance->toolTip().toStdString();
   return Napi::String::New(env, toolTip);
 }
 
 Napi::Value QListWidgetItemWrap::setWhatsThis(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string whatsThis = info[0].As<Napi::String>().Utf8Value();
   this->instance->setWhatsThis(QString::fromUtf8(whatsThis.c_str()));
   return env.Null();
@@ -359,15 +299,11 @@ Napi::Value QListWidgetItemWrap::setWhatsThis(const Napi::CallbackInfo& info) {
 
 Napi::Value QListWidgetItemWrap::whatsThis(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string whatsThis = this->instance->whatsThis().toStdString();
   return Napi::String::New(env, whatsThis);
 }
 
 Napi::Value QListWidgetItemWrap::type(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->type());
 }

--- a/src/cpp/lib/QtWidgets/QMainWindow/qmainwindow_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMainWindow/qmainwindow_wrap.cpp
@@ -37,8 +37,6 @@ QMainWindowWrap::~QMainWindowWrap() { extrautils::safeDelete(this->instance); }
 QMainWindowWrap::QMainWindowWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMainWindowWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -56,8 +54,6 @@ QMainWindowWrap::QMainWindowWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QMainWindowWrap::setCentralWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* centralWidget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);
@@ -67,7 +63,6 @@ Napi::Value QMainWindowWrap::setCentralWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QMainWindowWrap::takeCentralWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->takeCentralWidget();
   // We will not return the value here since we are doing it in js side anyway
   return env.Null();
@@ -75,8 +70,6 @@ Napi::Value QMainWindowWrap::takeCentralWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QMainWindowWrap::setMenuBar(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   QMenuBarWrap* menuBar = Napi::ObjectWrap<QMenuBarWrap>::Unwrap(menuObject);
 
@@ -87,8 +80,6 @@ Napi::Value QMainWindowWrap::setMenuBar(const Napi::CallbackInfo& info) {
 
 Napi::Value QMainWindowWrap::setMenuWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* menuWidget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(menuObject);
@@ -100,8 +91,6 @@ Napi::Value QMainWindowWrap::setMenuWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QMainWindowWrap::center(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   auto window = this->getInternalInstance();
   // https://wiki.qt.io/How_to_Center_a_Window_on_the_Screen
   window->setGeometry(
@@ -113,8 +102,6 @@ Napi::Value QMainWindowWrap::center(const Napi::CallbackInfo& info) {
 
 Napi::Value QMainWindowWrap::setStatusBar(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object statusBarArg = info[0].As<Napi::Object>();
 
   QStatusBar* statusBar = nullptr;
@@ -131,8 +118,6 @@ Napi::Value QMainWindowWrap::setStatusBar(const Napi::CallbackInfo& info) {
 
 Napi::Value QMainWindowWrap::statusBar(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QStatusBar* statusBar = this->instance->statusBar();
 
   return QStatusBarWrap::fromQStatusBar(env, statusBar);

--- a/src/cpp/lib/QtWidgets/QMenu/qmenu_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMenu/qmenu_wrap.cpp
@@ -31,8 +31,6 @@ NMenu* QMenuWrap::getInternalInstance() { return this->instance; }
 QMenuWrap::QMenuWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMenuWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -53,16 +51,12 @@ QMenuWrap::~QMenuWrap() { extrautils::safeDelete(this->instance); }
 
 Napi::Value QMenuWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QMenuWrap::setTitle(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String message = info[0].As<Napi::String>();
   this->instance->setTitle(QString::fromStdString(message.Utf8Value()));
 
@@ -71,8 +65,6 @@ Napi::Value QMenuWrap::setTitle(const Napi::CallbackInfo& info) {
 
 Napi::Value QMenuWrap::addSeparator(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   auto value =
       Napi::External<QAction>::New(env, this->instance->addSeparator());
   return Napi::Value::From(env, value);
@@ -80,8 +72,6 @@ Napi::Value QMenuWrap::addSeparator(const Napi::CallbackInfo& info) {
 
 Napi::Value QMenuWrap::exec(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0) {
     Napi::Object pointObject = info[0].As<Napi::Object>();
     QPointWrap* pointWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(pointObject);
@@ -105,8 +95,6 @@ Napi::Value QMenuWrap::exec(const Napi::CallbackInfo& info) {
 
 Napi::Value QMenuWrap::popup(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object pointObject = info[0].As<Napi::Object>();
   QPointWrap* pointWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(pointObject);
   QPoint* qpoint = pointWrap->getInternalInstance();

--- a/src/cpp/lib/QtWidgets/QMenuBar/qmenubar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMenuBar/qmenubar_wrap.cpp
@@ -29,8 +29,6 @@ NMenuBar* QMenuBarWrap::getInternalInstance() { return this->instance; }
 QMenuBarWrap::QMenuBarWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMenuBarWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance =
@@ -55,8 +53,6 @@ QMenuBarWrap::~QMenuBarWrap() { extrautils::safeDelete(this->instance); }
 
 Napi::Value QMenuBarWrap::addMenu(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   QMenuWrap* menuWrap = Napi::ObjectWrap<QMenuWrap>::Unwrap(menuObject);
 
@@ -67,8 +63,6 @@ Napi::Value QMenuBarWrap::addMenu(const Napi::CallbackInfo& info) {
 
 Napi::Value QMenuBarWrap::addSeparator(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   auto value =
       Napi::External<QAction>::New(env, this->instance->addSeparator());
   return Napi::Value::From(env, value);

--- a/src/cpp/lib/QtWidgets/QMessageBox/qmessagebox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QMessageBox/qmessagebox_wrap.cpp
@@ -32,7 +32,6 @@ QMessageBoxWrap::~QMessageBoxWrap() { extrautils::safeDelete(this->instance); }
 QMessageBoxWrap::QMessageBoxWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QMessageBoxWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -52,7 +51,6 @@ QMessageBoxWrap::QMessageBoxWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QMessageBoxWrap::setDefaultButton(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object buttonObject = info[0].As<Napi::Object>();
   QPushButtonWrap* buttonWrap =
       Napi::ObjectWrap<QPushButtonWrap>::Unwrap(buttonObject);
@@ -61,7 +59,6 @@ Napi::Value QMessageBoxWrap::setDefaultButton(const Napi::CallbackInfo& info) {
 }
 Napi::Value QMessageBoxWrap::addButton(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object buttonObject = info[0].As<Napi::Object>();
   QObjectWrap* qobjWrap = Napi::ObjectWrap<QObjectWrap>::Unwrap(buttonObject);
   QAbstractButton* btn =
@@ -73,13 +70,11 @@ Napi::Value QMessageBoxWrap::addButton(const Napi::CallbackInfo& info) {
 }
 Napi::Value QMessageBoxWrap::accept(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->accept();
   return env.Null();
 }
 Napi::Value QMessageBoxWrap::done(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number r = info[0].As<Napi::Number>();
   this->instance->done(r.Int32Value());
   return env.Null();
@@ -88,8 +83,6 @@ Napi::Value QMessageBoxWrap::done(const Napi::CallbackInfo& info) {
 Napi::Value StaticQMessageBoxWrapMethods::about(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object parentObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* parentWidgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(parentObject);
@@ -107,8 +100,6 @@ Napi::Value StaticQMessageBoxWrapMethods::about(
 Napi::Value StaticQMessageBoxWrapMethods::aboutQt(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object parentObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* parentWidgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(parentObject);

--- a/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPainter/qpainter_wrap.cpp
@@ -67,8 +67,6 @@ QPainterWrap::~QPainterWrap() { delete this->instance; }
 QPainterWrap::QPainterWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPainterWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object deviceObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* deviceWrap =
@@ -84,7 +82,6 @@ QPainterWrap::QPainterWrap(const Napi::CallbackInfo& info)
 }
 Napi::Value QPainterWrap::drawArc(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int width = info[2].As<Napi::Number>().Int32Value();
@@ -96,7 +93,6 @@ Napi::Value QPainterWrap::drawArc(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   Napi::String napiText = info[2].As<Napi::String>();
@@ -106,7 +102,6 @@ Napi::Value QPainterWrap::drawText(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawPath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object pathObject = info[0].As<Napi::Object>();
   QPainterPathWrap* pathWrap =
       Napi::ObjectWrap<QPainterPathWrap>::Unwrap(pathObject);
@@ -116,7 +111,6 @@ Napi::Value QPainterWrap::drawPath(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::strokePath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object pathObject = info[0].As<Napi::Object>();
   QPainterPathWrap* pathWrap =
       Napi::ObjectWrap<QPainterPathWrap>::Unwrap(pathObject);
@@ -129,8 +123,6 @@ Napi::Value QPainterWrap::strokePath(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::begin(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String napiType = info[1].As<Napi::String>();
   std::string type = napiType.Utf8Value();
 
@@ -152,20 +144,17 @@ Napi::Value QPainterWrap::begin(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::end(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   bool ret = this->instance->end();
   return Napi::Value::From(env, ret);
 }
 Napi::Value QPainterWrap::rotate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal angle = info[0].As<Napi::Number>().DoubleValue();
   this->instance->rotate(angle);
   return env.Null();
 }
 Napi::Value QPainterWrap::setFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object fontObject = info[0].As<Napi::Object>();
   QFontWrap* fontWrap = Napi::ObjectWrap<QFontWrap>::Unwrap(fontObject);
   QFont* font = fontWrap->getInternalInstance();
@@ -174,7 +163,6 @@ Napi::Value QPainterWrap::setFont(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::setPen(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String napiType = info[1].As<Napi::String>();
   std::string type = napiType.Utf8Value();
 
@@ -196,7 +184,6 @@ Napi::Value QPainterWrap::setPen(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawEllipse(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 4) {
     Napi::TypeError::New(env, "Invalid number of arguments to drawEllipse")
         .ThrowAsJavaScriptException();
@@ -213,7 +200,6 @@ Napi::Value QPainterWrap::drawEllipse(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterWrap::drawImage(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
@@ -233,7 +219,6 @@ Napi::Value QPainterWrap::drawImage(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterWrap::drawPie(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 6) {
     Napi::TypeError::New(env, "Invalid number of arguments to drawPie")
         .ThrowAsJavaScriptException();
@@ -251,7 +236,6 @@ Napi::Value QPainterWrap::drawPie(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawLine(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x1 = info[0].As<Napi::Number>().Int32Value();
   int y1 = info[1].As<Napi::Number>().Int32Value();
   int x2 = info[2].As<Napi::Number>().Int32Value();
@@ -261,7 +245,6 @@ Napi::Value QPainterWrap::drawLine(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::scale(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal sx = info[0].As<Napi::Number>().DoubleValue();
   qreal sy = info[1].As<Napi::Number>().DoubleValue();
   this->instance->scale(sx, sy);
@@ -269,7 +252,6 @@ Napi::Value QPainterWrap::scale(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::translate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal dx = info[0].As<Napi::Number>().DoubleValue();
   qreal dy = info[1].As<Napi::Number>().DoubleValue();
   this->instance->translate(dx, dy);
@@ -277,7 +259,6 @@ Napi::Value QPainterWrap::translate(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawConvexPolygon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Array pointsNapi = info[0].As<Napi::Array>();
   QPolygon polygon;
   for (int i = 0; i < pointsNapi.Length(); i++) {
@@ -291,19 +272,16 @@ Napi::Value QPainterWrap::drawConvexPolygon(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::save(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->save();
   return env.Null();
 }
 Napi::Value QPainterWrap::restore(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->restore();
   return env.Null();
 }
 Napi::Value QPainterWrap::setBrush(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   Napi::String napiType = info[1].As<Napi::String>();
   std::string type = napiType.Utf8Value();
@@ -324,7 +302,6 @@ Napi::Value QPainterWrap::setBrush(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::setRenderHint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QPainter::RenderHint hint =
       (QPainter::RenderHint)info[0].As<Napi::Number>().Int32Value();
 
@@ -334,8 +311,6 @@ Napi::Value QPainterWrap::setRenderHint(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterWrap::setTransform(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String napiType = info[0].As<Napi::String>();
   std::string type = napiType.Utf8Value();
   if (type == "matrix2x3") {
@@ -349,25 +324,21 @@ Napi::Value QPainterWrap::setTransform(const Napi::CallbackInfo& info) {
     QTransform xform(m11, m12, m21, m22, m31, m32);
     this->instance->setTransform(xform, combine);
   }
-
   return env.Null();
 }
 
 Napi::Value QPainterWrap::beginNativePainting(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->beginNativePainting();
   return env.Null();
 }
 Napi::Value QPainterWrap::endNativePainting(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->endNativePainting();
   return env.Null();
 }
 Napi::Value QPainterWrap::fillRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int width = info[2].As<Napi::Number>().Int32Value();
@@ -380,13 +351,11 @@ Napi::Value QPainterWrap::fillRect(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::compositionMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   uint mode = static_cast<uint>(this->instance->compositionMode());
   return Napi::Value::From(env, mode);
 }
 Napi::Value QPainterWrap::setCompositionMode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   QPainter::CompositionMode mode =
       (QPainter::CompositionMode)info[0].As<Napi::Number>().Uint32Value();
   this->instance->setCompositionMode(mode);
@@ -394,20 +363,17 @@ Napi::Value QPainterWrap::setCompositionMode(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::opacity(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal opacity = this->instance->opacity();
   return Napi::Value::From(env, opacity);
 }
 Napi::Value QPainterWrap::setOpacity(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal opacity = info[0].As<Napi::Number>().DoubleValue();
   this->instance->setOpacity(opacity);
   return env.Null();
 }
 Napi::Value QPainterWrap::drawPoint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   this->instance->drawPoint(x, y);
@@ -415,7 +381,6 @@ Napi::Value QPainterWrap::drawPoint(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int width = info[2].As<Napi::Number>().Int32Value();
@@ -425,7 +390,6 @@ Napi::Value QPainterWrap::drawRect(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::eraseRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int width = info[2].As<Napi::Number>().Int32Value();
@@ -435,7 +399,6 @@ Napi::Value QPainterWrap::eraseRect(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::boundingRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int w = info[2].As<Napi::Number>().Int32Value();
@@ -450,7 +413,6 @@ Napi::Value QPainterWrap::boundingRect(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::drawChord(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int width = info[2].As<Napi::Number>().Int32Value();
@@ -462,7 +424,6 @@ Napi::Value QPainterWrap::drawChord(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterWrap::setBrushOrigin(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   this->instance->setBrushOrigin(x, y);

--- a/src/cpp/lib/QtWidgets/QPainterPath/qpainterpath_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPainterPath/qpainterpath_wrap.cpp
@@ -61,8 +61,6 @@ QPainterPathWrap::~QPainterPathWrap() { this->instance.reset(); }
 QPainterPathWrap::QPainterPathWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPainterPathWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 0) {
     this->instance = std::make_unique<QPainterPath>();
   } else {
@@ -73,7 +71,6 @@ QPainterPathWrap::QPainterPathWrap(const Napi::CallbackInfo& info)
 }
 Napi::Value QPainterPathWrap::moveTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal x = info[0].As<Napi::Number>().DoubleValue();
   qreal y = info[1].As<Napi::Number>().DoubleValue();
   this->instance->moveTo(x, y);
@@ -81,7 +78,6 @@ Napi::Value QPainterPathWrap::moveTo(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::addRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal x = info[0].As<Napi::Number>().DoubleValue();
   qreal y = info[1].As<Napi::Number>().DoubleValue();
   qreal width = info[2].As<Napi::Number>().DoubleValue();
@@ -91,7 +87,6 @@ Napi::Value QPainterPathWrap::addRect(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::lineTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal x = info[0].As<Napi::Number>().DoubleValue();
   qreal y = info[1].As<Napi::Number>().DoubleValue();
   this->instance->lineTo(x, y);
@@ -99,7 +94,6 @@ Napi::Value QPainterPathWrap::lineTo(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::cubicTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal c1X = info[0].As<Napi::Number>().DoubleValue();
   qreal c1Y = info[1].As<Napi::Number>().DoubleValue();
   qreal c2X = info[2].As<Napi::Number>().DoubleValue();
@@ -111,7 +105,6 @@ Napi::Value QPainterPathWrap::cubicTo(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::quadTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal cx = info[0].As<Napi::Number>().DoubleValue();
   qreal cy = info[1].As<Napi::Number>().DoubleValue();
   qreal endPointX = info[2].As<Napi::Number>().DoubleValue();
@@ -121,14 +114,12 @@ Napi::Value QPainterPathWrap::quadTo(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::closeSubpath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->closeSubpath();
   return env.Null();
 }
 
 Napi::Value QPainterPathWrap::addEllipse(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal x = info[0].As<Napi::Number>().DoubleValue();
   qreal y = info[1].As<Napi::Number>().DoubleValue();
   qreal width = info[2].As<Napi::Number>().DoubleValue();
@@ -139,7 +130,6 @@ Napi::Value QPainterPathWrap::addEllipse(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::addPath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 1) {
     Napi::TypeError::New(env, "No Path Specified to addPath")
         .ThrowAsJavaScriptException();
@@ -159,7 +149,6 @@ Napi::Value QPainterPathWrap::addPath(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::addRoundedRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() >= 6) {
     qreal x = info[0].As<Napi::Number>().DoubleValue();
     qreal y = info[1].As<Napi::Number>().DoubleValue();
@@ -186,7 +175,6 @@ Napi::Value QPainterPathWrap::addRoundedRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::addText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 4) {
     Napi::TypeError::New(env, "Invalid number of arguments to addText")
         .ThrowAsJavaScriptException();
@@ -218,7 +206,6 @@ Napi::Value QPainterPathWrap::angleAtPercent(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::arcMoveTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 5) {
     Napi::TypeError::New(env, "Invalid number of arguments to arcMoveTo")
         .ThrowAsJavaScriptException();
@@ -236,7 +223,6 @@ Napi::Value QPainterPathWrap::arcMoveTo(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::arcTo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 6) {
     Napi::TypeError::New(env, "Invalid number of arguments to arcTo")
         .ThrowAsJavaScriptException();
@@ -282,7 +268,6 @@ Napi::Value QPainterPathWrap::clear(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::connectPath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() < 1) {
     Napi::TypeError::New(env, "No Path Specified to connectPath")
         .ThrowAsJavaScriptException();
@@ -334,7 +319,6 @@ Napi::Value QPainterPathWrap::fillRule(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::intersects(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object pathObject = info[0].As<Napi::Object>();
   QPainterPathWrap* pathWrap =
       Napi::ObjectWrap<QPainterPathWrap>::Unwrap(pathObject);
@@ -360,7 +344,6 @@ Napi::Value QPainterPathWrap::percentAtLength(const Napi::CallbackInfo& info) {
 }
 Napi::Value QPainterPathWrap::pointAtPercent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal p = info[0].As<Napi::Number>().DoubleValue();
   QPointF point = static_cast<QPointF>(this->instance->pointAtPercent(p));
   qreal x = static_cast<qreal>(point.x());
@@ -380,7 +363,6 @@ Napi::Value QPainterPathWrap::reserve(const Napi::CallbackInfo& info) {
 Napi::Value QPainterPathWrap::setElementPositionAt(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int index = info[0].As<Napi::Number>().Int32Value();
   qreal x = info[1].As<Napi::Number>().DoubleValue();
   qreal y = info[2].As<Napi::Number>().DoubleValue();
@@ -389,7 +371,6 @@ Napi::Value QPainterPathWrap::setElementPositionAt(
 }
 Napi::Value QPainterPathWrap::setFillRule(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int v = info[0].As<Napi::Number>().Int32Value();
   this->instance->setFillRule(static_cast<Qt::FillRule>(v));
   return env.Null();
@@ -397,7 +378,6 @@ Napi::Value QPainterPathWrap::setFillRule(const Napi::CallbackInfo& info) {
 
 Napi::Value QPainterPathWrap::slopeAtPercent(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal v = info[0].As<Napi::Number>().DoubleValue();
   qreal slope = static_cast<qreal>(this->instance->slopeAtPercent(v));
   return Napi::Number::From(env, slope);
@@ -405,7 +385,6 @@ Napi::Value QPainterPathWrap::slopeAtPercent(const Napi::CallbackInfo& info) {
 // Napi::Value subtracted(const Napi::CallbackInfo& info);
 Napi::Value QPainterPathWrap::swap(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Object pathObject = info[0].As<Napi::Object>();
   QPainterPathWrap* pathWrap =
       Napi::ObjectWrap<QPainterPathWrap>::Unwrap(pathObject);
@@ -418,7 +397,6 @@ Napi::Value QPainterPathWrap::swap(const Napi::CallbackInfo& info) {
 // Napi::Value toSubpathPolygons(const Napi::CallbackInfo& info);
 Napi::Value QPainterPathWrap::translate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   qreal x = info[0].As<Napi::Number>().DoubleValue();
   qreal y = info[1].As<Napi::Number>().DoubleValue();
   this->instance->translate(x, y);

--- a/src/cpp/lib/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPlainTextEdit/qplaintextedit_wrap.cpp
@@ -37,8 +37,6 @@ NPlainTextEdit *QPlainTextEditWrap::getInternalInstance() {
 QPlainTextEditWrap::QPlainTextEditWrap(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<QPlainTextEditWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap *parentWidgetWrap =
@@ -62,7 +60,6 @@ QPlainTextEditWrap::~QPlainTextEditWrap() {
 
 Napi::Value QPlainTextEditWrap::setPlainText(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String plainText = info[0].As<Napi::String>();
   this->instance->setPlainText(plainText.Utf8Value().c_str());
   return env.Null();
@@ -71,7 +68,6 @@ Napi::Value QPlainTextEditWrap::setPlainText(const Napi::CallbackInfo &info) {
 Napi::Value QPlainTextEditWrap::setPlaceholderText(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String text = info[0].As<Napi::String>();
   this->instance->setPlaceholderText(text.Utf8Value().c_str());
   return env.Null();
@@ -79,7 +75,6 @@ Napi::Value QPlainTextEditWrap::setPlaceholderText(
 
 Napi::Value QPlainTextEditWrap::setReadOnly(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean isReadOnly = info[0].As<Napi::Boolean>();
   this->instance->setReadOnly(isReadOnly.Value());
   return env.Null();
@@ -87,13 +82,11 @@ Napi::Value QPlainTextEditWrap::setReadOnly(const Napi::CallbackInfo &info) {
 
 Napi::Value QPlainTextEditWrap::toPlainText(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Value::From(env, this->instance->toPlainText().toStdString());
 }
 
 Napi::Value QPlainTextEditWrap::clear(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clear();
   return env.Null();
 }
@@ -101,7 +94,6 @@ Napi::Value QPlainTextEditWrap::clear(const Napi::CallbackInfo &info) {
 Napi::Value QPlainTextEditWrap::setWordWrapMode(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number mode = info[0].As<Napi::Number>();
   this->instance->setWordWrapMode(
       static_cast<QTextOption::WrapMode>(mode.Int32Value()));
@@ -110,7 +102,6 @@ Napi::Value QPlainTextEditWrap::setWordWrapMode(
 
 Napi::Value QPlainTextEditWrap::wordWrapMode(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = static_cast<int>(this->instance->wordWrapMode());
   return Napi::Number::From(env, value);
 }
@@ -118,7 +109,6 @@ Napi::Value QPlainTextEditWrap::wordWrapMode(const Napi::CallbackInfo &info) {
 Napi::Value QPlainTextEditWrap::setLineWrapMode(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number mode = info[0].As<Napi::Number>();
   this->instance->setLineWrapMode(
       static_cast<QPlainTextEdit::LineWrapMode>(mode.Int32Value()));
@@ -127,7 +117,6 @@ Napi::Value QPlainTextEditWrap::setLineWrapMode(
 
 Napi::Value QPlainTextEditWrap::lineWrapMode(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = static_cast<int>(this->instance->lineWrapMode());
   return Napi::Number::From(env, value);
 }
@@ -135,7 +124,6 @@ Napi::Value QPlainTextEditWrap::lineWrapMode(const Napi::CallbackInfo &info) {
 Napi::Value QPlainTextEditWrap::insertPlainText(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String plainText = info[0].As<Napi::String>();
   this->instance->insertPlainText(plainText.Utf8Value().c_str());
   return env.Null();

--- a/src/cpp/lib/QtWidgets/QProgressBar/qprogressbar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QProgressBar/qprogressbar_wrap.cpp
@@ -30,8 +30,6 @@ QProgressBarWrap::~QProgressBarWrap() {
 QProgressBarWrap::QProgressBarWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QProgressBarWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -50,24 +48,18 @@ QProgressBarWrap::QProgressBarWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QProgressBarWrap::resetFormat(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->resetFormat();
   return env.Null();
 }
 
 Napi::Value QProgressBarWrap::reset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->reset();
   return env.Null();
 }
 
 Napi::Value QProgressBarWrap::setRange(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int minimum = info[0].As<Napi::Number>().Int32Value();
   int maximum = info[1].As<Napi::Number>().Int32Value();
   this->instance->setRange(minimum, maximum);

--- a/src/cpp/lib/QtWidgets/QProgressDialog/qprogressdialog_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QProgressDialog/qprogressdialog_wrap.cpp
@@ -34,8 +34,6 @@ QProgressDialogWrap::~QProgressDialogWrap() {
 QProgressDialogWrap::QProgressDialogWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QProgressDialogWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -55,16 +53,12 @@ QProgressDialogWrap::QProgressDialogWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QProgressDialogWrap::cancel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->cancel();
   return env.Null();
 }
 
 Napi::Value QProgressDialogWrap::reset(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->reset();
   return env.Null();
 }
@@ -72,8 +66,6 @@ Napi::Value QProgressDialogWrap::reset(const Napi::CallbackInfo& info) {
 Napi::Value QProgressDialogWrap::setCancelButtonText(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string napiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(napiText.c_str());
   this->instance->setCancelButtonText(text);
@@ -82,8 +74,6 @@ Napi::Value QProgressDialogWrap::setCancelButtonText(
 
 Napi::Value QProgressDialogWrap::setRange(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int minimum = info[0].As<Napi::Number>().Int32Value();
   int maximum = info[1].As<Napi::Number>().Int32Value();
   this->instance->setRange(minimum, maximum);

--- a/src/cpp/lib/QtWidgets/QPushButton/qpushbutton_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QPushButton/qpushbutton_wrap.cpp
@@ -30,7 +30,6 @@ QPushButtonWrap::~QPushButtonWrap() {
 QPushButtonWrap::QPushButtonWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QPushButtonWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NPushButton>>().Data();
@@ -58,8 +57,6 @@ QPushButtonWrap::QPushButtonWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QPushButtonWrap::setMenu(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   QMenuWrap* menuWrap = Napi::ObjectWrap<QMenuWrap>::Unwrap(menuObject);
   this->instance->setMenu(menuWrap->getInternalInstance());
@@ -68,8 +65,6 @@ Napi::Value QPushButtonWrap::setMenu(const Napi::CallbackInfo& info) {
 
 Napi::Value QPushButtonWrap::showMenu(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->showMenu();
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QRadioButton/qradiobutton_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QRadioButton/qradiobutton_wrap.cpp
@@ -24,7 +24,6 @@ NRadioButton* QRadioButtonWrap::getInternalInstance() { return this->instance; }
 QRadioButtonWrap::QRadioButtonWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QRadioButtonWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NRadioButton>>().Data();

--- a/src/cpp/lib/QtWidgets/QScrollArea/qscrollarea_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QScrollArea/qscrollarea_wrap.cpp
@@ -34,8 +34,6 @@ QScrollAreaWrap::~QScrollAreaWrap() {
 QScrollAreaWrap::QScrollAreaWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QScrollAreaWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -59,8 +57,6 @@ QScrollAreaWrap::QScrollAreaWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QScrollAreaWrap::ensureVisible(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   int xmargin = info[2].As<Napi::Number>().Int32Value();
@@ -72,8 +68,6 @@ Napi::Value QScrollAreaWrap::ensureVisible(const Napi::CallbackInfo& info) {
 Napi::Value QScrollAreaWrap::ensureWidgetVisible(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object childWidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* childWidgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(childWidgetObject);
@@ -86,8 +80,6 @@ Napi::Value QScrollAreaWrap::ensureWidgetVisible(
 
 Napi::Value QScrollAreaWrap::setWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object contentWidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* contentWidgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(contentWidgetObject);
@@ -97,8 +89,6 @@ Napi::Value QScrollAreaWrap::setWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QScrollAreaWrap::takeWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->takeWidget();
   // We will not return the value here since we are doing it in js side anyway
   return env.Null();
@@ -107,8 +97,6 @@ Napi::Value QScrollAreaWrap::takeWidget(const Napi::CallbackInfo& info) {
 Napi::Value QScrollAreaWrap::setViewportMargins(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   NScrollArea* nScrollArea = qobject_cast<NScrollArea*>(this->instance);
   if (nScrollArea != nullptr) {
     int left = info[0].As<Napi::Number>().Int32Value();
@@ -122,8 +110,6 @@ Napi::Value QScrollAreaWrap::setViewportMargins(
 
 Napi::Value QScrollAreaWrap::viewportMargins(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   NScrollArea* nScrollArea = qobject_cast<NScrollArea*>(this->instance);
 
   QMargins margins;

--- a/src/cpp/lib/QtWidgets/QScrollBar/qscrollbar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QScrollBar/qscrollbar_wrap.cpp
@@ -23,8 +23,6 @@ NScrollBar* QScrollBarWrap::getInternalInstance() { return this->instance; }
 QScrollBarWrap::QScrollBarWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QScrollBarWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QShortcut/qshortcut_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QShortcut/qshortcut_wrap.cpp
@@ -29,8 +29,6 @@ NShortcut* QShortcutWrap::getInternalInstance() { return this->instance; }
 QShortcutWrap::QShortcutWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QShortcutWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -47,7 +45,6 @@ QShortcutWrap::~QShortcutWrap() { extrautils::safeDelete(this->instance); }
 
 Napi::Value QShortcutWrap::setEnabled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean enabled = info[0].As<Napi::Boolean>();
   this->instance->setEnabled(enabled.Value());
   return env.Null();
@@ -55,7 +52,6 @@ Napi::Value QShortcutWrap::setEnabled(const Napi::CallbackInfo& info) {
 
 Napi::Value QShortcutWrap::setAutoRepeat(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean enabled = info[0].As<Napi::Boolean>();
   this->instance->setAutoRepeat(enabled.Value());
   return env.Null();
@@ -63,8 +59,6 @@ Napi::Value QShortcutWrap::setAutoRepeat(const Napi::CallbackInfo& info) {
 
 Napi::Value QShortcutWrap::setKey(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object shortcutSequence = info[0].As<Napi::Object>();
   QKeySequenceWrap* keysequence =
       Napi::ObjectWrap<QKeySequenceWrap>::Unwrap(shortcutSequence);
@@ -74,8 +68,6 @@ Napi::Value QShortcutWrap::setKey(const Napi::CallbackInfo& info) {
 
 Napi::Value QShortcutWrap::setContext(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number shortcutContextEnum = info[0].As<Napi::Number>();
   int shortCutContext = shortcutContextEnum.Int32Value();
   this->instance->setContext(static_cast<Qt::ShortcutContext>(shortCutContext));

--- a/src/cpp/lib/QtWidgets/QSlider/qslider_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSlider/qslider_wrap.cpp
@@ -23,8 +23,6 @@ NSlider* QSliderWrap::getInternalInstance() { return this->instance; }
 QSliderWrap::QSliderWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSliderWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QSpinBox/qspinbox_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSpinBox/qspinbox_wrap.cpp
@@ -23,8 +23,6 @@ NSpinBox* QSpinBoxWrap::getInternalInstance() { return this->instance; }
 QSpinBoxWrap::QSpinBoxWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSpinBoxWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -45,8 +43,6 @@ QSpinBoxWrap::~QSpinBoxWrap() { extrautils::safeDelete(this->instance); }
 
 Napi::Value QSpinBoxWrap::setRange(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number minimum = info[0].As<Napi::Number>();
   Napi::Number maximum = info[1].As<Napi::Number>();
   this->instance->setRange(minimum.Int32Value(), maximum.Int32Value());

--- a/src/cpp/lib/QtWidgets/QSplitter/qsplitter_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSplitter/qsplitter_wrap.cpp
@@ -32,8 +32,6 @@ QSplitterWrap::~QSplitterWrap() { extrautils::safeDelete(this->instance); }
 QSplitterWrap::QSplitterWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSplitterWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -52,8 +50,6 @@ QSplitterWrap::QSplitterWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QSplitterWrap::addWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);
@@ -64,20 +60,16 @@ Napi::Value QSplitterWrap::addWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QSplitterWrap::childrenCollapsible(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Boolean::New(env, this->instance->childrenCollapsible());
 }
 
 Napi::Value QSplitterWrap::count(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   return Napi::Number::New(env, this->instance->count());
 }
 
 Napi::Value QSplitterWrap::indexOf(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);
@@ -88,8 +80,6 @@ Napi::Value QSplitterWrap::indexOf(const Napi::CallbackInfo& info) {
 
 Napi::Value QSplitterWrap::insertWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object widgetObject = info[1].As<Napi::Object>();
   NodeWidgetWrap* widgetWrap =
@@ -101,24 +91,18 @@ Napi::Value QSplitterWrap::insertWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QSplitterWrap::isCollapsible(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   return Napi::Boolean::New(env, this->instance->isCollapsible(index));
 }
 
 Napi::Value QSplitterWrap::orientation(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env,
                            static_cast<int>(this->instance->orientation()));
 }
 
 Napi::Value QSplitterWrap::setCollapsible(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   bool collapse = info[1].As<Napi::Boolean>().Value();
   this->instance->setCollapsible(index, collapse);
@@ -127,8 +111,6 @@ Napi::Value QSplitterWrap::setCollapsible(const Napi::CallbackInfo& info) {
 
 Napi::Value QSplitterWrap::setOrientation(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int orientation = info[0].As<Napi::Number>().Int32Value();
   this->instance->setOrientation(static_cast<Qt::Orientation>(orientation));
 

--- a/src/cpp/lib/QtWidgets/QStackedWidget/qstackedwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QStackedWidget/qstackedwidget_wrap.cpp
@@ -35,8 +35,6 @@ QStackedWidgetWrap::~QStackedWidgetWrap() {
 QStackedWidgetWrap::QStackedWidgetWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QStackedWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -57,8 +55,6 @@ QStackedWidgetWrap::QStackedWidgetWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QStackedWidgetWrap::addWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);
@@ -69,8 +65,6 @@ Napi::Value QStackedWidgetWrap::addWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QStackedWidgetWrap::removeWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);
@@ -81,7 +75,6 @@ Napi::Value QStackedWidgetWrap::removeWidget(const Napi::CallbackInfo& info) {
 Napi::Value QStackedWidgetWrap::setCurrentIndex(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number index = info[0].As<Napi::Number>();
   this->instance->setCurrentIndex(index.Int32Value());
   return env.Null();
@@ -89,7 +82,6 @@ Napi::Value QStackedWidgetWrap::setCurrentIndex(
 
 Napi::Value QStackedWidgetWrap::currentIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = this->instance->currentIndex();
   return Napi::Number::New(env, value);
 }
@@ -97,8 +89,6 @@ Napi::Value QStackedWidgetWrap::currentIndex(const Napi::CallbackInfo& info) {
 Napi::Value QStackedWidgetWrap::setCurrentWidget(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   NodeWidgetWrap* widget =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(qwidgetObject);

--- a/src/cpp/lib/QtWidgets/QStandardItem/qstandarditem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QStandardItem/qstandarditem_wrap.cpp
@@ -36,8 +36,6 @@ QStandardItemWrap::~QStandardItemWrap() {
 QStandardItemWrap::QStandardItemWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QStandardItemWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     this->instance = info[0].As<Napi::External<QStandardItem>>().Data();
     if (info.Length() == 2) {
@@ -60,7 +58,6 @@ QStandardItemWrap::QStandardItemWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QStandardItemWrap::setCheckState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int state = info[0].As<Napi::Number>().Int32Value();
 
   this->instance->setCheckState(Qt::CheckState(state));
@@ -68,7 +65,6 @@ Napi::Value QStandardItemWrap::setCheckState(const Napi::CallbackInfo& info) {
 }
 Napi::Value QStandardItemWrap::setData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = info[0].As<Napi::Number>().Int32Value();
   int role = info[1].As<Napi::Number>().Int32Value();
 
@@ -77,7 +73,6 @@ Napi::Value QStandardItemWrap::setData(const Napi::CallbackInfo& info) {
 }
 Napi::Value QStandardItemWrap::setFlags(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int flags = info[0].As<Napi::Number>().Int32Value();
 
   this->instance->setFlags(Qt::ItemFlag(flags));
@@ -85,7 +80,6 @@ Napi::Value QStandardItemWrap::setFlags(const Napi::CallbackInfo& info) {
 }
 Napi::Value QStandardItemWrap::checkState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int state = static_cast<int>(this->instance->checkState());
   return Napi::Number::From(env, state);
 }

--- a/src/cpp/lib/QtWidgets/QStandardItemModel/qstandarditemmodel_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QStandardItemModel/qstandarditemmodel_wrap.cpp
@@ -32,8 +32,6 @@ NStandardItemModel* QStandardItemModelWrap::getInternalInstance() {
 QStandardItemModelWrap::QStandardItemModelWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QStandardItemModelWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -54,7 +52,6 @@ QStandardItemModelWrap::~QStandardItemModelWrap() {}
 
 Napi::Value QStandardItemModelWrap::item(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
 

--- a/src/cpp/lib/QtWidgets/QStatusBar/qstatusbar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QStatusBar/qstatusbar_wrap.cpp
@@ -50,8 +50,6 @@ QStatusBarWrap::~QStatusBarWrap() { extrautils::safeDelete(this->instance); }
 QStatusBarWrap::QStatusBarWrap(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<QStatusBarWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap *parentWidgetWrap =
@@ -72,8 +70,6 @@ QStatusBarWrap::QStatusBarWrap(const Napi::CallbackInfo &info)
 
 Napi::Value QStatusBarWrap::addPermanentWidget(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetArg = info[0].As<Napi::Object>();
   Napi::Number stretchArg = info[1].As<Napi::Number>();
 
@@ -89,8 +85,6 @@ Napi::Value QStatusBarWrap::addPermanentWidget(const Napi::CallbackInfo &info) {
 
 Napi::Value QStatusBarWrap::addWidget(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetArg = info[0].As<Napi::Object>();
   Napi::Number stretchArg = info[1].As<Napi::Number>();
 
@@ -106,8 +100,6 @@ Napi::Value QStatusBarWrap::addWidget(const Napi::CallbackInfo &info) {
 
 Napi::Value QStatusBarWrap::clearMessage(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clearMessage();
 
   return env.Null();
@@ -115,8 +107,6 @@ Napi::Value QStatusBarWrap::clearMessage(const Napi::CallbackInfo &info) {
 
 Napi::Value QStatusBarWrap::currentMessage(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string currentMessage = this->instance->currentMessage().toStdString();
 
   return Napi::String::New(env, currentMessage);
@@ -125,8 +115,6 @@ Napi::Value QStatusBarWrap::currentMessage(const Napi::CallbackInfo &info) {
 Napi::Value QStatusBarWrap::insertPermanentWidget(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number indexArg = info[0].As<Napi::Number>();
   Napi::Object widgetArg = info[1].As<Napi::Object>();
   Napi::Number stretchArg = info[2].As<Napi::Number>();
@@ -145,8 +133,6 @@ Napi::Value QStatusBarWrap::insertPermanentWidget(
 
 Napi::Value QStatusBarWrap::insertWidget(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number indexArg = info[0].As<Napi::Number>();
   Napi::Object widgetArg = info[1].As<Napi::Object>();
   Napi::Number stretchArg = info[2].As<Napi::Number>();
@@ -156,58 +142,41 @@ Napi::Value QStatusBarWrap::insertWidget(const Napi::CallbackInfo &info) {
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetArg);
   QWidget *widget = widgetWrap->getInternalInstance();
   int stretch = stretchArg.Int32Value();
-
   int targetIndex = this->instance->insertWidget(index, widget, stretch);
-
   return Napi::Value::From(env, targetIndex);
 }
 
 Napi::Value QStatusBarWrap::isSizeGripEnabled(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool isEnabled = this->instance->isSizeGripEnabled();
-
   return Napi::Value::From(env, isEnabled);
 }
 
 Napi::Value QStatusBarWrap::removeWidget(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetArg = info[0].As<Napi::Object>();
 
   NodeWidgetWrap *widgetWrap =
       Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetArg);
   QWidget *widget = widgetWrap->getInternalInstance();
-
   this->instance->removeWidget(widget);
-
   return env.Null();
 }
 
 Napi::Value QStatusBarWrap::showMessage(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String message = info[0].As<Napi::String>();
   Napi::Number timeout = info[1].As<Napi::Number>();
 
   this->instance->showMessage(QString::fromStdString(message.Utf8Value()),
                               timeout.Int32Value());
-
   return env.Null();
 }
 
 Napi::Value QStatusBarWrap::setSizeGripEnabled(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Boolean enableArg = info[0].As<Napi::Boolean>();
-
   bool enable = enableArg.ToBoolean();
-
   this->instance->setSizeGripEnabled(enable);
-
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QStyleFactory/qstylefactory_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QStyleFactory/qstylefactory_wrap.cpp
@@ -8,8 +8,6 @@ namespace QStyleFactoryWrap {
 
 Napi::Value create(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String key = info[0].As<Napi::String>();
 
   QStyle* style =
@@ -22,8 +20,6 @@ Napi::Value create(const Napi::CallbackInfo& info) {
 
 Napi::Value keys(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QStringList keys = QStyleFactory::keys();
   Napi::Array keysNapi = Napi::Array::New(env, keys.size());
   for (int i = 0; i < keys.size(); i++) {

--- a/src/cpp/lib/QtWidgets/QSvgWidget/qsvgwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSvgWidget/qsvgwidget_wrap.cpp
@@ -26,7 +26,6 @@ QSvgWidgetWrap::~QSvgWidgetWrap() { extrautils::safeDelete(this->instance); }
 QSvgWidgetWrap::QSvgWidgetWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSvgWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -45,8 +44,6 @@ QSvgWidgetWrap::QSvgWidgetWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QSvgWidgetWrap::load(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Value value = info[0];
   std::string napis = value.As<Napi::String>().Utf8Value();
   QString s = QString::fromUtf8(napis.c_str());

--- a/src/cpp/lib/QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSystemTrayIcon/qsystemtrayicon_wrap.cpp
@@ -35,8 +35,6 @@ NSystemTrayIcon* QSystemTrayIconWrap::getInternalInstance() {
 QSystemTrayIconWrap::QSystemTrayIconWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QSystemTrayIconWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -59,24 +57,18 @@ QSystemTrayIconWrap::~QSystemTrayIconWrap() {
 
 Napi::Value QSystemTrayIconWrap::show(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->show();
   return env.Null();
 }
 
 Napi::Value QSystemTrayIconWrap::hide(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->hide();
   return env.Null();
 }
 
 Napi::Value QSystemTrayIconWrap::setIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object iconObject = info[0].As<Napi::Object>();
   QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
   this->instance->setIcon(*iconWrap->getInternalInstance());
@@ -85,16 +77,12 @@ Napi::Value QSystemTrayIconWrap::setIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QSystemTrayIconWrap::isVisible(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool visibility = this->instance->isVisible();
   return Napi::Boolean::New(env, visibility);
 }
 
 Napi::Value QSystemTrayIconWrap::setToolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String toolTip = info[0].As<Napi::String>();
   this->instance->setToolTip(QString::fromStdString(toolTip.Utf8Value()));
   return env.Null();
@@ -103,8 +91,6 @@ Napi::Value QSystemTrayIconWrap::setToolTip(const Napi::CallbackInfo& info) {
 Napi::Value QSystemTrayIconWrap::setContextMenu(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   QMenuWrap* menuWrap = Napi::ObjectWrap<QMenuWrap>::Unwrap(menuObject);
   this->instance->setContextMenu(menuWrap->getInternalInstance());
@@ -113,7 +99,6 @@ Napi::Value QSystemTrayIconWrap::setContextMenu(
 
 Napi::Value QSystemTrayIconWrap::showMessage(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::String title = info[0].As<Napi::String>();
   Napi::String message = info[1].As<Napi::String>();
   Napi::Object iconObject = info[2].As<Napi::Object>();

--- a/src/cpp/lib/QtWidgets/QTabBar/qtabbar_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTabBar/qtabbar_wrap.cpp
@@ -57,8 +57,6 @@ QTabBarWrap::~QTabBarWrap() {
 QTabBarWrap::QTabBarWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTabBarWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NTabBar>>().Data();
@@ -86,8 +84,6 @@ QTabBarWrap::QTabBarWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QTabBarWrap::setAccessibleTabName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   std::string napiName = info[1].As<Napi::String>().Utf8Value();
   QString name = QString::fromUtf8(napiName.c_str());
@@ -97,8 +93,6 @@ Napi::Value QTabBarWrap::setAccessibleTabName(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::accessibleTabName(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QString tabName = this->instance->accessibleTabName(index);
   return Napi::String::New(env, tabName.toStdString());
@@ -106,8 +100,6 @@ Napi::Value QTabBarWrap::accessibleTabName(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::addTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = 0;
   if (info.Length() == 2) {
     Napi::Object iconObject = info[0].As<Napi::Object>();
@@ -125,8 +117,6 @@ Napi::Value QTabBarWrap::addTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::insertTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int result = 0;
   if (info.Length() == 3) {
     int index = info[0].As<Napi::Number>().Int32Value();
@@ -147,8 +137,6 @@ Napi::Value QTabBarWrap::insertTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabEnabled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   bool enabled = info[1].As<Napi::Boolean>().Value();
   this->instance->setTabEnabled(index, enabled);
@@ -157,8 +145,6 @@ Napi::Value QTabBarWrap::setTabEnabled(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::isTabEnabled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   bool enabled = this->instance->isTabEnabled(index);
   return Napi::Boolean::New(env, enabled);
@@ -166,8 +152,6 @@ Napi::Value QTabBarWrap::isTabEnabled(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::moveTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int from = info[0].As<Napi::Number>().Int32Value();
   int to = info[1].As<Napi::Number>().Int32Value();
   this->instance->moveTab(from, to);
@@ -176,8 +160,6 @@ Napi::Value QTabBarWrap::moveTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::removeTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   this->instance->removeTab(index);
   return env.Null();
@@ -185,8 +167,6 @@ Napi::Value QTabBarWrap::removeTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabButton(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   int position = info[1].As<Napi::Number>().Int32Value();
   Napi::Object widgetObject = info[2].As<Napi::Object>();
@@ -200,8 +180,6 @@ Napi::Value QTabBarWrap::setTabButton(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object variantObject = info[1].As<Napi::Object>();
   QVariantWrap* variantWrap =
@@ -212,8 +190,6 @@ Napi::Value QTabBarWrap::setTabData(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QVariant variant = this->instance->tabData(index);
   auto instance = QVariantWrap::constructor.New(
@@ -223,8 +199,6 @@ Napi::Value QTabBarWrap::tabData(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object iconObject = info[1].As<Napi::Object>();
   QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
@@ -234,8 +208,6 @@ Napi::Value QTabBarWrap::setTabIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QIcon icon = this->instance->tabIcon(index);
   auto instance = QIconWrap::constructor.New(
@@ -245,8 +217,6 @@ Napi::Value QTabBarWrap::tabIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   std::string napiText = info[1].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(napiText.c_str());
@@ -256,8 +226,6 @@ Napi::Value QTabBarWrap::setTabText(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QString text = this->instance->tabText(index);
   return Napi::String::New(env, text.toStdString());
@@ -265,8 +233,6 @@ Napi::Value QTabBarWrap::tabText(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabTextColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object colorObject = info[1].As<Napi::Object>();
   QColorWrap* colorWrap = Napi::ObjectWrap<QColorWrap>::Unwrap(colorObject);
@@ -276,8 +242,6 @@ Napi::Value QTabBarWrap::setTabTextColor(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabTextColor(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QColor color = this->instance->tabTextColor(index);
   auto instance = QColorWrap::constructor.New(
@@ -287,8 +251,6 @@ Napi::Value QTabBarWrap::tabTextColor(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabToolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   std::string napiTip = info[1].As<Napi::String>().Utf8Value();
   QString tip = QString::fromUtf8(napiTip.c_str());
@@ -298,8 +260,6 @@ Napi::Value QTabBarWrap::setTabToolTip(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabToolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QString tip = this->instance->tabToolTip(index);
   return Napi::String::New(env, tip.toStdString());
@@ -307,8 +267,6 @@ Napi::Value QTabBarWrap::tabToolTip(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::setTabWhatsThis(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   std::string napiText = info[1].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(napiText.c_str());
@@ -318,8 +276,6 @@ Napi::Value QTabBarWrap::setTabWhatsThis(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabWhatsThis(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QString text = this->instance->tabWhatsThis(index);
   return Napi::String::New(env, text.toStdString());
@@ -327,8 +283,6 @@ Napi::Value QTabBarWrap::tabWhatsThis(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabAt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object pointObject = info[0].As<Napi::Object>();
   QPointWrap* pointWrap = Napi::ObjectWrap<QPointWrap>::Unwrap(pointObject);
   int index = this->instance->tabAt(*pointWrap->getInternalInstance());
@@ -337,8 +291,6 @@ Napi::Value QTabBarWrap::tabAt(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabBarWrap::tabRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   QRect rect = this->instance->tabRect(index);
   auto instance = QRectWrap::constructor.New({Napi::External<QRect>::New(

--- a/src/cpp/lib/QtWidgets/QTabWidget/qtabwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTabWidget/qtabwidget_wrap.cpp
@@ -36,8 +36,6 @@ QTabWidgetWrap::~QTabWidgetWrap() { extrautils::safeDelete(this->instance); }
 QTabWidgetWrap::QTabWidgetWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTabWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -58,8 +56,6 @@ QTabWidgetWrap::QTabWidgetWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QTabWidgetWrap::addTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object pageObject = info[0].As<Napi::Object>();
   Napi::Object iconObject = info[1].As<Napi::Object>();
   Napi::String napiLabel = info[2].As<Napi::String>();
@@ -77,8 +73,6 @@ Napi::Value QTabWidgetWrap::addTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::insertTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int tabPosition = info[0].As<Napi::Number>().Int32Value();
   Napi::Object pageObject = info[1].As<Napi::Object>();
   Napi::Object iconObject = info[2].As<Napi::Object>();
@@ -97,8 +91,6 @@ Napi::Value QTabWidgetWrap::insertTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::indexOf(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object widgetObject = info[0].As<Napi::Object>();
 
   NodeWidgetWrap* widgetObjectWrap =
@@ -110,7 +102,6 @@ Napi::Value QTabWidgetWrap::indexOf(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::setTabPosition(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int tabPosition = info[0].As<Napi::Number>().Int32Value();
   this->instance->setTabPosition(
       static_cast<QTabWidget::TabPosition>(tabPosition));
@@ -119,7 +110,6 @@ Napi::Value QTabWidgetWrap::setTabPosition(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::setTabText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int tabIndex = info[0].As<Napi::Number>().Int32Value();
   Napi::String napiLabel = info[1].As<Napi::String>();
   std::string label = napiLabel.Utf8Value();
@@ -129,8 +119,6 @@ Napi::Value QTabWidgetWrap::setTabText(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::setTabIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int tabIndex = info[0].As<Napi::Number>().Int32Value();
   Napi::Object iconObject = info[1].As<Napi::Object>();
   QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
@@ -140,7 +128,6 @@ Napi::Value QTabWidgetWrap::setTabIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::setCurrentIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number index = info[0].As<Napi::Number>();
   this->instance->setCurrentIndex(index.Int32Value());
   return env.Null();
@@ -148,14 +135,12 @@ Napi::Value QTabWidgetWrap::setCurrentIndex(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::currentIndex(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = this->instance->currentIndex();
   return Napi::Number::New(env, value);
 }
 
 Napi::Value QTabWidgetWrap::removeTab(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number index = info[0].As<Napi::Number>();
   this->instance->removeTab(index.Int32Value());
   return env.Null();
@@ -163,7 +148,6 @@ Napi::Value QTabWidgetWrap::removeTab(const Napi::CallbackInfo& info) {
 
 Napi::Value QTabWidgetWrap::setTabsClosable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean closable = info[0].As<Napi::Boolean>();
   this->instance->setTabsClosable(closable.Value());
   return env.Null();

--- a/src/cpp/lib/QtWidgets/QTableView/qtableview_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableView/qtableview_wrap.cpp
@@ -26,8 +26,6 @@ QTableViewWrap::~QTableViewWrap() {
 QTableViewWrap::QTableViewWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTableViewWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NTableView>>().Data();

--- a/src/cpp/lib/QtWidgets/QTableWidget/qtablewidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableWidget/qtablewidget_wrap.cpp
@@ -97,8 +97,6 @@ QTableWidgetWrap::~QTableWidgetWrap() {
 QTableWidgetWrap::QTableWidgetWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTableWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 2 || info.Length() == 3) {
     int rows = info[0].As<Napi::Number>().Int32Value();
     int columns = info[1].As<Napi::Number>().Int32Value();
@@ -131,8 +129,6 @@ QTableWidgetWrap::QTableWidgetWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QTableWidgetWrap::selectedRanges(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QList<QTableWidgetSelectionRange> range = this->instance->selectedRanges();
   Napi::Array napiRange = Napi::Array::New(env, range.size());
 
@@ -159,8 +155,6 @@ Napi::Value QTableWidgetWrap::selectedRanges(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetWrap::closePersistentEditor(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -171,8 +165,6 @@ Napi::Value QTableWidgetWrap::closePersistentEditor(
 
 Napi::Value QTableWidgetWrap::editItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -183,8 +175,6 @@ Napi::Value QTableWidgetWrap::editItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setCellWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   Napi::Object widgetObject = info[2].As<Napi::Object>();
@@ -197,8 +187,6 @@ Napi::Value QTableWidgetWrap::setCellWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   Napi::Object itemObject = info[2].As<Napi::Object>();
@@ -212,8 +200,6 @@ Napi::Value QTableWidgetWrap::setItem(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetWrap::setHorizontalHeaderItem(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   Napi::Object itemObject = info[1].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
@@ -227,8 +213,6 @@ Napi::Value QTableWidgetWrap::setHorizontalHeaderItem(
 Napi::Value QTableWidgetWrap::setHorizontalHeaderLabels(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array labelsNapi = info[0].As<Napi::Array>();
   QList<QString> list;
   for (int i = 0; i < labelsNapi.Length(); i++) {
@@ -244,8 +228,6 @@ Napi::Value QTableWidgetWrap::setHorizontalHeaderLabels(
 Napi::Value QTableWidgetWrap::setVerticalHeaderItem(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
@@ -258,8 +240,6 @@ Napi::Value QTableWidgetWrap::setVerticalHeaderItem(
 Napi::Value QTableWidgetWrap::setVerticalHeaderLabels(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array labelsNapi = info[0].As<Napi::Array>();
   QList<QString> list;
   for (int i = 0; i < labelsNapi.Length(); i++) {
@@ -274,22 +254,18 @@ Napi::Value QTableWidgetWrap::setVerticalHeaderLabels(
 
 Napi::Value QTableWidgetWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  this->instance->clear();
+ this->instance->clear();
   return env.Null();
 }
 
 Napi::Value QTableWidgetWrap::clearContents(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-  this->instance->clearContents();
+ this->instance->clearContents();
   return env.Null();
 }
 
 Napi::Value QTableWidgetWrap::insertColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   this->instance->insertColumn(column);
   return env.Null();
@@ -297,8 +273,6 @@ Napi::Value QTableWidgetWrap::insertColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::removeColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   this->instance->removeColumn(column);
   return env.Null();
@@ -306,8 +280,6 @@ Napi::Value QTableWidgetWrap::removeColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::insertRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->insertRow(row);
   return env.Null();
@@ -315,8 +287,6 @@ Napi::Value QTableWidgetWrap::insertRow(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::removeRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->removeRow(row);
   return env.Null();
@@ -324,8 +294,6 @@ Napi::Value QTableWidgetWrap::removeRow(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::scrollToItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -339,8 +307,6 @@ Napi::Value QTableWidgetWrap::scrollToItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::cellWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
 
@@ -353,8 +319,6 @@ Napi::Value QTableWidgetWrap::cellWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::column(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -364,16 +328,12 @@ Napi::Value QTableWidgetWrap::column(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::currentColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = this->instance->currentColumn();
   return Napi::Number::New(env, column);
 }
 
 Napi::Value QTableWidgetWrap::currentItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QTableWidgetItem* item = this->instance->currentItem();
   auto instance = QTableWidgetItemWrap::constructor.New(
       {Napi::External<QTableWidgetItem>::New(env, item),
@@ -383,16 +343,12 @@ Napi::Value QTableWidgetWrap::currentItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::currentRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = this->instance->currentRow();
   return Napi::Number::New(env, row);
 }
 
 Napi::Value QTableWidgetWrap::findItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string napiText = info[0].As<Napi::String>().Utf8Value();
   QString text = QString::fromUtf8(napiText.c_str());
   int flags = info[1].As<Napi::Number>().Int32Value();
@@ -413,8 +369,6 @@ Napi::Value QTableWidgetWrap::findItems(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetWrap::isPersistentEditorOpen(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -425,8 +379,6 @@ Napi::Value QTableWidgetWrap::isPersistentEditorOpen(
 
 Napi::Value QTableWidgetWrap::item(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
 
@@ -439,8 +391,6 @@ Napi::Value QTableWidgetWrap::item(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::itemAt(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int x = info[0].As<Napi::Number>().Int32Value();
   int y = info[1].As<Napi::Number>().Int32Value();
   QTableWidgetItem* item = this->instance->itemAt(x, y);
@@ -453,8 +403,6 @@ Napi::Value QTableWidgetWrap::itemAt(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetWrap::openPersistentEditor(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -464,8 +412,6 @@ Napi::Value QTableWidgetWrap::openPersistentEditor(
 
 Napi::Value QTableWidgetWrap::removeCellWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   this->instance->removeCellWidget(row, column);
@@ -474,8 +420,6 @@ Napi::Value QTableWidgetWrap::removeCellWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::row(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -485,8 +429,6 @@ Napi::Value QTableWidgetWrap::row(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setCurrentCell(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   this->instance->setCurrentCell(row, column);
@@ -495,8 +437,6 @@ Napi::Value QTableWidgetWrap::setCurrentCell(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setCurrentItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -506,8 +446,6 @@ Napi::Value QTableWidgetWrap::setCurrentItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::sortItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int order = info[1].As<Napi::Number>().Int32Value();
   this->instance->sortItems(column, static_cast<Qt::SortOrder>(order));
@@ -516,8 +454,6 @@ Napi::Value QTableWidgetWrap::sortItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::takeItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int column = info[1].As<Napi::Number>().Int32Value();
   this->instance->takeItem(row, column);
@@ -526,8 +462,6 @@ Napi::Value QTableWidgetWrap::takeItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::visualColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int logicalColumn = info[0].As<Napi::Number>().Int32Value();
   int column = this->instance->visualColumn(logicalColumn);
   return Napi::Number::New(env, column);
@@ -535,8 +469,6 @@ Napi::Value QTableWidgetWrap::visualColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::visualItemRect(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTableWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTableWidgetItemWrap>::Unwrap(itemObject);
@@ -548,8 +480,6 @@ Napi::Value QTableWidgetWrap::visualItemRect(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::visualRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int logicalRow = info[0].As<Napi::Number>().Int32Value();
   int row = this->instance->visualRow(logicalRow);
   return Napi::Number::New(env, row);
@@ -559,8 +489,6 @@ Napi::Value QTableWidgetWrap::visualRow(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::hideColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   this->instance->hideColumn(column);
   return env.Null();
@@ -568,8 +496,6 @@ Napi::Value QTableWidgetWrap::hideColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::hideRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->hideRow(row);
   return env.Null();
@@ -578,8 +504,6 @@ Napi::Value QTableWidgetWrap::hideRow(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetWrap::resizeColumnToContents(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   this->instance->resizeColumnToContents(column);
   return env.Null();
@@ -588,8 +512,6 @@ Napi::Value QTableWidgetWrap::resizeColumnToContents(
 Napi::Value QTableWidgetWrap::resizeColumnsToContents(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->resizeColumnsToContents();
   return env.Null();
 }
@@ -597,8 +519,6 @@ Napi::Value QTableWidgetWrap::resizeColumnsToContents(
 Napi::Value QTableWidgetWrap::resizeRowToContents(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->resizeRowToContents(row);
   return env.Null();
@@ -607,16 +527,12 @@ Napi::Value QTableWidgetWrap::resizeRowToContents(
 Napi::Value QTableWidgetWrap::resizeRowsToContents(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->resizeRowsToContents();
   return env.Null();
 }
 
 Napi::Value QTableWidgetWrap::selectColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   this->instance->selectColumn(column);
   return env.Null();
@@ -624,8 +540,6 @@ Napi::Value QTableWidgetWrap::selectColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::selectRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->selectRow(row);
   return env.Null();
@@ -633,8 +547,6 @@ Napi::Value QTableWidgetWrap::selectRow(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setShowGrid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool show = info[0].As<Napi::Boolean>().Value();
   this->instance->setShowGrid(show);
   return env.Null();
@@ -642,16 +554,12 @@ Napi::Value QTableWidgetWrap::setShowGrid(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::showGrid(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool show = this->instance->showGrid();
   return Napi::Boolean::New(env, show);
 }
 
 Napi::Value QTableWidgetWrap::showColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   this->instance->showColumn(column);
   return env.Null();
@@ -659,8 +567,6 @@ Napi::Value QTableWidgetWrap::showColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::showRow(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   this->instance->showRow(row);
   return env.Null();
@@ -668,8 +574,6 @@ Napi::Value QTableWidgetWrap::showRow(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::sortByColumn(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int orderInt = info[1].As<Napi::Number>().Int32Value();
   Qt::SortOrder order = static_cast<Qt::SortOrder>(orderInt);
@@ -679,8 +583,6 @@ Napi::Value QTableWidgetWrap::sortByColumn(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setColumnWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int width = info[1].As<Napi::Number>().Int32Value();
   this->instance->setColumnWidth(column, width);
@@ -689,8 +591,6 @@ Napi::Value QTableWidgetWrap::setColumnWidth(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setRowHeight(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int row = info[0].As<Napi::Number>().Int32Value();
   int height = info[1].As<Napi::Number>().Int32Value();
   this->instance->setRowHeight(row, height);
@@ -699,24 +599,18 @@ Napi::Value QTableWidgetWrap::setRowHeight(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::columnCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = static_cast<int>(this->instance->columnCount());
   return Napi::Number::New(env, count);
 }
 
 Napi::Value QTableWidgetWrap::rowCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = static_cast<int>(this->instance->rowCount());
   return Napi::Number::New(env, count);
 }
 
 Napi::Value QTableWidgetWrap::setColumnCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = info[0].As<Napi::Number>().Int32Value();
   this->instance->setColumnCount(count);
   return env.Null();
@@ -724,8 +618,6 @@ Napi::Value QTableWidgetWrap::setColumnCount(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetWrap::setRowCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int count = info[0].As<Napi::Number>().Int32Value();
   this->instance->setRowCount(count);
   return env.Null();
@@ -734,8 +626,6 @@ Napi::Value QTableWidgetWrap::setRowCount(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetWrap::setSortingEnabled(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool enable = info[0].As<Napi::Boolean>().Value();
   this->instance->setSortingEnabled(enable);
   return env.Null();
@@ -743,8 +633,6 @@ Napi::Value QTableWidgetWrap::setSortingEnabled(
 
 Napi::Value QTableWidgetWrap::isSortingEnabled(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool enabled = this->instance->isSortingEnabled();
   return Napi::Boolean::New(env, enabled);
 }

--- a/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTableWidgetItem/qtablewidgetitem_wrap.cpp
@@ -65,8 +65,6 @@ QTableWidgetItemWrap::~QTableWidgetItemWrap() {
 QTableWidgetItemWrap::QTableWidgetItemWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTableWidgetItemWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<QTableWidgetItem>>().Data();
@@ -91,16 +89,12 @@ QTableWidgetItemWrap::QTableWidgetItemWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QTableWidgetItemWrap::row(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = static_cast<int>(this->instance->row());
   return Napi::Number::New(env, state);
 }
 
 Napi::Value QTableWidgetItemWrap::column(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = static_cast<int>(this->instance->column());
   return Napi::Number::New(env, state);
 }
@@ -108,8 +102,6 @@ Napi::Value QTableWidgetItemWrap::column(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetItemWrap::setBackground(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object brushObject = info[0].As<Napi::Object>();
   QBrushWrap* brushWrap = Napi::ObjectWrap<QBrushWrap>::Unwrap(brushObject);
   this->instance->setBackground(*brushWrap->getInternalInstance());
@@ -118,8 +110,6 @@ Napi::Value QTableWidgetItemWrap::setBackground(
 
 Napi::Value QTableWidgetItemWrap::background(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QBrush brush = this->instance->background();
   auto instance = QBrushWrap::constructor.New(
       {Napi::External<QBrush>::New(env, new QBrush(brush))});
@@ -129,8 +119,6 @@ Napi::Value QTableWidgetItemWrap::background(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetItemWrap::setCheckState(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = info[0].As<Napi::Number>().Int32Value();
   this->instance->setCheckState(static_cast<Qt::CheckState>(state));
   return env.Null();
@@ -138,16 +126,12 @@ Napi::Value QTableWidgetItemWrap::setCheckState(
 
 Napi::Value QTableWidgetItemWrap::checkState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int state = static_cast<int>(this->instance->checkState());
   return Napi::Number::New(env, state);
 }
 
 Napi::Value QTableWidgetItemWrap::setData(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int role = info[0].As<Napi::Number>().Int32Value();
   Napi::Object variantObject = info[1].As<Napi::Object>();
   QVariantWrap* variantWrap =
@@ -158,8 +142,6 @@ Napi::Value QTableWidgetItemWrap::setData(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::data(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int role = info[0].As<Napi::Number>().Int32Value();
   QVariant data = this->instance->data(role);
   auto instance = QVariantWrap::constructor.New(
@@ -169,8 +151,6 @@ Napi::Value QTableWidgetItemWrap::data(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::setFlags(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int flags = info[0].As<Napi::Number>().Int32Value();
   this->instance->setFlags(static_cast<Qt::ItemFlags>(flags));
   return env.Null();
@@ -178,16 +158,12 @@ Napi::Value QTableWidgetItemWrap::setFlags(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::flags(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int flags = static_cast<int>(this->instance->flags());
   return Napi::Number::New(env, flags);
 }
 
 Napi::Value QTableWidgetItemWrap::setFont(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object fontObject = info[0].As<Napi::Object>();
   QFontWrap* fontWrap = Napi::ObjectWrap<QFontWrap>::Unwrap(fontObject);
   this->instance->setFont(*fontWrap->getInternalInstance());
@@ -196,8 +172,6 @@ Napi::Value QTableWidgetItemWrap::setFont(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::font(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QFont font = this->instance->font();
   auto instance = QFontWrap::constructor.New(
       {Napi::External<QFont>::New(env, new QFont(font))});
@@ -207,8 +181,6 @@ Napi::Value QTableWidgetItemWrap::font(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetItemWrap::setForeground(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object brushObject = info[0].As<Napi::Object>();
   QBrushWrap* brushWrap = Napi::ObjectWrap<QBrushWrap>::Unwrap(brushObject);
   this->instance->setForeground(*brushWrap->getInternalInstance());
@@ -217,8 +189,6 @@ Napi::Value QTableWidgetItemWrap::setForeground(
 
 Napi::Value QTableWidgetItemWrap::foreground(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QBrush brush = this->instance->foreground();
   auto instance = QBrushWrap::constructor.New(
       {Napi::External<QBrush>::New(env, new QBrush(brush))});
@@ -227,8 +197,6 @@ Napi::Value QTableWidgetItemWrap::foreground(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object iconObject = info[0].As<Napi::Object>();
   QIconWrap* iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
   this->instance->setIcon(*iconWrap->getInternalInstance());
@@ -237,8 +205,6 @@ Napi::Value QTableWidgetItemWrap::setIcon(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QIcon icon = this->instance->icon();
   auto instance = QIconWrap::constructor.New(
       {Napi::External<QIcon>::New(env, new QIcon(icon))});
@@ -247,8 +213,6 @@ Napi::Value QTableWidgetItemWrap::icon(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::setSelected(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool select = info[0].As<Napi::Boolean>().Value();
   this->instance->setSelected(select);
   return env.Null();
@@ -256,15 +220,11 @@ Napi::Value QTableWidgetItemWrap::setSelected(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::isSelected(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isSelected());
 }
 
 Napi::Value QTableWidgetItemWrap::setSizeHint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object sizeObject = info[0].As<Napi::Object>();
   QSizeWrap* sizeWrap = Napi::ObjectWrap<QSizeWrap>::Unwrap(sizeObject);
   this->instance->setSizeHint(*sizeWrap->getInternalInstance());
@@ -273,8 +233,6 @@ Napi::Value QTableWidgetItemWrap::setSizeHint(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::sizeHint(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QSize size = this->instance->sizeHint();
   auto instance = QSizeWrap::constructor.New({Napi::External<QSize>::New(
       env, new QSize(size.width(), size.height()))});
@@ -283,8 +241,6 @@ Napi::Value QTableWidgetItemWrap::sizeHint(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::setStatusTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string statusTip = info[0].As<Napi::String>().Utf8Value();
   this->instance->setStatusTip(QString::fromUtf8(statusTip.c_str()));
   return env.Null();
@@ -292,16 +248,12 @@ Napi::Value QTableWidgetItemWrap::setStatusTip(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::statusTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string statusTip = this->instance->text().toStdString();
   return Napi::String::New(env, statusTip);
 }
 
 Napi::Value QTableWidgetItemWrap::setText(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string text = info[0].As<Napi::String>().Utf8Value();
   this->instance->setText(QString::fromUtf8(text.c_str()));
   return env.Null();
@@ -309,8 +261,6 @@ Napi::Value QTableWidgetItemWrap::setText(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::text(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string text = this->instance->text().toStdString();
   return Napi::String::New(env, text);
 }
@@ -318,8 +268,6 @@ Napi::Value QTableWidgetItemWrap::text(const Napi::CallbackInfo& info) {
 Napi::Value QTableWidgetItemWrap::setTextAlignment(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int alignment = info[0].As<Napi::Number>().Int32Value();
   this->instance->setTextAlignment(alignment);
   return env.Null();
@@ -328,16 +276,12 @@ Napi::Value QTableWidgetItemWrap::setTextAlignment(
 Napi::Value QTableWidgetItemWrap::textAlignment(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int alignment = this->instance->textAlignment();
   return Napi::Number::New(env, alignment);
 }
 
 Napi::Value QTableWidgetItemWrap::setToolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string toolTip = info[0].As<Napi::String>().Utf8Value();
   this->instance->setToolTip(QString::fromUtf8(toolTip.c_str()));
   return env.Null();
@@ -345,16 +289,12 @@ Napi::Value QTableWidgetItemWrap::setToolTip(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::toolTip(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string toolTip = this->instance->toolTip().toStdString();
   return Napi::String::New(env, toolTip);
 }
 
 Napi::Value QTableWidgetItemWrap::setWhatsThis(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string whatsThis = info[0].As<Napi::String>().Utf8Value();
   this->instance->setWhatsThis(QString::fromUtf8(whatsThis.c_str()));
   return env.Null();
@@ -362,15 +302,11 @@ Napi::Value QTableWidgetItemWrap::setWhatsThis(const Napi::CallbackInfo& info) {
 
 Napi::Value QTableWidgetItemWrap::whatsThis(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   std::string whatsThis = this->instance->whatsThis().toStdString();
   return Napi::String::New(env, whatsThis);
 }
 
 Napi::Value QTableWidgetItemWrap::type(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->type());
 }

--- a/src/cpp/lib/QtWidgets/QTextBrowser/qtextbrowser_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTextBrowser/qtextbrowser_wrap.cpp
@@ -38,8 +38,6 @@ NTextBrowser* QTextBrowserWrap::getInternalInstance() { return this->instance; }
 QTextBrowserWrap::QTextBrowserWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTextBrowserWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -63,15 +61,11 @@ QTextBrowserWrap::~QTextBrowserWrap() {
 Napi::Value QTextBrowserWrap::backwardHistoryCount(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->backwardHistoryCount());
 }
 
 Napi::Value QTextBrowserWrap::clearHistory(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->clearHistory();
   return env.Null();
 }
@@ -79,15 +73,11 @@ Napi::Value QTextBrowserWrap::clearHistory(const Napi::CallbackInfo& info) {
 Napi::Value QTextBrowserWrap::forwardHistoryCount(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Number::New(env, this->instance->forwardHistoryCount());
 }
 
 Napi::Value QTextBrowserWrap::historyTitle(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int i = info[0].As<Napi::Number>().Int32Value();
   QString title = this->instance->historyTitle(i);
   return Napi::String::New(env, title.toStdString());
@@ -95,8 +85,6 @@ Napi::Value QTextBrowserWrap::historyTitle(const Napi::CallbackInfo& info) {
 
 Napi::Value QTextBrowserWrap::historyUrl(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int i = info[0].As<Napi::Number>().Int32Value();
   QUrl url = this->instance->historyUrl(i);
   auto instance = QUrlWrap::constructor.New(
@@ -107,47 +95,35 @@ Napi::Value QTextBrowserWrap::historyUrl(const Napi::CallbackInfo& info) {
 Napi::Value QTextBrowserWrap::isBackwardAvailable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isBackwardAvailable());
 }
 
 Napi::Value QTextBrowserWrap::isForwardAvailable(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   return Napi::Boolean::New(env, this->instance->isForwardAvailable());
 }
 
 Napi::Value QTextBrowserWrap::backward(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->backward();
   return env.Null();
 }
 
 Napi::Value QTextBrowserWrap::forward(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->forward();
   return env.Null();
 }
 
 Napi::Value QTextBrowserWrap::home(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->home();
   return env.Null();
 }
 
 Napi::Value QTextBrowserWrap::reload(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->reload();
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QTextEdit/qtextedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTextEdit/qtextedit_wrap.cpp
@@ -22,8 +22,6 @@ NTextEdit* QTextEditWrap::getInternalInstance() { return this->instance; }
 QTextEditWrap::QTextEditWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTextEditWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QTimeEdit/qtimeedit_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTimeEdit/qtimeedit_wrap.cpp
@@ -20,8 +20,6 @@ NTimeEdit* QTimeEditWrap::getInternalInstance() { return this->instance; }
 QTimeEditWrap::QTimeEditWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTimeEditWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =

--- a/src/cpp/lib/QtWidgets/QToolButton/qtoolbutton_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QToolButton/qtoolbutton_wrap.cpp
@@ -32,8 +32,6 @@ QToolButtonWrap::~QToolButtonWrap() {
 QToolButtonWrap::QToolButtonWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QToolButtonWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() > 0 && info[0].IsExternal()) {
     // --- if external ---
     this->instance = info[0].As<Napi::External<NToolButton>>().Data();
@@ -60,8 +58,6 @@ QToolButtonWrap::QToolButtonWrap(const Napi::CallbackInfo& info)
 
 Napi::Value QToolButtonWrap::setMenu(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object menuObject = info[0].As<Napi::Object>();
   QMenuWrap* menuWrap = Napi::ObjectWrap<QMenuWrap>::Unwrap(menuObject);
   this->instance->setMenu(menuWrap->getInternalInstance());
@@ -70,8 +66,6 @@ Napi::Value QToolButtonWrap::setMenu(const Napi::CallbackInfo& info) {
 
 Napi::Value QToolButtonWrap::setDefaultAction(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object actionObject = info[0].As<Napi::Object>();
   QActionWrap* actionWrap = Napi::ObjectWrap<QActionWrap>::Unwrap(actionObject);
   this->instance->setDefaultAction(actionWrap->getInternalInstance());
@@ -80,8 +74,6 @@ Napi::Value QToolButtonWrap::setDefaultAction(const Napi::CallbackInfo& info) {
 
 Napi::Value QToolButtonWrap::showMenu(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   this->instance->showMenu();
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QTreeWidget/qtreewidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTreeWidget/qtreewidget_wrap.cpp
@@ -40,8 +40,6 @@ NTreeWidget* QTreeWidgetWrap::getInternalInstance() { return this->instance; }
 QTreeWidgetWrap::QTreeWidgetWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<QTreeWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
     NodeWidgetWrap* parentWidgetWrap =
@@ -62,8 +60,6 @@ QTreeWidgetWrap::~QTreeWidgetWrap() { extrautils::safeDelete(this->instance); }
 
 Napi::Value QTreeWidgetWrap::addTopLevelItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTreeWidgetItemWrap* itemWrap =
       Napi::ObjectWrap<QTreeWidgetItemWrap>::Unwrap(itemObject);
@@ -74,8 +70,6 @@ Napi::Value QTreeWidgetWrap::addTopLevelItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::addTopLevelItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array itemsNapi = info[0].As<Napi::Array>();
   QList<QTreeWidgetItem*> items;
   for (int i = 0; i < itemsNapi.Length(); i++) {
@@ -94,8 +88,6 @@ Napi::Value QTreeWidgetWrap::addTopLevelItems(const Napi::CallbackInfo& info) {
 Napi::Value QTreeWidgetWrap::insertTopLevelItem(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Object itemObject = info[1].As<Napi::Object>();
   QTreeWidgetItemWrap* itemWrap =
@@ -109,7 +101,6 @@ Napi::Value QTreeWidgetWrap::insertTopLevelItem(
 Napi::Value QTreeWidgetWrap::insertTopLevelItems(
     const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int index = info[0].As<Napi::Number>().Int32Value();
   Napi::Array itemsNapi = info[1].As<Napi::Array>();
   QList<QTreeWidgetItem*> items;
@@ -128,8 +119,6 @@ Napi::Value QTreeWidgetWrap::insertTopLevelItems(
 
 Napi::Value QTreeWidgetWrap::selectedItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QList<QTreeWidgetItem*> items = this->instance->selectedItems();
   Napi::Array napiItems = Napi::Array::New(env, items.size());
   for (int i = 0; i < items.size(); i++) {
@@ -146,8 +135,6 @@ Napi::Value QTreeWidgetWrap::selectedItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::setColumnCount(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int columns = info[0].As<Napi::Number>().Int32Value();
   this->instance->setColumnCount(columns);
 
@@ -156,8 +143,6 @@ Napi::Value QTreeWidgetWrap::setColumnCount(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::setColumnWidth(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int columns = info[0].As<Napi::Number>().Int32Value();
   int width = info[1].As<Napi::Number>().Int32Value();
   this->instance->setColumnWidth(columns, width);
@@ -167,8 +152,6 @@ Napi::Value QTreeWidgetWrap::setColumnWidth(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::setHeaderLabel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String napiLabel = info[0].As<Napi::String>();
   if (napiLabel.IsEmpty()) {
     Napi::TypeError::New(env, "Label must be specified")
@@ -187,8 +170,6 @@ Napi::Value QTreeWidgetWrap::setHeaderLabel(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::setHeaderLabels(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Array napiLabelArray = info[0].As<Napi::Array>();
   QStringList headerLabels;
   for (int i = 0; i < napiLabelArray.Length(); i++) {
@@ -203,8 +184,6 @@ Napi::Value QTreeWidgetWrap::setHeaderLabels(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::setItemWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTreeWidgetItemWrap* itemWidgetWrap =
       Napi::ObjectWrap<QTreeWidgetItemWrap>::Unwrap(itemObject);
@@ -224,8 +203,6 @@ Napi::Value QTreeWidgetWrap::setItemWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::currentItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   QTreeWidgetItem* currentItem = this->instance->currentItem();
   if (currentItem != nullptr) {
     Napi::Object value = QTreeWidgetItemWrap::constructor.New(
@@ -240,8 +217,6 @@ Napi::Value QTreeWidgetWrap::currentItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::findItems(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::String napiText = info[0].As<Napi::String>();
   std::string text = napiText.Utf8Value();
   int flag = info[1].As<Napi::Number>().Int32Value();
@@ -262,8 +237,6 @@ Napi::Value QTreeWidgetWrap::findItems(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::takeTopLevelItem(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int index = info[0].As<Napi::Number>().Int32Value();
 
   QTreeWidgetItem* itemRemoved = this->instance->takeTopLevelItem(index);
@@ -281,7 +254,6 @@ Napi::Value QTreeWidgetWrap::takeTopLevelItem(const Napi::CallbackInfo& info) {
 
 Napi::Value QTreeWidgetWrap::clear(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clear();
   return env.Null();
 }

--- a/src/cpp/lib/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QTreeWidgetItem/qtreewidgetitem_wrap.cpp
@@ -137,8 +137,6 @@ QTreeWidgetItemWrap::QTreeWidgetItemWrap(const Napi::CallbackInfo &info)
 
 Napi::Value QTreeWidgetItemWrap::setIcon(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int const column = info[0].As<Napi::Number>().Int32Value();
   Napi::Object const iconObject = info[1].As<Napi::Object>();
   QIconWrap *iconWrap = Napi::ObjectWrap<QIconWrap>::Unwrap(iconObject);
@@ -147,8 +145,6 @@ Napi::Value QTreeWidgetItemWrap::setIcon(const Napi::CallbackInfo &info) {
 }
 Napi::Value QTreeWidgetItemWrap::icon(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Number const column = info[0].As<Napi::Number>();
   QIcon icon = this->instance->icon(column);
   auto instance = QIconWrap::constructor.New(
@@ -157,8 +153,6 @@ Napi::Value QTreeWidgetItemWrap::icon(const Napi::CallbackInfo &info) {
 }
 Napi::Value QTreeWidgetItemWrap::setText(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   Napi::String napiText = info[1].As<Napi::String>();
   std::string text = napiText.Utf8Value();
@@ -167,8 +161,6 @@ Napi::Value QTreeWidgetItemWrap::setText(const Napi::CallbackInfo &info) {
 }
 Napi::Value QTreeWidgetItemWrap::parent(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   if (this->instance->parent() == nullptr) {
     return env.Null();
   } else {
@@ -182,14 +174,12 @@ Napi::Value QTreeWidgetItemWrap::parent(const Napi::CallbackInfo &info) {
 }
 Napi::Value QTreeWidgetItemWrap::childCount(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   int value = static_cast<int>(this->instance->childCount());
   return Napi::Number::From(env, value);
 }
 
 Napi::Value QTreeWidgetItemWrap::child(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number index = info[0].As<Napi::Number>();
 
   if (this->instance->child(index) == nullptr) {
@@ -205,7 +195,6 @@ Napi::Value QTreeWidgetItemWrap::child(const Napi::CallbackInfo &info) {
 }
 Napi::Value QTreeWidgetItemWrap::text(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Number column = info[0].As<Napi::Number>();
 
   if (this->instance->text(column) == nullptr) {
@@ -216,14 +205,12 @@ Napi::Value QTreeWidgetItemWrap::text(const Napi::CallbackInfo &info) {
 }
 Napi::Value QTreeWidgetItemWrap::setSelected(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean selected = info[0].As<Napi::Boolean>();
   this->instance->setSelected(selected.Value());
   return env.Null();
 }
 Napi::Value QTreeWidgetItemWrap::setExpanded(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean expanded = info[0].As<Napi::Boolean>();
   this->instance->setExpanded(expanded.Value());
   return env.Null();
@@ -231,8 +218,6 @@ Napi::Value QTreeWidgetItemWrap::setExpanded(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::addChild(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object itemObject = info[0].As<Napi::Object>();
   QTreeWidgetItemWrap *itemWidgetWrap =
       Napi::ObjectWrap<QTreeWidgetItemWrap>::Unwrap(itemObject);
@@ -245,8 +230,6 @@ Napi::Value QTreeWidgetItemWrap::addChild(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::setFlags(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int flags = info[0].As<Napi::Number>().Int32Value();
   this->instance->setFlags(static_cast<Qt::ItemFlags>(flags));
 
@@ -255,8 +238,6 @@ Napi::Value QTreeWidgetItemWrap::setFlags(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::setCheckState(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int checkState = info[1].As<Napi::Number>().Int32Value();
 
@@ -268,8 +249,6 @@ Napi::Value QTreeWidgetItemWrap::setCheckState(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::flags(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Qt::ItemFlags flags = this->instance->flags();
 
   return Napi::Value::From(env, static_cast<int>(flags));
@@ -277,8 +256,6 @@ Napi::Value QTreeWidgetItemWrap::flags(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::setData(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int role = info[1].As<Napi::Number>().Int32Value();
 
@@ -294,8 +271,6 @@ Napi::Value QTreeWidgetItemWrap::setData(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::data(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   int column = info[0].As<Napi::Number>().Int32Value();
   int role = info[1].As<Napi::Number>().Int32Value();
 
@@ -308,7 +283,6 @@ Napi::Value QTreeWidgetItemWrap::data(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::setHidden(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   Napi::Boolean hide = info[0].As<Napi::Boolean>();
   this->instance->setHidden(hide.Value());
   return env.Null();
@@ -316,8 +290,6 @@ Napi::Value QTreeWidgetItemWrap::setHidden(const Napi::CallbackInfo &info) {
 
 Napi::Value QTreeWidgetItemWrap::isHidden(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   bool hide = this->instance->isHidden();
   return Napi::Boolean::New(env, hide);
 }

--- a/src/cpp/lib/QtWidgets/QWidget/qwidget_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QWidget/qwidget_wrap.cpp
@@ -22,7 +22,6 @@ QWidgetWrap::~QWidgetWrap() { extrautils::safeDelete(this->instance); }
 QWidgetWrap::QWidgetWrap(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<QWidgetWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1) {
     if (info[0].IsExternal()) {
       this->instance =

--- a/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp
+++ b/src/cpp/lib/core/FlexLayout/flexlayout_wrap.cpp
@@ -28,7 +28,6 @@ FlexLayoutWrap::~FlexLayoutWrap() { extrautils::safeDelete(this->instance); }
 FlexLayoutWrap::FlexLayoutWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<FlexLayoutWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
 
   if (info.Length() == 1) {
     Napi::Object parentObject = info[0].As<Napi::Object>();
@@ -46,8 +45,6 @@ FlexLayoutWrap::FlexLayoutWrap(const Napi::CallbackInfo& info)
 
 Napi::Value FlexLayoutWrap::addWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   Napi::External<YGNode> childFlexNodeObject =
       info[1].As<Napi::External<YGNode>>();
@@ -61,8 +58,6 @@ Napi::Value FlexLayoutWrap::addWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value FlexLayoutWrap::insertChildBefore(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   Napi::External<YGNode> beforeChildFlexNodeObject =
       info[1].As<Napi::External<YGNode>>();
@@ -81,8 +76,6 @@ Napi::Value FlexLayoutWrap::insertChildBefore(const Napi::CallbackInfo& info) {
 
 Napi::Value FlexLayoutWrap::removeWidget(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::Object qwidgetObject = info[0].As<Napi::Object>();
   Napi::External<YGNode> childFlexNodeObject =
       info[1].As<Napi::External<YGNode>>();
@@ -96,8 +89,6 @@ Napi::Value FlexLayoutWrap::removeWidget(const Napi::CallbackInfo& info) {
 
 Napi::Value FlexLayoutWrap::setFlexNode(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   Napi::External<YGNode> flexNodeObject = info[0].As<Napi::External<YGNode>>();
   YGNodeRef flexNodeRef = flexNodeObject.Data();
 

--- a/src/cpp/lib/test/cachetestqobject_wrap.cpp
+++ b/src/cpp/lib/test/cachetestqobject_wrap.cpp
@@ -26,7 +26,6 @@ CacheTestQObject* CacheTestQObjectWrap::getInternalInstance() {
 CacheTestQObjectWrap::CacheTestQObjectWrap(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<CacheTestQObjectWrap>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   if (info.Length() == 1 && info[0].IsExternal()) {
     this->instance = info[0].As<Napi::External<CacheTestQObject>>().Data();
   } else {
@@ -47,8 +46,6 @@ void CacheTestQObjectWrap::connectSignalsToEventEmitter() {
 
 Napi::Value CacheTestQObjectWrap::foo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   CacheTestQObject* foo = this->instance->foo();
   return WrapperCache::instance.get<CacheTestQObject, CacheTestQObjectWrap>(
       env, foo);
@@ -56,15 +53,12 @@ Napi::Value CacheTestQObjectWrap::foo(const Napi::CallbackInfo& info) {
 
 Napi::Value CacheTestQObjectWrap::clearFoo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
   this->instance->clearFoo();
   return env.Null();
 }
 
 Napi::Value CacheTestQObjectWrap::bar(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
-
   CacheTestQObject* bar = this->instance->bar();
   return WrapperCache::instance.get<CacheTestQObject, CacheTestQObjectWrap>(
       env, bar);


### PR DESCRIPTION
NodeGui had a lot of uses of `HandleScope` which wasn't needed or even in some cases was using (=returning) handles from a `HandleScope` which has been freed.

See: https://stackoverflow.com/questions/54187588/understanding-node-addon-api-n-api-handlescope
