### PR TITLE
Replace `nodegui-starter` git repo with the more supported `nodegui-simple-starter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://github.com/nodegui/examples
 
 ## Getting Started
 
--   Check out [nodegui-starter](https://github.com/nodegui/nodegui-starter) to get up and running with your own React NodeGUI app!
+-   Check out [nodegui-simple-starter](https://github.com/sedwards2009/nodegui-simple-starter) to get up and running with your own React NodeGUI app!
 -   Read through the [docs](https://nodegui.github.io/nodegui).
 -   Checkout the examples: https://github.com/nodegui/examples .
 -   [Tutorial: Build a native Meme Search Desktop app with Javascript (NodeGui) and Giphy API](https://www.sitepoint.com/build-native-desktop-gif-searcher-app-using-nodegui/)

--- a/README.md
+++ b/README.md
@@ -173,30 +173,30 @@ You will need to download and install Qt from source since there are no binaries
 (https://www.reddit.com/r/QtFramework/comments/ll58wg/how_to_build_qt_creator_for_macos_arm64_a_guide/)
 
 ```
-git clone git://code.qt.io/qt/qt5.git
-cd qt5
-git checkout 5.15
+git clone git://code.qt.io/qt/qt5.git qt6
+cd qt6
+git checkout 6.6
 
 ./init-repository --module-subset=essential -f
 git submodule init qtsvg
 git submodule update qtsvg
 
 cd ..
-mkdir qt5-5.15-macOS-release
-cd qt5-5.15-macOS-release
+mkdir qt6-6.6-macOS-release
+cd qt6-6.6-macOS-release
 
-../qt5/configure -release QMAKE_APPLE_DEVICE_ARCHS=arm64 -opensource -confirm-license -nomake examples -nomake tests -skip qt3d -skip webengine -skip qtactiveqt -skip qtcanvas3d  -skip qtdeclarative -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtcharts -skip qtgraphicaleffects -skip qtlocation  -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtscript
+../qt6/configure -release QMAKE_APPLE_DEVICE_ARCHS=arm64 -opensource -confirm-license -nomake examples -nomake tests -skip qt3d -skip webengine -skip qtactiveqt -skip qtcanvas3d  -skip qtdeclarative -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtcharts -skip qtgraphicaleffects -skip qtlocation  -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtscript
 
 make -j15
 
 make install
 ```
 
-This should install Qt into something like this `/usr/local/Qt-5.15.3` (your directory can change. This will be displayed when running make)
+This should install Qt into something like this `/usr/local/Qt-6.6.0` (your directory can change. This will be displayed when running make)
 
 **Pointing nodegui to use your custom Qt installation**
 
-Now just set `export QT_INSTALL_DIR=<your qt path>` . In the above example it would look something like this `export QT_INSTALL_DIR=/usr/local/Qt-5.15.3`. Add this in your .zshrc or .bashrc so that you dont need to repeat this process again.
+Now just set `export QT_INSTALL_DIR=<your qt path>` . In the above example it would look something like this `export QT_INSTALL_DIR=/usr/local/Qt-6.6.0`. Add this in your .zshrc or .bashrc so that you dont need to repeat this process again.
 
 Now just `rm -rf node_modules` and do `npm install` again.
 

--- a/website/docs/guides/debugging-in-vscode.md
+++ b/website/docs/guides/debugging-in-vscode.md
@@ -6,8 +6,8 @@ title: Debugging in VSCode
 - **Open a NodeGui project in VSCode.**
 
   ```sh
-  $ git clone git@github.com:nodegui/nodegui-starter.git
-  $ code nodegui-starter
+  $ git clone https://github.com/sedwards2009/nodegui-simple-starter.git
+  $ code nodegui-simple-starter
   ```
 
 - **Add a file `.vscode/launch.json` with the following configuration:**
@@ -44,7 +44,7 @@ title: Debugging in VSCode
   }
   ```
 
-  **Tip**: 
+  **Tip**:
     1. You could also configure a preLaunchTask for building typescript before launching the debugger everytime.
     2. enable source-map feature for debugging.
 

--- a/website/docs/guides/getting-started.md
+++ b/website/docs/guides/getting-started.md
@@ -140,20 +140,21 @@ The logs should say something like `CustomQt detected at <your qt path>. Hence, 
 ### Hello World
 
 Clone and run the code in this tutorial by using the
-[`nodegui/nodegui-starter`][quick-start] repository.
+[`sedwards2009/nodegui-simple-starter`][quick-start] repository.
 
 **Note**: Running this requires [Git](https://git-scm.com) and [npm](https://www.npmjs.com/).
 
 ```sh
 
-git clone https://github.com/nodegui/nodegui-starter
+git clone https://github.com/sedwards2009/nodegui-simple-starter.git
 
-cd nodegui-starter
+cd nodegui-simple-starter
 
 npm install
 
-npm start
+npm run build
 
+npm run run
 ```
 
 **Note**: If you encounter errors installing `nodegui`, please check the [FAQs](../faq.md#why-does-installation-fail-at-minimal-qt-setup) for additional help.
@@ -166,4 +167,4 @@ Congratulations! You've successfully run and modified your first NodeGui app.
 
 If you're curious to learn more about NodeGui, continue on to the [tutorial](tutorial.md).
 
-[quick-start]: https://github.com/nodegui/nodegui-starter
+[quick-start]: https://github.com/sedwards2009/nodegui-simple-starter

--- a/website/docs/guides/tutorial.md
+++ b/website/docs/guides/tutorial.md
@@ -44,22 +44,24 @@ Firstly, we are running a regular Node.js app. This means that we are not runnin
 ## Trying out the starter project
 
 Clone and run the code by using the
-[`nodegui/nodegui-starter`][quick-start] repository.
+[`sedwards2009/nodegui-simple-starter`][quick-start] repository.
 
 **Note**: Running this requires [Git](https://git-scm.com) and [npm](https://www.npmjs.com/).
 
 ```sh
 
-git clone https://github.com/nodegui/nodegui-starter
+git clone https://github.com/sedwards2009/nodegui-simple-starter.git
 
-cd nodegui-starter
+cd nodegui-simple-starter
 
 npm install
 
-npm start
+npm run build
+
+npm run start
 ```
 
-[quick-start]: https://github.com/nodegui/nodegui-starter
+[quick-start]: https://github.com/sedwards2009/nodegui-simple-starter
 
 ## What else other than a basic window?
 

--- a/website/src/components/Try.js
+++ b/website/src/components/Try.js
@@ -54,10 +54,11 @@ export const Try = () => {
                     <Description>
                         <SubTitle>1. Run these commands</SubTitle>
                         <Terminal>
-                            <Code>git clone https://github.com/nodegui/nodegui-starter</Code>
-                            <Code>cd nodegui-starter</Code>
+                            <Code>git clone https://github.com/sedwards2009/nodegui-simple-starter.git</Code>
+                            <Code>cd nodegui-simple-starter</Code>
                             <Code>npm install</Code>
-                            <Code>npm start</Code>
+                            <Code>npm run build</Code>
+                            <Code>npm run run</Code>
                         </Terminal>
                         <SubTitle>
                             2.{' '}


### PR DESCRIPTION
`nodegui-starter` hasn't been updated for a long time. `nodegui-simple-starter` has a better chance of being supported and uses tools which at least one person/project depends on.
