### PR TITLE
replace the deprecated `cuid` with `@paralleldrive/cuid2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
     "name": "@nodegui/nodegui",
-    "version": "0.74.0",
+    "version": "0.74.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@nodegui/nodegui",
-            "version": "0.74.0",
+            "version": "0.74.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@nodegui/artifact-installer": "^1.1.0",
-                "@nodegui/qode": "24.12.0-rc18",
+                "@nodegui/qode": "24.12.0-rc19",
+                "@paralleldrive/cuid2": "^3.3.0",
                 "cmake-js": "^7.4.0",
                 "cross-env": "^7.0.3",
-                "cuid": "^2.1.8",
                 "manage-path": "^2.0.0",
                 "memoize-one": "^5.2.1",
                 "mkdirp": "^3.0.1",
@@ -1026,6 +1026,18 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodegui/artifact-installer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@nodegui/artifact-installer/-/artifact-installer-1.1.0.tgz",
@@ -1039,10 +1051,11 @@
             }
         },
         "node_modules/@nodegui/qode": {
-            "version": "24.12.0-rc18",
-            "resolved": "https://registry.npmjs.org/@nodegui/qode/-/qode-24.12.0-rc18.tgz",
-            "integrity": "sha512-c1YaKW8tG9ziIs/DVFOR4i+wslv5c0ZPbd/hB/WmMvHmyTtcAvADPsx4ThHFA/Po5Z836RfORGJR1RtQpjcEJg==",
+            "version": "24.12.0-rc19",
+            "resolved": "https://registry.npmjs.org/@nodegui/qode/-/qode-24.12.0-rc19.tgz",
+            "integrity": "sha512-18goj/U6XHHPO+NlyXOf0PuWYnNIAwsqfz7xFl7z+hTyDWKDXX9Ok+7G8uhMo5mhQG3fwPzWa9A8RYs/ni/w9A==",
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "make-dir": "^3.1.0",
@@ -1084,6 +1097,20 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@paralleldrive/cuid2": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-3.3.0.tgz",
+            "integrity": "sha512-OqiFvSOF0dBSesELYY2CAMa4YINvlLpvKOz/rv6NeZEqiyttlHgv98Juwv4Ch+GrEV7IZ8jfI2VcEoYUjXXCjw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "^2.0.1",
+                "bignumber.js": "^9.3.1",
+                "error-causes": "^3.0.2"
+            },
+            "bin": {
+                "cuid2": "bin/cuid2.js"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -1706,6 +1733,15 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/bignumber.js": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2049,11 +2085,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/cuid": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
-            "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
-        },
         "node_modules/debug": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -2232,6 +2263,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/error-causes": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/error-causes/-/error-causes-3.0.2.tgz",
+            "integrity": "sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw==",
+            "license": "MIT"
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
@@ -6666,6 +6703,11 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
+        },
         "@nodegui/artifact-installer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@nodegui/artifact-installer/-/artifact-installer-1.1.0.tgz",
@@ -6679,9 +6721,9 @@
             }
         },
         "@nodegui/qode": {
-            "version": "24.12.0-rc18",
-            "resolved": "https://registry.npmjs.org/@nodegui/qode/-/qode-24.12.0-rc18.tgz",
-            "integrity": "sha512-c1YaKW8tG9ziIs/DVFOR4i+wslv5c0ZPbd/hB/WmMvHmyTtcAvADPsx4ThHFA/Po5Z836RfORGJR1RtQpjcEJg==",
+            "version": "24.12.0-rc19",
+            "resolved": "https://registry.npmjs.org/@nodegui/qode/-/qode-24.12.0-rc19.tgz",
+            "integrity": "sha512-18goj/U6XHHPO+NlyXOf0PuWYnNIAwsqfz7xFl7z+hTyDWKDXX9Ok+7G8uhMo5mhQG3fwPzWa9A8RYs/ni/w9A==",
             "requires": {
                 "env-paths": "^2.2.1",
                 "make-dir": "^3.1.0",
@@ -6714,6 +6756,16 @@
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
+            }
+        },
+        "@paralleldrive/cuid2": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-3.3.0.tgz",
+            "integrity": "sha512-OqiFvSOF0dBSesELYY2CAMa4YINvlLpvKOz/rv6NeZEqiyttlHgv98Juwv4Ch+GrEV7IZ8jfI2VcEoYUjXXCjw==",
+            "requires": {
+                "@noble/hashes": "^2.0.1",
+                "bignumber.js": "^9.3.1",
+                "error-causes": "^3.0.2"
             }
         },
         "@sinclair/typebox": {
@@ -7184,6 +7236,11 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "bignumber.js": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7421,11 +7478,6 @@
                 "which": "^2.0.1"
             }
         },
-        "cuid": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
-            "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
-        },
         "debug": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -7547,6 +7599,11 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+        },
+        "error-causes": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/error-causes/-/error-causes-3.0.2.tgz",
+            "integrity": "sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw=="
         },
         "error-ex": {
             "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "dependencies": {
         "@nodegui/artifact-installer": "^1.1.0",
         "@nodegui/qode": "24.12.0-rc19",
+        "@paralleldrive/cuid2": "^3.3.0",
         "cmake-js": "^7.4.0",
         "cross-env": "^7.0.3",
-        "cuid": "^2.1.8",
         "manage-path": "^2.0.0",
         "memoize-one": "^5.2.1",
         "mkdirp": "^3.0.1",

--- a/src/lib/core/Style/StyleSheet.ts
+++ b/src/lib/core/Style/StyleSheet.ts
@@ -1,5 +1,5 @@
 import postcss from 'postcss';
-import cuid from 'cuid';
+import cuid2 from '@paralleldrive/cuid2';
 import nodeguiAutoPrefixer from 'postcss-nodegui-autoprefixer';
 import { QWidget, QWidgetSignals } from '../../QtWidgets/QWidget';
 export class StyleSheet {
@@ -22,7 +22,7 @@ export function prepareInlineStyleSheet<Signals extends QWidgetSignals>(
     // So doing it in multiple passes of event loop allows objectName to be set before using it. The above await solves it.
     let cssId = widget.objectName();
     if (!cssId) {
-        cssId = cuid();
+        cssId = cuid2.createId();
         widget.setObjectName(cssId);
     }
     return `


