### PR TITLE
Update many older GH Actions scripts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ jobs:
     gh-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                 node-version: '16.x'
             - name: Add key to allow access to repository

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -10,8 +10,8 @@ jobs:
                 os: [ubuntu-20.04]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                 node-version: '16.x'
             - name: Install ubuntu deps
@@ -23,7 +23,7 @@ jobs:
               run: npm run build
             - name: Archive using npm pack
               run: npm --no-git-tag-version version 0.0.0-latest-master && npm pack
-            - uses: actions/upload-artifact@v1
+            - uses: actions/upload-artifact@v4
               with:
                   name: latest-release
                   path: nodegui-nodegui-0.0.0-latest-master.tgz
@@ -42,7 +42,7 @@ jobs:
                       nodegui-nodegui-0.0.0-latest-master.tgz:nodegui-master.tgz:application/tar+gzip
                   recreate: true
             - name: Repository Dispatch
-              uses: peter-evans/repository-dispatch@v1
+              uses: peter-evans/repository-dispatch@v3
               with:
                   token: ${{ secrets.REPO_ACCESS_TOKEN }}
                   repository: nodegui/nodegui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
     env:
       ARCHIVE_FILENAME: nodegui-binary-${{github.event.release.tag_name}}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '16.x'
 
       - name: Install ubuntu deps
-        if: contains(matrix.os, 'ubuntu-20.04')
+        if: contains(matrix.platform, 'linux')
         run: sudo apt install mesa-common-dev libglu1-mesa-dev libegl1 libopengl-dev
 
       - name: Install deps
@@ -42,7 +42,7 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL: 8
 
       - name: Compress files
-        if: ${{!contains(matrix.os, 'windows-latest')}}
+        if: ${{!contains(matrix.platform, 'win32')}}
         uses: a7ul/tar-action@v1.0.2
         id: compress
         with:
@@ -53,7 +53,7 @@ jobs:
           outPath: ${{ env.ARCHIVE_FILENAME }}
 
       - name: Compress files (Windows)
-        if: contains(matrix.os, 'windows-latest')
+        if: contains(matrix.platform, 'win32')
         uses: a7ul/tar-action@v1.0.2
         id: compress-windows
         with:
@@ -65,25 +65,25 @@ jobs:
             ./nodegui_core.exp
           outPath: ${{ env.ARCHIVE_FILENAME }}
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARCHIVE_FILENAME }}
           path: ${{ env.ARCHIVE_FILENAME }}
 
       - name: Upload release binaries
-        uses: alexellis/upload-assets@0.2.2
+        run: |
+            gh release upload "${{github.event.release.tag_name}}" \
+              ${{ env.ARCHIVE_FILENAME }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["${{ env.ARCHIVE_FILENAME }}"]'
 
   publish-npm-package:
     needs: precompile
     if: contains(github.event.release.tag_name, 'v0.0.0-latest-master') == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '16.x'
       - name: Install ubuntu deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
                 os: [ubuntu-20.04, windows-latest, macos-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                 node-version: '16.x'
             - name: Install ubuntu deps


### PR DESCRIPTION
GH Actions is giving warnings about a bunch of these 'actions' using old Node versions. Sooner or later they will just stop working. Time to fix things up a bit.
