### PR TITLE
Move most code into `qsplitter_macro.h` for reuse in subclasses

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QSplitter/nsplitter.hpp
+++ b/src/cpp/include/nodegui/QtWidgets/QSplitter/nsplitter.hpp
@@ -3,7 +3,7 @@
 #include <QSplitter>
 
 #include "Extras/Export/export.h"
-#include "QtWidgets/QFrame/qframe_macro.h"
+#include "QtWidgets/QSplitter/qsplitter_macro.h"
 #include "core/NodeWidget/nodewidget.h"
 
 class DLL_EXPORT NSplitter : public QSplitter, public NodeWidget {
@@ -12,14 +12,5 @@ class DLL_EXPORT NSplitter : public QSplitter, public NodeWidget {
  public:
   using QSplitter::QSplitter;
 
-  virtual void connectSignalsToEventEmitter() {
-    QFRAME_SIGNALS
-    QObject::connect(this, &QSplitter::splitterMoved, [=](int pos, int index) {
-      Napi::Env env = this->emitOnNode.Env();
-      Napi::HandleScope scope(env);
-      this->emitOnNode.Call({Napi::String::New(env, "splitterMoved"),
-                             Napi::Number::New(env, pos),
-                             Napi::Number::New(env, index)});
-    });
-  }
+  virtual void connectSignalsToEventEmitter() { QSPLITTER_SIGNALS }
 };

--- a/src/cpp/include/nodegui/QtWidgets/QSplitter/qsplitter_macro.h
+++ b/src/cpp/include/nodegui/QtWidgets/QSplitter/qsplitter_macro.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "QtWidgets/QFrame/qframe_macro.h"
+#include "QtWidgets/QFrame/qframe_wrap.h"
+
+/*
+
+    This macro adds common QSplitter exported methods
+    The exported methods are taken into this macro to avoid writing them in each
+   and every widget we export.
+ */
+
+#ifndef QSPLITTER_WRAPPED_METHODS_DECLARATION
+#define QSPLITTER_WRAPPED_METHODS_DECLARATION                                  \
+                                                                               \
+  QFRAME_WRAPPED_METHODS_DECLARATION                                           \
+                                                                               \
+  Napi::Value addWidget(const Napi::CallbackInfo& info) {                      \
+    Napi::Env env = info.Env();                                                \
+    Napi::Object widgetObject = info[0].As<Napi::Object>();                    \
+    NodeWidgetWrap* widgetWrap =                                               \
+        Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);                \
+                                                                               \
+    this->instance->addWidget(widgetWrap->getInternalInstance());              \
+    return env.Null();                                                         \
+  }                                                                            \
+  Napi::Value childrenCollapsible(const Napi::CallbackInfo& info) {            \
+    Napi::Env env = info.Env();                                                \
+    return Napi::Boolean::New(env, this->instance->childrenCollapsible());     \
+  }                                                                            \
+  Napi::Value count(const Napi::CallbackInfo& info) {                          \
+    Napi::Env env = info.Env();                                                \
+    return Napi::Number::New(env, this->instance->count());                    \
+  }                                                                            \
+  Napi::Value indexOf(const Napi::CallbackInfo& info) {                        \
+    Napi::Env env = info.Env();                                                \
+    Napi::Object widgetObject = info[0].As<Napi::Object>();                    \
+    NodeWidgetWrap* widgetWrap =                                               \
+        Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);                \
+    return Napi::Number::New(                                                  \
+        env, this->instance->indexOf(widgetWrap->getInternalInstance()));      \
+  }                                                                            \
+  Napi::Value insertWidget(const Napi::CallbackInfo& info) {                   \
+    Napi::Env env = info.Env();                                                \
+    int index = info[0].As<Napi::Number>().Int32Value();                       \
+    Napi::Object widgetObject = info[1].As<Napi::Object>();                    \
+    NodeWidgetWrap* widgetWrap =                                               \
+        Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);                \
+    this->instance->insertWidget(index, widgetWrap->getInternalInstance());    \
+    return env.Null();                                                         \
+  }                                                                            \
+  Napi::Value isCollapsible(const Napi::CallbackInfo& info) {                  \
+    Napi::Env env = info.Env();                                                \
+    int index = info[0].As<Napi::Number>().Int32Value();                       \
+    return Napi::Boolean::New(env, this->instance->isCollapsible(index));      \
+  }                                                                            \
+  Napi::Value orientation(const Napi::CallbackInfo& info) {                    \
+    Napi::Env env = info.Env();                                                \
+    return Napi::Number::New(env,                                              \
+                             static_cast<int>(this->instance->orientation())); \
+  }                                                                            \
+  Napi::Value setCollapsible(const Napi::CallbackInfo& info) {                 \
+    Napi::Env env = info.Env();                                                \
+    int index = info[0].As<Napi::Number>().Int32Value();                       \
+    bool collapse = info[1].As<Napi::Boolean>().Value();                       \
+    this->instance->setCollapsible(index, collapse);                           \
+    return env.Null();                                                         \
+  }                                                                            \
+  Napi::Value setOrientation(const Napi::CallbackInfo& info) {                 \
+    Napi::Env env = info.Env();                                                \
+    int orientation = info[0].As<Napi::Number>().Int32Value();                 \
+    this->instance->setOrientation(static_cast<Qt::Orientation>(orientation)); \
+    return env.Null();                                                         \
+  }
+
+#endif  // QSPLITTER_WRAPPED_METHODS_DECLARATION
+
+#ifndef QSPLITTER_WRAPPED_METHODS_EXPORT_DEFINE
+#define QSPLITTER_WRAPPED_METHODS_EXPORT_DEFINE(WidgetWrapName)          \
+                                                                         \
+  QFRAME_WRAPPED_METHODS_EXPORT_DEFINE(WidgetWrapName)                   \
+                                                                         \
+  InstanceMethod("addWidget", &WidgetWrapName::addWidget),               \
+      InstanceMethod("childrenCollapsible",                              \
+                     &WidgetWrapName::childrenCollapsible),              \
+      InstanceMethod("count", &WidgetWrapName::count),                   \
+      InstanceMethod("indexOf", &WidgetWrapName::indexOf),               \
+      InstanceMethod("insertWidget", &WidgetWrapName::insertWidget),     \
+      InstanceMethod("isCollapsible", &WidgetWrapName::isCollapsible),   \
+      InstanceMethod("orientation", &WidgetWrapName::orientation),       \
+      InstanceMethod("setCollapsible", &WidgetWrapName::setCollapsible), \
+      InstanceMethod("setOrientation", &WidgetWrapName::setOrientation),
+
+#endif  // QSPLITTER_WRAPPED_METHODS_EXPORT_DEFINE
+
+#ifndef QSPLITTER_SIGNALS
+#define QSPLITTER_SIGNALS                                                     \
+  QWIDGET_SIGNALS                                                             \
+  QObject::connect(this, &QSplitter::splitterMoved, [=](int pos, int index) { \
+    Napi::Env env = this->emitOnNode.Env();                                   \
+    Napi::HandleScope scope(env);                                             \
+    this->emitOnNode.Call({Napi::String::New(env, "splitterMoved"),           \
+                           Napi::Number::New(env, pos),                       \
+                           Napi::Number::New(env, index)});                   \
+  });
+
+#endif  // QSPLITTER_SIGNALS

