### PR TITLE
Expose the QWidget::grab method to script.

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QWidget/qwidget_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QWidget/qwidget_macro.h
@@ -6,9 +6,11 @@
 
 #include "QtCore/QObject/qobject_wrap.h"
 #include "QtCore/QPoint/qpoint_wrap.h"
+#include "QtCore/QRect/qrect_wrap.h"
 #include "QtCore/QSize/qsize_wrap.h"
 #include "QtGui/QCursor/qcursor_wrap.h"
 #include "QtGui/QIcon/qicon_wrap.h"
+#include "QtGui/QPixmap/qpixmap_wrap.h"
 #include "QtGui/QStyle/qstyle_wrap.h"
 #include "QtGui/QWindow/qwindow_wrap.h"
 #include "QtWidgets/QAction/qaction_wrap.h"
@@ -454,6 +456,17 @@
     this->instance->clearMask();                                               \
     return env.Null();                                                         \
   }                                                                            \
+  Napi::Value grab(const Napi::CallbackInfo& info) {                           \
+    Napi::Env env = info.Env();                                                \
+    Napi::Object boundingRectObject = info[0].As<Napi::Object>();              \
+    QRectWrap* boundingRectWrap =                                              \
+        Napi::ObjectWrap<QRectWrap>::Unwrap(boundingRectObject);               \
+    auto pixmap =                                                              \
+        this->instance->grab(*boundingRectWrap->getInternalInstance());        \
+    auto instance = QPixmapWrap::constructor.New(                              \
+        {Napi::External<QPixmap>::New(env, new QPixmap(pixmap))});             \
+    return instance;                                                           \
+  }                                                                            \
   Napi::Value grabKeyboard(const Napi::CallbackInfo& info) {                   \
     Napi::Env env = info.Env();                                                \
     this->instance->grabKeyboard();                                            \
@@ -633,6 +646,7 @@
       InstanceMethod("setFixedWidth", &WidgetWrapName::setFixedWidth),         \
       InstanceMethod("ensurePolished", &WidgetWrapName::ensurePolished),       \
       InstanceMethod("clearMask", &WidgetWrapName::clearMask),                 \
+      InstanceMethod("grab", &WidgetWrapName::grab),                           \
       InstanceMethod("grabKeyboard", &WidgetWrapName::grabKeyboard),           \
       InstanceMethod("grabMouse", &WidgetWrapName::grabMouse),                 \
       InstanceMethod("hasHeightForWidth", &WidgetWrapName::hasHeightForWidth), \

--- a/src/lib/QtWidgets/QWidget.ts
+++ b/src/lib/QtWidgets/QWidget.ts
@@ -12,6 +12,7 @@ import { YogaWidget } from '../core/YogaWidget';
 import { QPoint } from '../QtCore/QPoint';
 import { QSize } from '../QtCore/QSize';
 import { QRect } from '../QtCore/QRect';
+import { QPixmap } from '../QtGui/QPixmap';
 import { QObjectSignals } from '../QtCore/QObject';
 import { QFont } from '../QtGui/QFont';
 import { QAction } from './QAction';
@@ -149,7 +150,10 @@ export abstract class NodeWidget<Signals extends QWidgetSignals> extends YogaWid
     geometry(): QRect {
         return QRect.fromQVariant(this.property('geometry'));
     }
-    // TODO: QPixmap 	grab(const QRect &rectangle = QRect(QPoint(0, 0), QSize(-1, -1)))
+    grab(rect?: QRect): QPixmap {
+        const arg = rect ?? new QRect(0, 0, -1, -1);
+        return this.native.grab(arg.native);
+    }
     // TODO: void 	grabGesture(Qt::GestureType gesture, Qt::GestureFlags flags = Qt::GestureFlags())
     grabKeyboard(): void {
         this.native.grabKeyboard();


### PR DESCRIPTION
Reference from qt base:
https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/kernel/qwidget.cpp#n5247

I tested that this worked by screen-grabing the central widget in the src/demo.ts

```ts
import { QRect } from './lib/QtCore/QRect';

// more of  src.demo.ts ...

const doGrab = () => {
    console.log('... now.');
    const pix = centralWidget.grab();
    console.log(`got pix ${pix}`);
    pix.save('out-test.png');
};

console.log('Trying to grab the central widget ...');
setTimeout(doGrab, 100);
```

The resulting `out-test.png` was:
![out-test](https://user-images.githubusercontent.com/322861/167281197-7da655fd-538b-4aa0-9a1b-f894d6781df9.png)


