### PR TITLE
Add setTitle and title to QWindow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,18 @@ jobs:
                 node-version: '18.12.1'
             - name: Install ubuntu deps
               if: contains(matrix.os, 'ubuntu-20.04')
-              run: sudo apt install mesa-common-dev libglu1-mesa-dev libegl1 libopengl-dev
+              run: sudo apt install mesa-common-dev libglu1-mesa-dev libegl1 libopengl-dev libxcb-icccm4 libxcb-shape0 libxkbcommon-x11-0 libxcb-xkb1 libxcb-cursor0 libxcb-keysyms1
             - name: Install deps
               run: npm install
             - name: Build nodegui
               run: npm run build
               env:
                 CMAKE_BUILD_PARALLEL_LEVEL: 8
+            - name: Run ubuntu tests
+              if: contains(matrix.os, 'ubuntu-20.04')
+              run: xvfb-run npm run test
             - name: Run tests
+              if: ${{ !contains(matrix.os, 'ubuntu-20.04') }}
               run: npm run test
             - name: Run linters for cpp
               run: npm run lint:cpp

--- a/src/lib/QtGui/QWindow.ts
+++ b/src/lib/QtGui/QWindow.ts
@@ -32,7 +32,6 @@ export class QWindow extends QObject<QWindowSignals> {
     // TODO:    void 	setMaximumWidth(int w)
     // TODO:    void 	setMinimumHeight(int h)
     // TODO:    void 	setMinimumWidth(int w)
-    // TODO:    void 	setTitle(const QString &)
     // TODO:    void 	setVisible(bool visible)
     // TODO:    void 	setWidth(int arg)
     // TODO:    void 	setX(int arg)
@@ -68,6 +67,12 @@ export class QWindow extends QObject<QWindowSignals> {
     setVisibility(visibility: Visibility): void {
         return this.native.setVisibility(visibility);
     }
+    title(): string {
+        return this.native.windowTitle();
+    }
+    setTitle(title: string): void {
+        return this.native.setWindowTitle(title);
+    }
 }
 wrapperCache.registerWrapper('QWindowWrap', QWindow);
 
@@ -75,6 +80,7 @@ export interface QWindowSignals extends QObjectSignals {
     screenChanged: (screen: QScreen) => void;
     visibilityChanged: (visibility: Visibility) => void;
     windowStateChanged: (windowState: WindowState) => void;
+    windowTitleChanged: (title: string) => void;
 }
 
 registerNativeWrapFunction('QWindowWrap', (native: any) => {

--- a/src/lib/QtGui/__tests__/QWindow.test.ts
+++ b/src/lib/QtGui/__tests__/QWindow.test.ts
@@ -1,0 +1,27 @@
+import { QWidget } from '../../..';
+import { QWindow } from '../QWindow';
+
+describe('QWindow', () => {
+    it('initialize', () => {
+        const widget = new QWidget();
+        const window = new QWindow(widget.native);
+        expect(window).toBeTruthy();
+    });
+    it('setTitle', () => {
+        const widget = new QWidget();
+        const window = new QWindow(widget.native);
+        const expectedTitle = 'Test window';
+        window.setTitle(expectedTitle);
+        expect(window.title()).toEqual(expectedTitle);
+    });
+    it('check if windowTitleChanged signal is working for window', () => {
+        const widget = new QWidget();
+        const window = new QWindow(widget.native);
+        const mock = jest.fn();
+        window.addEventListener('windowTitleChanged', mock);
+        const expectedTitle = 'Test window';
+        window.setTitle(expectedTitle);
+        expect(mock).toBeCalledTimes(1);
+        expect(mock.mock.calls[0][0]).toEqual(expectedTitle);
+    });
+});

--- a/src/lib/core/__test__/WrapperCache.test.ts
+++ b/src/lib/core/__test__/WrapperCache.test.ts
@@ -1,12 +1,8 @@
 import { QObject } from '../../QtCore/QObject';
-import { QApplication } from '../../QtGui/QApplication';
 import { CacheTestQObject } from './CacheTestQObject';
 import { wrapperCache } from '../WrapperCache';
 
 describe('WrapperCache using CacheTestQObject', () => {
-    const qApp = QApplication.instance();
-    qApp.setQuitOnLastWindowClosed(true);
-
     it('Cached foo', () => {
         wrapperCache._flush();
         const a = new CacheTestQObject();
@@ -92,6 +88,4 @@ describe('WrapperCache using CacheTestQObject', () => {
         expect(allKids[0]).toEqual(kid1);
         expect(allKids[1]).toEqual(kid2);
     });
-
-    qApp.quit();
 });


### PR DESCRIPTION
- Added setTitle, title functions and windowTitleChanged signal to QWindow. (https://doc.qt.io/qt-6/qwindow.html#title-prop)
- Removed use of QApplication in WrapperCache tests as calling quit ends running of the tests - all tests in WrapperCache still pass with it removed.