--- a/src/cpp/include/nodegui/QtWidgets/QSplitter/qsplitter_wrap.h
+++ b/src/cpp/include/nodegui/QtWidgets/QSplitter/qsplitter_wrap.h
@@ -5,11 +5,11 @@
 #include <QPointer>
 
 #include "Extras/Export/export.h"
-#include "QtWidgets/QFrame/qframe_macro.h"
 #include "QtWidgets/QSplitter/nsplitter.hpp"
+#include "QtWidgets/QSplitter/qsplitter_macro.h"
 
 class DLL_EXPORT QSplitterWrap : public Napi::ObjectWrap<QSplitterWrap> {
-  QFRAME_WRAPPED_METHODS_DECLARATION
+  QSPLITTER_WRAPPED_METHODS_DECLARATION
  private:
   QPointer<QSplitter> instance;
 
@@ -21,13 +21,4 @@ class DLL_EXPORT QSplitterWrap : public Napi::ObjectWrap<QSplitterWrap> {
   // class constructor
   static Napi::FunctionReference constructor;
   // wrapped methods
-  Napi::Value addWidget(const Napi::CallbackInfo& info);
-  Napi::Value childrenCollapsible(const Napi::CallbackInfo& info);
-  Napi::Value count(const Napi::CallbackInfo& info);
-  Napi::Value indexOf(const Napi::CallbackInfo& info);
-  Napi::Value insertWidget(const Napi::CallbackInfo& info);
-  Napi::Value isCollapsible(const Napi::CallbackInfo& info);
-  Napi::Value orientation(const Napi::CallbackInfo& info);
-  Napi::Value setCollapsible(const Napi::CallbackInfo& info);
-  Napi::Value setOrientation(const Napi::CallbackInfo& info);
 };

--- a/src/cpp/lib/QtWidgets/QSplitter/qsplitter_wrap.cpp
+++ b/src/cpp/lib/QtWidgets/QSplitter/qsplitter_wrap.cpp
@@ -8,18 +8,7 @@ Napi::Object QSplitterWrap::init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
   char CLASSNAME[] = "QSplitter";
   Napi::Function func = DefineClass(
-      env, CLASSNAME,
-      {InstanceMethod("addWidget", &QSplitterWrap::addWidget),
-       InstanceMethod("childrenCollapsible",
-                      &QSplitterWrap::childrenCollapsible),
-       InstanceMethod("count", &QSplitterWrap::count),
-       InstanceMethod("indexOf", &QSplitterWrap::indexOf),
-       InstanceMethod("insertWidget", &QSplitterWrap::insertWidget),
-       InstanceMethod("isCollapsible", &QSplitterWrap::isCollapsible),
-       InstanceMethod("orientation", &QSplitterWrap::orientation),
-       InstanceMethod("setCollapsible", &QSplitterWrap::setCollapsible),
-       InstanceMethod("setOrientation", &QSplitterWrap::setOrientation),
-       QFRAME_WRAPPED_METHODS_EXPORT_DEFINE(QSplitterWrap)});
+      env, CLASSNAME, {QSPLITTER_WRAPPED_METHODS_EXPORT_DEFINE(QSplitterWrap)});
   constructor = Napi::Persistent(func);
   exports.Set(CLASSNAME, func);
   QOBJECT_REGISTER_WRAPPER(QSplitter, QSplitterWrap);
