### PR TITLE
Fix QmenuBar crash

### DIFF
--- a/src/cpp/include/nodegui/QtWidgets/QMenu/nmenu.hpp
+++ b/src/cpp/include/nodegui/QtWidgets/QMenu/nmenu.hpp
@@ -30,14 +30,18 @@ class DLL_EXPORT NMenu : public QMenu, public NodeWidget {
       Napi::Env env = this->emitOnNode.Env();
       Napi::HandleScope scope(env);
       auto instance = WrapperCache::instance.getWrapper(env, action);
-      this->emitOnNode.Call({Napi::String::New(env, "hovered"), instance});
+      if (instance != nullptr) {
+        this->emitOnNode.Call({Napi::String::New(env, "hovered"), instance});
+      }
     });
 
     QObject::connect(this, &QMenu::triggered, [=](QAction* action) {
       Napi::Env env = this->emitOnNode.Env();
       Napi::HandleScope scope(env);
       auto instance = WrapperCache::instance.getWrapper(env, action);
-      this->emitOnNode.Call({Napi::String::New(env, "triggered"), instance});
-    });
+      if (instance != nullptr) {
+        this->emitOnNode.Call({Napi::String::New(env, "triggered"), instance});
+      }
+    }); 
   }
 };

--- a/src/cpp/include/nodegui/QtWidgets/QMenuBar/nmenubar.hpp
+++ b/src/cpp/include/nodegui/QtWidgets/QMenuBar/nmenubar.hpp
@@ -18,14 +18,21 @@ class DLL_EXPORT NMenuBar : public QMenuBar, public NodeWidget {
       Napi::Env env = this->emitOnNode.Env();
       Napi::HandleScope scope(env);
       auto instance = WrapperCache::instance.getWrapper(env, action);
-      this->emitOnNode.Call({Napi::String::New(env, "hovered"), instance});
-    });
+      // For some reason "instance" becomes a nullptr sometimes, 
+      // Passing in a nullptr CRASHES this
+      // since we don't know which item "hovered" we don't continue with the event.
+      if (instance != nullptr) {
+         this->emitOnNode.Call({Napi::String::New(env, "hovered"), instance});
+      }
+    }); 
 
     QObject::connect(this, &QMenuBar::triggered, [=](QAction* action) {
       Napi::Env env = this->emitOnNode.Env();
       Napi::HandleScope scope(env);
       auto instance = WrapperCache::instance.getWrapper(env, action);
-      this->emitOnNode.Call({Napi::String::New(env, "triggered"), instance});
-    });
+      if (instance != nullptr) {
+        this->emitOnNode.Call({Napi::String::New(env, "triggered"), instance});
+      }
+    }); 
   }
 };


### PR DESCRIPTION
This fixes the QMenuBar crash basically `instance` becomes a nullptr after moving the mouse over the menu items.    emitting a nullptr to the event and creates a crash.

Interestingly enough this event is then triggered by hovering over menu items and instance is then NOT a nullptr.   Very strange behavior from QT (or something in the event system somewhere).