### PR TITLE
fix breaking build on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,8 +267,6 @@ endif()
 if (APPLE)
     file(RELATIVE_PATH QT_LIBRARY_REL_PATH "${CMAKE_BINARY_DIR}/Release" "${QT_CMAKE_HOME_DIR}/../..")
     set_target_properties(${CORE_WIDGETS_ADDON} PROPERTIES INSTALL_RPATH "@loader_path/${QT_LIBRARY_REL_PATH}")
-    set_target_properties(${CORE_WIDGETS_ADDON} PROPERTIES SKIP_BUILD_RPATH FALSE)
-    set_target_properties(${CORE_WIDGETS_ADDON} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 endif()
 
 target_link_libraries(${CORE_WIDGETS_ADDON} PRIVATE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nodegui/nodegui",
-    "version": "0.57.0",
+    "version": "0.57.1",
     "description": "A cross-platform library to build native desktop apps.",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/src/lib/QtWidgets/__tests__/QMainWindow.test.ts
+++ b/src/lib/QtWidgets/__tests__/QMainWindow.test.ts
@@ -14,6 +14,6 @@ describe('QMainWindow', () => {
         const win = new QMainWindow();
         const widget = new QWidget();
         win.setCentralWidget(widget);
-        expect(win.centralWidget).toEqual(widget);
+        expect(win.centralWidget()).toEqual(widget);
     });
 });

--- a/src/lib/core/__test__/WrapperCache.test.ts
+++ b/src/lib/core/__test__/WrapperCache.test.ts
@@ -35,7 +35,7 @@ describe('WrapperCache using CacheTestQObject', () => {
         const fooId = foo.native.__id__();
         a.clearFoo();
         expect(foo.native).toBeNull();
-
+        console.log(''); // for some reason this fixes the test in macos
         const foo2 = a.foo();
         expect(foo2).not.toBe(foo);
         expect(foo2.native.__id__()).not.toBe(fooId);


### PR DESCRIPTION
Without this change I get a warning from CMake 3.21.3

```
info TOOL Using Unix Makefiles generator.
info CMD BUILD
info RUN [
info RUN   'cmake',
info RUN   '--build',
info RUN   '/Users/atul/Projects/personal/nodegui/build',
info RUN   '--config',
info RUN   'Release'
info RUN ]
-- Using QT installation for nodegui_core QT_CMAKE_HOME_DIR:/Users/atul/Projects/personal/nodegui/miniqt/Qt-5.15.3/lib/cmake/Qt5
-- Configuring done
CMake Warning (dev):
  Policy CMP0068 is not set: RPATH settings on macOS do not affect
  install_name.  Run "cmake --help-policy CMP0068" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

  For compatibility with older versions of CMake, the install_name fields for
  the following targets are still affected by RPATH settings:

   nodegui_core

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: /Users/atul/Projects/personal/nodegui/build
[  1%] Automatic MOC and UIC for target nodegui_core
[  1%] Built target nodegui_core_autogen
Consolidate compiler generated dependencies of target nodegui_core
[100%] Built target nodegui_core
```

And the app fails to load with the nodegui-starter with the following error:
```
modules by path ./node_modules/source-map/ 99.4 KiB
  ./node_modules/source-map/source-map.js 405 bytes [built] [code generated]
  ./node_modules/source-map/lib/source-map-generator.js 14 KiB [built] [code generated]
  + 9 modules
modules by path ./node_modules/cuid/ 2.88 KiB
  ./node_modules/cuid/index.js 2.18 KiB [built] [code generated]
  ./node_modules/cuid/lib/fingerprint.js 435 bytes [built] [code generated]
  + 2 modules
+ 13 modules
webpack 5.74.0 compiled successfully in 1400 ms
node:internal/modules/cjs/loader:1154
  return process.dlopen(module, path.toNamespacedPath(filename));
                 ^

Error: dlopen(/Users/atul/Projects/personal/nodegui-starter/dist/nodegui_core-d981bb66a8bf69184988100e4829ef06.node, 0x0001): Library not loaded: @rpath/QtSvg.framework/Versions/5/QtSvg
  Referenced from: /Users/atul/Projects/personal/nodegui-starter/dist/nodegui_core-d981bb66a8bf69184988100e4829ef06.node
  Reason: tried: '/Users/atul/Projects/personal/nodegui-starter/dist/../../miniqt/Qt-5.15.3/lib/QtSvg.framework/Versions/5/QtSvg' (no such file), '/Users/atul/Projects/personal/nodegui-starter/dist/../../miniqt/Qt-5.15.3/lib/QtSvg.framework/Versions/5/QtSvg' (no such file), '/Library/Frameworks/QtSvg.framework/Versions/5/QtSvg' (no such file), '/System/Library/Frameworks/QtSvg.framework/Versions/5/QtSvg' (no such file)
    at Object.Module._extensions..node (node:internal/modules/cjs/loader:1154:18)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at eval (webpack://nodegui-starter/./node_modules/@nodegui/nodegui/build/Release/nodegui_core.node?:1:18)
    at Object../node_modules/@nodegui/nodegui/build/Release/nodegui_core.node (/Users/atul/Projects/personal/nodegui-starter/dist/index.js:2632:1)
    at __webpack_require__ (/Users/atul/Projects/personal/nodegui-starter/dist/index.js:3139:42)
    at eval (webpack://nodegui-starter/./node_modules/@nodegui/nodegui/dist/lib/utils/addon.js?:3:15)
    at Object../node_modules/@nodegui/nodegui/dist/lib/utils/addon.js (/Users/atul/Projects/personal/nodegui-starter/dist/index.js:2549:1) {
  code: 'ERR_DLOPEN_FAILED'
}
```

With the change above the build succeeds and works well even with the packer.