@@ -55,73 +44,4 @@ QSplitterWrap::QSplitterWrap(const Napi::CallbackInfo& info)
   }
   this->rawData =
       extrautils::configureQWidget(this->getInternalInstance(), false);
-}
-
-Napi::Value QSplitterWrap::addWidget(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  Napi::Object widgetObject = info[0].As<Napi::Object>();
-  NodeWidgetWrap* widgetWrap =
-      Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);
-
-  this->instance->addWidget(widgetWrap->getInternalInstance());
-  return env.Null();
-}
-
-Napi::Value QSplitterWrap::childrenCollapsible(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  return Napi::Boolean::New(env, this->instance->childrenCollapsible());
-}
-
-Napi::Value QSplitterWrap::count(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  return Napi::Number::New(env, this->instance->count());
-}
-
-Napi::Value QSplitterWrap::indexOf(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  Napi::Object widgetObject = info[0].As<Napi::Object>();
-  NodeWidgetWrap* widgetWrap =
-      Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);
-
-  return Napi::Number::New(
-      env, this->instance->indexOf(widgetWrap->getInternalInstance()));
-}
-
-Napi::Value QSplitterWrap::insertWidget(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  int index = info[0].As<Napi::Number>().Int32Value();
-  Napi::Object widgetObject = info[1].As<Napi::Object>();
-  NodeWidgetWrap* widgetWrap =
-      Napi::ObjectWrap<NodeWidgetWrap>::Unwrap(widgetObject);
-
-  this->instance->insertWidget(index, widgetWrap->getInternalInstance());
-  return env.Null();
-}
-
-Napi::Value QSplitterWrap::isCollapsible(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  int index = info[0].As<Napi::Number>().Int32Value();
-  return Napi::Boolean::New(env, this->instance->isCollapsible(index));
-}
-
-Napi::Value QSplitterWrap::orientation(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  return Napi::Number::New(env,
-                           static_cast<int>(this->instance->orientation()));
-}
-
-Napi::Value QSplitterWrap::setCollapsible(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  int index = info[0].As<Napi::Number>().Int32Value();
-  bool collapse = info[1].As<Napi::Boolean>().Value();
-  this->instance->setCollapsible(index, collapse);
-  return env.Null();
-}
-
-Napi::Value QSplitterWrap::setOrientation(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  int orientation = info[0].As<Napi::Number>().Int32Value();
-  this->instance->setOrientation(static_cast<Qt::Orientation>(orientation));
-
-  return env.Null();
 }

--- a/src/lib/QtWidgets/QSplitter.ts
+++ b/src/lib/QtWidgets/QSplitter.ts
@@ -36,7 +36,7 @@ splitterHorizontal.addWidget(right);
 ```
 
  */
-export class QSplitter extends QFrame<QSplitterSignals> {
+export class QSplitter<Signals extends QSplitterSignals = QSplitterSignals> extends QFrame<Signals> {
     constructor(arg?: QWidget<QWidgetSignals> | NativeElement) {
         let native: NativeElement;
         if (checkIfNativeElement(arg)) {


### PR DESCRIPTION
This is needed by a plugin I'm working on.
