### PR TITLE
chore(deps): Bump typedoc to 0.28.9 and update tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
         "jest": "29.7.0",
         "prettier": "^2.3.2",
         "ts-jest": "29.2.5",
-        "typedoc": "^0.17.8",
-        "typedoc-plugin-markdown": "^2.4.2",
+        "typedoc": "^0.28.9",
+        "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "^5.9.3"
     },
     "binary": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,17 +14,13 @@
     },
     "include": ["src"],
     "typedocOptions": {
-        "mode": "file",
         "out": "website/docs/api/generated",
         "plugin": ["typedoc-plugin-markdown"],
         "exclude": ["demo.ts"],
         "excludeExternals": true,
-        "excludeNotExported": true,
+        "excludeNotDocumented": true,
         "excludePrivate": true,
         "excludeProtected": true,
-        "includeDeclarations": true,
-        "hideBreadcrumbs": true,
-        "hideSources": true,
-        "theme": "docusaurus2"
+        "disableSources": true
     }
 }


### PR DESCRIPTION
Related with the issue #1075

Hey @sedwards2009, I updated the typedoc version. The idea was to avoid vulnerable code, but I realized that this update is useful for updating the documentation on the CI environment because it's failing due to an incompatible TypeScript and markdown plugin.

- typedoc ^0.28.9
- typedoc-plugin-markdown ^4.9.0
- tsconfig update for new [options](https://typedoc.org/documents/Options.html)