### PR DESCRIPTION
I had a problem with `cuid` not working properly:

```
/home/momchil/Projects/seraphimcms-installer/node_modules/@nodegui/nodegui/dist/lib/core/Style/StyleSheet.js:28
        cssId = (0, cuid_1.default)();
                                   ^

TypeError: (0 , cuid_1.default) is not a function
    at prepareInlineStyleSheet (/home/momchil/Projects/seraphimcms-installer/node_modules/@nodegui/nodegui/dist/lib/core/Style/StyleSheet.js:28:36)
    at QPushButton.setInlineStyle (/home/momchil/Projects/seraphimcms-installer/node_modules/@nodegui/nodegui/dist/lib/QtWidgets/QWidget.js:398:76)
    at QPushButton.memoized [as setInlineStyle] (/home/momchil/Projects/seraphimcms-installer/node_modules/memoize-one/dist/memoize-one.cjs.js:42:31)
    at new Window (file:///home/momchil/Projects/seraphimcms-installer/dist/window/index.js:1:1198)
    at file:///home/momchil/Projects/seraphimcms-installer/dist/main.js:1:39
```

I narrowed the problematic file to `src/lib/core/Style/StyleSheet.ts`, which used a nonexistent default export of `cuid`.

The only change I made was to replace `cuid` with a `@paralleldrive/cuid2`, since I found out `cuid` is deprecated.

Attempting to run the project again worked successfully.

One thing I'd like to note - maybe `cuid`/`@paralleldrive/cuid2` should be replaced with something like `crypto.random.UUID`. I don't understand why a whole library is required to create random IDs.