### PR TITLE
Add build for macOS arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
           - os: windows-latest
             platform: win32
             arch: x64
-          - os: macos-13
+          - os: macos-15
             platform: darwin
-            arch: x64
+            arch: [x64, arm64]
     runs-on: ${{ matrix.os }}
     env:
       ARCHIVE_FILENAME: nodegui-binary-${{github.event.release.tag_name}}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,12 @@ jobs:
           - os: windows-latest
             platform: win32
             arch: x64
+          - os: macos-13
+            platform: darwin
+            arch: x64
           - os: macos-15
             platform: darwin
-            arch: [x64, arm64]
+            arch: arm64
     runs-on: ${{ matrix.os }}
     env:
       ARCHIVE_FILENAME: nodegui-binary-${{github.event.release.tag_name}}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-22.04, windows-latest, macos-13]
+                os: [ubuntu-22.04, windows-latest, macos-13, macos-15]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Changes the build actions to create an arm64 build as well as the 64 bit one. I think this should close #1024, and the others.

Tested using a manual action for just the arm64 build and worked for me.