### PR TITLE
fix for linux not finding miniQt

### DIFF
--- a/scripts/qode.js
+++ b/scripts/qode.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var os = require('os');
 var path = require('path');
 var qodeConfig = require('@nodegui/qode');
 var managePath = require('manage-path');
@@ -10,6 +11,12 @@ var proc = require('child_process');
 // Add Qt's bin to the path of Qode so that it can find the dll's
 var alterPath = managePath(process.env);
 alterPath.unshift(path.join(qtConfig.qtHome, 'bin'));
+
+// Add Qt's lib to LD_LIBRARY_PATH so linux can find the libs when bundled with webpack
+if(os.platform == 'linux') {
+    var oldLD_PATH = process.env.LD_LIBRARY_PATH ?? "";
+    process.env.LD_LIBRARY_PATH = oldLD_PATH + ":" + path.join(qtConfig.qtHome, 'lib');
+}
 
 var child = proc.spawn(qodeConfig.qodePath, process.argv.slice(2), {
     stdio: 'inherit',


### PR DESCRIPTION
adding miniQt to the LD_LIBRARY_PATH environment variable fixes the problem with linux not using miniQT when bundled with webpack like in the nodegui-starter template. this fixes https://github.com/nodegui/nodegui-starter/issues/229 fixes https://github.com/nodegui/nodegui/issues/972